### PR TITLE
AA: add task to check AA labeled GH cases

### DIFF
--- a/docs/staging/AA/archive-administration.md
+++ b/docs/staging/AA/archive-administration.md
@@ -35,6 +35,7 @@ Less commonly, they are asked to do the following tasks:
 * {ref}`aa-signing-bootloaders`
 * {ref}`aa-phasing-sru-updates`
 * {ref}`aa-i386-allowlist-updates`
+* {ref}`aa-triage-contributions`
 
 The following list of Archive-related services needs to be updated with details
 of the charmed hosted services as they are migrated.

--- a/docs/staging/AA/maintainers/triage-aa-contributions.md
+++ b/docs/staging/AA/maintainers/triage-aa-contributions.md
@@ -1,0 +1,17 @@
+(aa-triage-contributions)=
+
+# Check contributions to AA process and documentation
+
+Everyone is encouraged in :ref:`contribute` to help with the documentation
+and modernizing the processes in this repository.
+
+To keep that maintainable for sub-teams the Ubuntu project documentation uses
+labels to separate issues and contributions related to particular sub-teams.
+
+Triage is done by the Authors for now, but eventually shall be automated
+based on which directory content is in.
+
+To process that influx the Archive Admin team shall semi regularly check
+[issues/discussions](https://github.com/ubuntu/ubuntu-project-docs/issues?q=state%3Aopen%20label%3A%22AA%22)
+and [pull requests](https://github.com/ubuntu/ubuntu-project-docs/pulls?q=is%3Aopen+is%3Apr+label%3AAA)
+labelled for the teams considerations.


### PR DESCRIPTION
Now that we have a proper way to contribute, we should add it as a task to check it.

Fixes: #80