### PR TITLE
Fixes issue #245 add a glossary term for chroot

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -269,6 +269,10 @@ Changelog
     * [Basic overview of the `debian/` directory](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/reference/debian-dir-overview/)
     * [Section 4.4 Debian changelog (Debian Policy Manual v4.6.2.0)](https://www.debian.org/doc/debian-policy/ch-source.html#debian-changelog-debian-changelog)
 
+Chroot
+Change root
+    Sets the root directory to the path provided as its first argument.
+
 CoF
 Circle of Friends
     The {term}`Ubuntu` logo is called **Circle of Friends**, because it is


### PR DESCRIPTION
I hope you find this to be a concise and meaningful definition and if not I look forward to your feedback. This definition has left me with a few questions Should there be glossary terms for path, root directory and arguments?  Should chroot be lower case always? I notice that diff is in the glossary in lower case but I'm not sure if that's the house style. Is there a better place for me to ask/suggest this stuff?