### PR TITLE
Fix hanging linkchecker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,6 +185,7 @@ redirects = {}
 
 linkcheck_ignore = [
     "http://127.0.0.1:8000",
+    "https://www.gnu.org/philosophy/free-sw.html",
 ]
 
 


### PR DESCRIPTION
The https://www.gnu.org/philosophy/free-sw.html link is causing the linkchecker in our automated tests to "hang" for no reason. Since the link works when clicked on, I'm adding it to the list of URLs ignored by the linkchecker.