### PR TITLE
Improve some Sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,9 @@
 import datetime
-import ast
 import os
-import sys
 import yaml
+from docutils.parsers.rst import roles
+from sphinx.util.docutils import SphinxRole
+from docutils import nodes
 
 # Configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.
@@ -242,6 +243,8 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinxcontrib.mermaid",
     "hoverxref.extension",
+    "sphinx-prompt",
+    "sphinx.ext.extlinks",
 ]
 
 # Excludes files or directories from processing
@@ -284,19 +287,21 @@ rst_epilog = """
 # manpages_url = 'https://manpages.ubuntu.com/manpages/{codename}/en/' + \
 #     'man{section}/{page}.{section}.html'
 
-import distro_info
+stable_distro = "plucky"
 
-sys.path.append('/usr/lib/python3/dist-packages')
-
-manpages_url = ("https://manpages.ubuntu.com/manpages/"
-                f"{distro_info.UbuntuDistroInfo().stable()}/en/"
-                "man{section}/{page}.{section}.html")
+manpages_url = (
+    "https://manpages.ubuntu.com/manpages/"
+    + stable_distro
+    + "/en/man{section}/{page}.{section}.html"
+)
 
 # Configure hoverxref options
 hoverxref_role_types = {
-    'term': 'tooltip',
+    "term": "tooltip",
 }
-hoverxref_roles = ['term',]
+hoverxref_roles = [
+    "term",
+]
 
 # Specifies a reST snippet to be prepended to each .rst file
 # This defines a :center: role that centers table cell content.
@@ -327,3 +332,26 @@ if os.path.exists("./reuse/substitutions.yaml"):
 # Add configuration for intersphinx mapping
 
 intersphinx_mapping = {}
+
+
+# Redefine the Sphinx 'command' role to behave/render like 'literal'
+
+
+class CommandRole(SphinxRole):
+    def run(self):
+        text = self.text
+        node = nodes.literal(text, text)
+        return [node], []
+
+
+def setup(app):
+    roles.register_local_role("command", CommandRole())
+
+
+# Define a custom role for package-name formatting
+def pkg_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    node = nodes.literal(rawtext, text)
+    return [node], []
+
+
+roles.register_local_role("pkg", pkg_role)

--- a/docs/how-to/contribute-docs.md
+++ b/docs/how-to/contribute-docs.md
@@ -13,7 +13,7 @@ To report a mistake on any page, or highlight some missing documentation,
 [file an issue](https://github.com/ubuntu/ubuntu-project-docs/issues) in our
 issues list on GitHub.
 
-You can do this using the "Give feedback" button on any page, which will open a
+You can do this using the {guilabel}`Give feedback` button on any page, which will open a
 new issue.
 
 Make sure to provide enough information in the issue for us to understand what
@@ -33,7 +33,7 @@ our documentation and make your proposal based on that revision.
 
 ## Contribute on GitHub
 
-If you are familiar with a Git development workflow, `checkout` the
+If you are familiar with a Git development workflow, `fork` the
 [Ubuntu Project docs repository](https://github.com/ubuntu/ubuntu-project-docs)
 and contribute your change as a
 [pull request](https://github.com/ubuntu/ubuntu-project-docs/pulls).
@@ -108,7 +108,42 @@ Follow these steps to build the documentation on your local machine.
 
 ## Documentation format
 
-The Ubuntu Project documentation is built with Sphinx using the MyST flavor of the Markdown mark-up language. If you're new to Markdown or MyST, read our [MyST style guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/style-guide-myst/).
+The Ubuntu Project documentation is built with Sphinx using a combination of the MyST flavor of the Markdown and reStructuredText mark-up languages. MyST is preferred for new content. If you're new to this, see our guides:
+
+* [MyST style guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/style-guide-myst/)
+* [reStructuredText style guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/style-guide/)
+
+
+### Semantic mark-up
+
+We encourage (though not mandate) the use of semantic mark-up where possible. See [Roles](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html) in Sphinx documentation for an overview of inline semantic roles available by default. The syntax is:
+
+| MyST | reStructuredText |
+| --- | --- |
+| `` {role}`term` `` | `` :role:`term` `` |
+
+The following roles are especially useful:
+
+`code`
+: Source-code snippets.
+
+`command`
+: Command-line interface (CLI) commands.
+
+`file`
+: Names of files and directories (including path).
+
+`guilabel`
+: Graphical user interface (GUI) elements: button, widgets, labels, ...
+
+`kbd`
+: Keyboard keys and shortcuts. Example:`` {kbd}`Shift+F1` `` (rendered as {kbd}`Shift+F1`).
+
+`manpage`
+: Link to an Ubuntu manual page. Example:`` {manpage}`man(1)` `` (rendered as a live link: {manpage}`man(1)`).
+
+`pkg`
+: Linux package name (this role is custom to this documentation project).
 
 
 ## Testing the documentation

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-last-updated-by-git
 sphinxcontrib-mermaid
 distro_info
 sphinx-hoverxref
+sphinx-prompt


### PR DESCRIPTION
* Change 'manpage' role config to manual
   * rationale: the use of a locally sourced (`/usr/lib/...`) Python function for automatically determining the current stable release of Ubuntu is brittle -- it only works on Ubuntu; anyone building the docs on any other system, including a different distro, would run into problems; that wouldn't be user-friendy.
* Add the 'pkg' role for semantic markup of packages
* Add the `sphinx-prompt` extension to enable the `prompt` directive
* Redefine the 'command' role to render like 'literal'