### PR TITLE
Fix links to pass linkcheck

### DIFF
--- a/docs/MIR/mir-rust.md
+++ b/docs/MIR/mir-rust.md
@@ -19,7 +19,7 @@ C code for some system libraries that could be statically linked.
 ### Automation via `debian/rules`
 
 A good example for automating Rust vendoring is provided by
-[s390-tools](https://git.launchpad.net/ubuntu/+source/s390-tools/tree/debian/rules)
+[s390-tools](https://sources.debian.org/src/s390-tools/2.35.0-1/debian/rules/)
 and can be executed via `debian/rules`.
 
 First, the package is updated as usual, including the new `debian/changelog`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -286,17 +286,21 @@ rst_epilog = """
 
 import distro_info
 
-sys.path.append('/usr/lib/python3/dist-packages')
+sys.path.append("/usr/lib/python3/dist-packages")
 
-manpages_url = ("https://manpages.ubuntu.com/manpages/"
-                f"{distro_info.UbuntuDistroInfo().stable()}/en/"
-                "man{section}/{page}.{section}.html")
+manpages_url = (
+    "https://manpages.ubuntu.com/manpages/"
+    f"{distro_info.UbuntuDistroInfo().stable()}/en/"
+    "man{section}/{page}.{section}.html"
+)
 
 # Configure hoverxref options
 hoverxref_role_types = {
-    'term': 'tooltip',
+    "term": "tooltip",
 }
-hoverxref_roles = ['term',]
+hoverxref_roles = [
+    "term",
+]
 
 # Specifies a reST snippet to be prepended to each .rst file
 # This defines a :center: role that centers table cell content.
@@ -326,4 +330,15 @@ if os.path.exists("./reuse/substitutions.yaml"):
 
 # Add configuration for intersphinx mapping
 
-intersphinx_mapping = {}
+intersphinx_mapping = {
+    "ubuntu-server": ("https://documentation.ubuntu.com/server/", None),
+    "pkg-guide": (
+        "https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/"
+        "en/2.0-preview/",
+        None,
+    ),
+    "starter-pack": (
+        "https://canonical-starter-pack.readthedocs-hosted.com/latest/",
+        None,
+    ),
+}

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1302,7 +1302,7 @@ Ubuntu ESM Team
     *Work in Progress*
 
     See also:
-    * [Ubuntu ESM Team](https://launchpad.net/~ubuntu-esm-team)
+    * [Ubuntu ESM Team](https://ubuntu.com/security/esm)
 
 Ubuntu flavors
     **Ubuntu flavors** are {term}`Distributions <Distribution>` of the default Ubuntu

--- a/docs/staging/new-packages.md
+++ b/docs/staging/new-packages.md
@@ -60,7 +60,7 @@ In order to have faster reviews, several teams have been set up to manage a
 given subset of packages. Some of them are:
 
 * [Debian GNOME Team](http://wiki.debian.org/Teams/DebianGnome)
-* [Debian KDE Team](http://pkg-kde.alioth.debian.org/)
+* [Debian KDE Team](https://salsa.debian.org/qt-kde-team/)
 * [Debian XFCE Group](http://wiki.debian.org/Teams/DebianXfceGroup)
 * [Debian Games Team](http://wiki.debian.org/Games/Team)
 * [Debian Multimedia](http://wiki.debian.org/DebianMultimedia)
@@ -68,8 +68,8 @@ given subset of packages. Some of them are:
 * [Debian Python Modules Team](http://wiki.debian.org/Teams/PythonModulesTeam)
 * [Debian Python Applications Packaging Team](http://wiki.debian.org/Teams/PythonAppsPackagingTeam)
 * [Debian CLI Applications Team](http://wiki.debian.org/Teams/DebianCliAppsTeam)
-* [Debian Mozilla Extension Team](http://wiki.debian.org/Teams/DebianMozExtTeam)
-* [Debian X Team](http://pkg-xorg.alioth.debian.org/)
+* [Debian Mozilla Extension Team](https://wiki.debian.org/Teams/DebianWebextensionTeam)
+* [Debian X Team](https://salsa.debian.org/xorg-team)
 
 More teams [can be found here](http://wiki.debian.org/Teams). If there is no
 team available that takes care of the group of packages you are interested in,
@@ -91,7 +91,7 @@ Ubuntu via Debian than directly.
 If you choose to do this, file an [Intent to Package (ITP)](http://www.debian.org/devel/wnpp/being_packaged)
 bug on the WNPP package in Debian to let others know that you're working on it
 (`reportbug -B debian wnpp` should do the right thing), then go through the
-[Debian Mentors](http://mentors.debian.net/cgi-bin/welcome) to get the package
+[Debian Mentors](http://mentors.debian.net/) to get the package
 uploaded. A number of Ubuntu Developers are also Debian Maintainers or Debian
 Developers, so they may be able to help you navigate Ubuntu/Debian interactions.
 
@@ -117,7 +117,7 @@ Developers are encouraged to examine their own packages using these guidelines
 prior to submitting them for review.
 
 To receive higher quality bug reports write an
-[apport hook](https://wiki.ubuntu.com/Apport#Per-package%20Apport%20Hooks) for your package.
+[apport hook](https://wiki.ubuntu.com/Apport#Per-package_Apport_Hooks) for your package.
 
 The [MOTU](https://wiki.ubuntu.com/MOTU) team approval policy for new packages:
 
@@ -140,10 +140,10 @@ The MOTU team uses the following workflow:
 
 * When you start to work on a new package, assign the `needs-packaging` bug to
   yourself and set it to "In Progress" (if there is no `needs-packaging` bug,
-  [file one](http://bugs.launchpad.net/ubuntu/+filebug?no-redirect&field.tag#needs-packaging)).
+  [file one](http://bugs.launchpad.net/ubuntu/+filebug)).
 
 * Once you have an initial package, follow the
-  [new packaging instructions](http://packaging.ubuntu.com/html/packaging-new-software.html#next-steps)
+  {external:doc}`new packaging instructions <tutorial/create-new-package>`
   to upload it to your PPA or a Launchpad branch, then add a link to the package
   in the description of the bug. Requests for changes or other communication
   about your package will be made as comments on your bug. Subscribing

--- a/docs/staging/phased-updates.md
+++ b/docs/staging/phased-updates.md
@@ -168,8 +168,8 @@ Checklist:
 
 1. Is any migration of data or settings required?
 
-1. How will the feature be tested? Please add an entry to
-  [New features](http://testcases.qa.ubuntu.com/Coverage/NewFeatures) for tracking test coverage.
+1. How will the feature be tested? W4ork with the
+  [Quality team](https://discourse.ubuntu.com/t/ubuntu-quality/39).
 
 ## Unresolved issues
 

--- a/docs/staging/sponsorship-process.md
+++ b/docs/staging/sponsorship-process.md
@@ -22,7 +22,7 @@ To make use of Ubuntu merge proposals, follow these steps:
 
 * [set up the tools](http://packaging.ubuntu.com/html/getting-set-up.html)
 * [get the source](http://packaging.ubuntu.com/html/udd-intro.html)
-* [work on the package](http://packaging.ubuntu.com/html/fixing-a-bug.html#work-on-a-fix)
+* {external:doc}`work on the package <tutorial/fix-bug>`
 * [seek sponsorship](https://wiki.ubuntu.com/DistributedDevelopment/Documentation/SeekingSponsorship)
 
 ```{admonition} Incorrect redirects
@@ -42,7 +42,7 @@ The traditional process involves:
 * Attach your work:
 
   * In the case of a patch (using the same upstream version), attach your
-    suggested patch (["Submitting the fix"](https://packaging.ubuntu.com/html/fixing-a-bug.html#submitting-the-fix-and-getting-it-included)).
+    suggested patch ({external:doc}`submitting the fix <tutorial/fix-bug>`).
     For security updates, please see the [security update packaging guidelines](https://wiki.ubuntu.com/SecurityTeam/UpdatePreparation#Packaging).
 
   * If the package uses a patch system (run `what-patch` in the source tree to
@@ -98,8 +98,8 @@ If you are unsure how to get a package sponsored, would like to add a new
 package or submit a patch, or have questions getting your package upstream
 into Debian, the Ubuntu Patch Pilots can help.
 
-To find out how to get in touch, please check the
-[program documentation](https://ubuntu.com/community/contribute/ubuntu-development/ubuntu-patch-pilots|program documentation).
+To find out how to get in touch, go to
+[Ubuntu Patch Pilots](https://ubuntu.com/community/contribute/ubuntu-development/ubuntu-patch-pilots).
 
 Generally asking for help in `#ubuntu-motu` or `#ubuntu-devel` is definitely on
 topic too. :-)


### PR DESCRIPTION
  * Substitute old links for new locations
  * Fix misformatted links
  * Add intersphinx to allow cross-linking

Notes:

* We're linking to the PG in a ton of places, so that will need to go away once the PG content is added to the repo. In the meantime, I added the PG as an intersphinx source, so we can start ref+doc linking to the content; plus it fixes a few links.
* Many of the fixed links are in `staging`, but I figure that's fine -- better to have a clean CI run to be able to spot real problems; plus those links would need to be fixed anyway.)