### PR TITLE
Add bug control section in bug fix

### DIFF
--- a/docs/contributors/bug-fix/bug-control.md
+++ b/docs/contributors/bug-fix/bug-control.md
@@ -7,7 +7,7 @@ lifecycle of the bug by Launchpad users with appropriate privilege. A logged-in 
 a certain number of these control fields; the other fields can only be edited if you are part of the
 Ubuntu Bug Control team.
 
-The Ubuntu Bug Control team ([ubuntu-bugcontrol](https://launchpad.net/~ubuntu-bugcontrol) in Launchpad)
+The Ubuntu Bug Control team ([`ubuntu-bugcontrol`](https://launchpad.net/~ubuntu-bugcontrol) in Launchpad)
 is a subset of the Ubuntu Bug Squad who can change the importance of Ubuntu bug tasks, set the status
 of an Ubuntu bug task to "Triaged" or "Won't Fix" and target a bug for a release of Ubuntu.
 

--- a/docs/contributors/bug-fix/bug-control.md
+++ b/docs/contributors/bug-fix/bug-control.md
@@ -1,0 +1,17 @@
+(bug-control)=
+# Ubuntu Bug Control
+
+When a public bug is reported in Launchpad for a specific Ubuntu package, it starts with initial values for
+its control data (Status, Importance, Assigned-To, ...). These control fields can be changed to reflect the
+lifecycle of the bug by Launchpad users with appropriate privilege. A logged-in Launchpad user can modify
+a certain number of these control fields; the other fields can only be edited if you are part of the
+Ubuntu Bug Control team.
+
+The Ubuntu Bug Control team ([ubuntu-bugcontrol](https://launchpad.net/~ubuntu-bugcontrol) in Launchpad)
+is a subset of the Ubuntu Bug Squad who can change the importance of Ubuntu bug tasks, set the status
+of an Ubuntu bug task to "Triaged" or "Won't Fix" and target a bug for a release of Ubuntu.
+
+Both individuals and teams can join Ubuntu Bug Control. There are generic requirements and specific requirements
+for a team or individual to join the team.
+
+More details on the requirements and application process can be found at the [Ubuntu Bug Control Wiki](https://wiki.ubuntu.com/UbuntuBugControl).


### PR DESCRIPTION
Since I got some questions from my team member asking why
they cannot modify a certain control fields for a Bug (affected Ubuntu serie).
I think it would be useful if we talk briefly about the Ubuntu bug control team.