### PR TITLE
Improve copybutton prompt exclusion

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,7 @@ sitemap_show_lastmod = True
 
 
 # Template and asset locations
-#html_static_path = [".sphinx/_static"]
+# html_static_path = [".sphinx/_static"]
 # templates_path = [".sphinx/_static/_templates"]
 
 
@@ -327,7 +327,17 @@ hoverxref_roles = [
 # This option excludes line numbers and prompts from being selected when
 # users copy commands using the copybutton
 # https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies
-copybutton_exclude = ".linenos, .gp"
+
+# Following option only works when the 'console' syntax highlighting
+# is used; better to use a regex.
+# copybutton_exclude = ".linenos, .gp"
+
+# Following regex stupidly using '|' because of a bug in copybutton ext.:
+#         https://github.com/executablebooks/sphinx-copybutton/issues/96
+# Replace with   r"(\S+@\S+)?[\$\#] "  when the bug is fixed.
+copybutton_prompt_text = r"\S+@\S+[\$\#] |[\$\#] "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
 
 # Specifies a reST snippet to be prepended to each .rst file
 # This defines a :center: role that centers table cell content.


### PR DESCRIPTION
This option"

```python
copybutton_exclude = ".linenos, .gp"
```
only works when the `console` syntax highlighting is used (it relies on Pygments CSS); better to use a regex.