### PR TITLE
Fix non-inclusive terms

### DIFF
--- a/docs/staging/germinate.md
+++ b/docs/staging/germinate.md
@@ -15,7 +15,7 @@ The minimum set of seeds this author has used is:
 * minimal
 * standard
 * custom
-* blacklist
+* blocklist
 * supported
 
 It might be possible to exclude some of these (the full set of seeds for Ubuntu
@@ -37,7 +37,7 @@ required:
 minimal: required
 standard: required minimal
 custom:
-blacklist:
+blocklist:
 supported:
 ```
 
@@ -51,7 +51,7 @@ seed has a corresponding output list of packages which includes the packages
 and depends in the seed itself, plus any packages and dependencies for the
 seeds listed as dependencies for the seed (recursively).
 
-*blacklist* is also special in that it doesn't define a list of packages to
+*blocklist* is also special in that it doesn't define a list of packages to
 include. Instead it lists packages which will never be included in the output
 of `germinate`.
 

--- a/docs/staging/package-archive.md
+++ b/docs/staging/package-archive.md
@@ -6,7 +6,7 @@ This content comes [from the wiki](https://wiki.ubuntu.com/UbuntuDevelopment/Pac
 It has not yet been reviewed for currency or accuracy.
 ```
 
-All current official Ubuntu packages are stored in the master archive, which is
+All current official Ubuntu packages are stored in the main archive, which is
 widely {ref}`mirrored <mirrors>`.
 A search interface is available at [http://packages.ubuntu.com](http://packages.ubuntu.com).
 Old versions can be retrieved from [Launchpad](http://launchpad.net/ubuntu).

--- a/docs/staging/package-archive.md
+++ b/docs/staging/package-archive.md
@@ -6,7 +6,7 @@ This content comes [from the wiki](https://wiki.ubuntu.com/UbuntuDevelopment/Pac
 It has not yet been reviewed for currency or accuracy.
 ```
 
-All current official Ubuntu packages are stored in the main archive, which is
+All current official Ubuntu packages are stored in the primary archive, which is
 widely {ref}`mirrored <mirrors>`.
 A search interface is available at [http://packages.ubuntu.com](http://packages.ubuntu.com).
 Old versions can be retrieved from [Launchpad](http://launchpad.net/ubuntu).

--- a/docs/staging/push-mirroring.md
+++ b/docs/staging/push-mirroring.md
@@ -113,7 +113,7 @@ JR9bXlpTBqjGCTaLVRFF4faLrLef5Qk=
 ### HTTP triggers
 
 While SSH triggers (above) are the preferred trigger method, it is also possible
-for the master Ubuntu archive to send HTTP triggers.
+for the main Ubuntu archive to send HTTP triggers.
 HTTP triggers can be nearly any format, for example:
 
 ```
@@ -135,7 +135,7 @@ random) UUID in the path itself. Treat these URLs as sensitive, to avoid outside
 users triggering unnecessary syncs.
 
 It is up to the mirror administrator to build logic into the HTTP endpoint which
-authenticates the master Ubuntu archive and begins a sync. This logic varies
-wildly based on your specific platform. Output format is undefined; the master
+authenticates the main Ubuntu archive and begins a sync. This logic varies
+wildly based on your specific platform. Output format is undefined; the main
 simply loads the URL and moves on without examining the output.
 

--- a/docs/staging/push-mirroring.md
+++ b/docs/staging/push-mirroring.md
@@ -113,7 +113,7 @@ JR9bXlpTBqjGCTaLVRFF4faLrLef5Qk=
 ### HTTP triggers
 
 While SSH triggers (above) are the preferred trigger method, it is also possible
-for the main Ubuntu archive to send HTTP triggers.
+for the primary Ubuntu archive to send HTTP triggers.
 HTTP triggers can be nearly any format, for example:
 
 ```
@@ -135,7 +135,7 @@ random) UUID in the path itself. Treat these URLs as sensitive, to avoid outside
 users triggering unnecessary syncs.
 
 It is up to the mirror administrator to build logic into the HTTP endpoint which
-authenticates the main Ubuntu archive and begins a sync. This logic varies
-wildly based on your specific platform. Output format is undefined; the main
+authenticates the primary Ubuntu archive and begins a sync. This logic varies
+wildly based on your specific platform. Output format is undefined; the primary
 simply loads the URL and moves on without examining the output.
 


### PR DESCRIPTION
This changes:

* 'master' to 'main' -- that's in reference to the Ubuntu archive, so even though it might not be called that, I expect it should be self-explanatory and not a problematic change (even if only in the docs for the time being).
* 'blacklist' to 'blocklist' -- in `germinate` terminology. This is more complicated because [`germinate`](https://launchpad.net/germinate), the tool itself, is full of the word. So, to get things moving, I submitted a bug against the tool ([Bug #2114677](https://bugs.launchpad.net/ubuntu/+source/germinate/+bug/2114677)), as well as a first naive attempt at fixing it in the tool ([MP #487117](https://code.launchpad.net/~rkratky/germinate/+git/germinate/+merge/487117)). Let's see how that goes...