### PR TITLE
Update mir-team-meeting.md -- remove atavastic text about client links

### DIFF
--- a/docs/MIR/mir-team-meeting.md
+++ b/docs/MIR/mir-team-meeting.md
@@ -63,7 +63,6 @@ Check these GH based lists:
 ### Mission: Check on progress, do deadlines seem doable?
 * ensure your teams items are prioritized among each other as you'd expect
 * ensure community requests do not get stomped by teams calling for favors too much
-Some clients can only work with one, some with the other escaping - the URLs point to the same place.
 * [Security assigned MIR in launchpad](https://bugs.launchpad.net/~ubuntu-security/+bugs?field.searchtext=%5BMIR%5D&assignee_option=choose&field.assignee=ubuntu-security&field.bug_reporter=&field.bug_commenter=&field.subscriber=ubuntu-mir)
 * [(internal) kanban board](https://warthogs.atlassian.net/jira/software/c/projects/SEC/boards/594)
 


### PR DESCRIPTION
Some irc clients / terminals didn't support one or another format for some of the links (url-encoding vs not) -- but now there's only the one link until there's a demonstrated need for two links, so lets remove the text explaining the duplication.