### PR TITLE
Add Ubuntu mission statement

### DIFF
--- a/docs/reference/governance/index.md
+++ b/docs/reference/governance/index.md
@@ -8,6 +8,6 @@ diversity-policy
 membership-perks
 Code of Conduct <code-of-conduct>
 teams
-mission
+Mission <mission>
 conflict-resolution
 ```

--- a/docs/reference/governance/mission.md
+++ b/docs/reference/governance/mission.md
@@ -59,4 +59,4 @@ There are 10 core principles of open-source software:
 1. The licence must not restrict other software.
 1. The licence must be technology-neutral.
 
-[Take a look at the Open Source Initiative’s definition of open-source software for a more detailed explanation](https://opensource.org/docs/definition.php).
+[Take a look at the Open Source Initiative’s definition of open-source software for a more detailed explanation](https://opensource.org/osd).

--- a/docs/reference/governance/mission.md
+++ b/docs/reference/governance/mission.md
@@ -1,4 +1,62 @@
 (mission)=
 
-# Mission
+# Our Mission
 
+## To bring free software to the widest audience
+
+In an era where the frontiers of innovation are public, and not private, the platforms for consuming that innovation should enable everyone to participate. That is the vision for Ubuntu and Canonical, which motivates us to enable a wide diversity of open source communities to collaborate under the Ubuntu umbrella.
+
+We believe that every computer user:
+
+- Should have the freedom to download, run, copy, distribute, study, share, change and improve their software for any purpose, without paying licensing fees.
+- Should be able to use their software in the language of their choice.
+- Should be able to use all software regardless of disability.
+- Our philosophy is reflected in the software we produce, the way we distribute it and our licensing terms, too - [Intellectual property rights policy](https://ubuntu.com/legal/intellectual-property-policy).
+
+We aim to be the platform which leads in achieving these ideals. We work to the goal that every piece of software you could possibly need is available under a licence that gives you those freedoms.
+
+## To accelerate innovation and underpin operations
+
+We make the world better by enabling anyone, anywhere, to pursue their ambitions regardless of their resources. It is important to us that a researcher in the furthest corner of the world from Silicon Valley can use Ubuntu on exactly the same terms as a startup in San Francisco, to build something that nobody has imagined before. It’s also important to us that Ubuntu enables those upstarts to grow, from garage visionaries to galactic stars, and Canonical serves to provide enterprise capabilities and services for Ubuntu users.
+
+## Free software
+
+Our preferred software licenses are ‘free software’ and always will be. Free software gives everyone the freedom to use it however they want and share with whoever they like. This freedom has huge benefits. At one end of the spectrum it enables the Ubuntu community to grow and share its collective experience and expertise to continually improve all things Ubuntu. At the other, we are able to give access to essential software for those who couldn’t otherwise afford it – an advantage that’s keenly felt by individuals and organisations all over the world.
+
+Quoting the [Free Software Foundation’s](https://www.fsf.org/), [‘What is Free Software’](https://www.gnu.org/philosophy/free-sw.html), the freedoms at the core of free software are defined as:
+
+- The freedom to run the program, for any purpose.
+- The freedom to study how the program works and adapt it to your needs.
+- The freedom to redistribute copies so you can help others.
+- The freedom to improve the program and release your improvements to the public, so that everyone benefits.
+
+## Open source
+
+Open source is collective power in action. The power of a worldwide community of highly skilled experts that build, share and improve the very latest software together - then make it available to everyone.
+
+The term open source was coined in 1998 to remove the ambiguity in the English word ‘free’ and it continues to enjoy growing success and wide recognition. Although some people regard ‘free’ and ‘open source’ as competing movements with different ends, we do not. Ubuntu proudly includes members who identify with both.
+
+Originally coined in 1998, the term open source came out of the free software movement, a collaborative force going strong since the dawn of computing in the 1950s. This early community was responsible for the development of many of the first operating systems, software and, in 1969, the Internet itself.
+
+The open-source community is thriving and today boasts some of the best brains in the business. The aim has not changed: free systems and software should be available to everybody, wherever they are.
+
+Without open source, many of the systems and applications we take for granted simply would not exist. All the big players in computing come from, or owe a huge creative debt to, the open-source community, and continue to rely on its talent and expertise when developing new products.
+
+In the spirit of open source, Ubuntu is absolutely free to download, use, share and improve. Please note, however, that the Ubuntu name and logo are protected trademarks, subject to our [intellectual property rights policy](https://ubuntu.com/legal/intellectual-property-policy).
+
+## What is open source?
+
+There are 10 core principles of open-source software:
+
+1. Software must be free to redistribute.
+1. The program must include source code.
+1. The licence must allow people to experiment with and redistribute modifications.
+1. Users have a right to know who is responsible for the software they are using.
+1. There should be no discrimination against any person or group.
+1. The licence must not restrict anyone from making use of the program in a specific field.
+1. No-one should need to acquire an additional licence to use or redistribute the program.
+1. The licence must not be specific to a product.
+1. The licence must not restrict other software.
+1. The licence must be technology-neutral.
+
+[Take a look at the Open Source Initiative’s definition of open-source software for a more detailed explanation](https://opensource.org/docs/definition.php).


### PR DESCRIPTION
Adds the Ubuntu Mission statement. This commit copies the text from https://ubuntu.com/community/ethos/mission at the time of commit 6b825599fc8a7f60f4662be6280167b4be74790a.