### PR TITLE
Fix broken file paths

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -277,13 +277,13 @@ Circle of Friends
     [core values of Ubuntu](https://design.ubuntu.com/brand):
     *Freedom*, *Reliable*, *Precise* and *Collaborative*.
 
-    ```{image} ../images/glossary-CoF-Square.png
+    ```{image} ../../images/glossary-CoF-Square.png
     :width: 200
     :height: 200
     :alt: Circle of Friends (Ubuntu Logo)
     ```
 
-    ```{image} ../images/glossary-Old-Ubuntu-Login-Background.jpg
+    ```{image} ../../images/glossary-Old-Ubuntu-Login-Background.jpg
     :height: 200
     :alt: Old Ubuntu-Login background showing three people in a circle holding hands.
     ```


### PR DESCRIPTION
The images linked in the glossary were broken by the recent reshuffle - this fixes them