### PR TITLE
Add Ubuntu Diversity Policy

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -15,6 +15,7 @@ dvipng
 empathic
 fonts
 freefont
+genotype
 GitHub
 GPG
 gyre
@@ -25,6 +26,7 @@ lang
 latexmk
 lifecycle
 Multipass
+neurotype
 organized
 otf
 plantuml

--- a/docs/reference/governance/code-of-conduct.md
+++ b/docs/reference/governance/code-of-conduct.md
@@ -40,6 +40,7 @@ Nobody is expected to be perfect in this community. Asking questions early avoid
 
 When somebody leaves or disengages from the project, we ask that they do so in a way that minimises disruption to the project. They should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
 
+(leadership-code-of-conduct)=
 ## Leadership, authority and responsibility
 
 We all lead by example, in debate and in action. We encourage new participants to feel empowered to lead, to take action, and to experiment when they feel innovation could improve the project. Leadership can be exercised by anyone simply by taking action, there is no need to wait for recognition when the opportunity to lead presents itself.

--- a/docs/reference/governance/diversity-policy.md
+++ b/docs/reference/governance/diversity-policy.md
@@ -2,3 +2,12 @@
 
 # Diversity policy
 
+The Ubuntu project welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+
+Standards for behaviour in the Ubuntu community are detailed in the {ref}`Code of Conduct <code-of-conduct>` and {ref}`Leadership Code of Conduct <leadership-code-of-conduct>`. We expect participants in our community to meet these standards in all their interactions and to help others to do so as well.
+
+Whenever any participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, {spellexception}`socio`-economic status, subculture and technical ability.
+
+Some of the ideas and wording for this statement were based on diversity statements from the [Python community](https://www.python.org/community/diversity/) and [{spellexception}`Dreamwidth` Studios](https://www.dreamwidth.org/legal/diversity) (CC-BY-SA 3.0).


### PR DESCRIPTION
Adds the Ubuntu diversity policy. This is commit copies the text from https://ubuntu.com/community/ethos/diversity at the time of commit 7005091adbeb5951d2ddd3b8b4253810aa05b3bc.