### PR TITLE
Add technical authors as default GitHub Code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Documentation about CODEOWNERS file: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Technical authors will be requested for review when someone opens a
+# pull request, unless a later match takes precedence.
+* @s-makin @rkratky


### PR DESCRIPTION
This adds the technical authors as the default reviewer for a GitHub Pull Request.

See the documentation about the `.github/CODEOWNERS` file: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners