### PR TITLE
Disable "fail on warning"

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,7 +27,7 @@ build:
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:


### PR DESCRIPTION
Due to broken links that may need to be followed up on before we can redirect correctly, we may not want to have the docs fail to build on warnings. Broken links are going to be very frequent, especially at the start.