### PR TITLE
feat: add "Ubuntu for Developers" link to index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -134,3 +134,4 @@ suggestions, fixes, and constructive feedback.
 - Ubuntu Desktop documentation
 - Ubuntu Core documentation
 - Ubuntu on Public Cloud
+- [Ubuntu for Developers](https://documentation.ubuntu.com/ubuntu-for-developers/)


### PR DESCRIPTION
This is a minor patch that adds a link to the new "Ubuntu for Developers" documentation to the index page under "Using Ubuntu".