### PR TITLE
Proposed migration; first take

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -19,6 +19,7 @@ downstreams
 Edubuntu
 enablement
 Fosstodon
+gvfs
 IPs
 Jira
 Kubuntu

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,6 +268,8 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinxext.rediraffe",
     "sphinx_sitemap",
+    "sphinx_reredirects",
+    "sphinx_togglebutton",
 ]
 
 # Excludes files or directories from processing

--- a/docs/contributors/advanced/resolve-a-migration-issue.md
+++ b/docs/contributors/advanced/resolve-a-migration-issue.md
@@ -1,0 +1,95 @@
+(resolve-a-migration-issue)=
+# How to resolve a migration issue
+
+This article provides guidance on how to resolve migration issues.
+
+:::{admonition} **Proposed migration** series
+The {term}`proposed migration` article series explains the various migration failures and ways of investigating them.
+
+Process overview:
+: {ref}`proposed-migration`
+
+Issue types:
+:   * {ref}`issues-preventing-migration`
+    * {ref}`autopkgtest-regressions`
+    * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`special-migration-cases`
+
+Practical guidance:
+: {ref}`resolve-a-migration-issue` (this article)
+:::
+
+
+## Downloading test dependencies
+
+Autopkgtest runs tests in a controlled network environment, so if a test case expects to download material from the internet, it likely fails. This usually means the test case is attempting to download of one the following:
+
+Dependency (e.g. via PIP or Maven)
+: Try to work around this by adding the missing dependency to `debian/tests/control`.
+
+Example file
+: Try to make the test case use a local file, or load the file from the proxy network.
+
+
+(trigger-tests-from-the-command-line)=
+## Trigger tests from the command line
+
+To (re-)trigger several tests at once, use your `autopkgtest.ubuntu.com` credentials from a browser cookie to perform the HTTP requests from the command line.
+
+:::{warning}
+These instructions involve extracting your credentials for the {term}`autopkgtest` infrastructure from the browser. Secure the credentials, and not to share them.
+:::
+
+The credentials are available in a cookie for `autopkgtest.ubuntu.com`. There are two values to extract:
+
+* `session`
+* `SRVNAME`
+
+
+### Using Firefox Developer Tools
+
+In Firefox:
+
+1. Browse to [autopkgtest.ubuntu.com](https://autopkgtest.ubuntu.com/), and log in.
+
+1. Open the {guilabel}`Developer Tools` (by pressing {kbd}`F12` or {kbd}`Ctrl+Shift+C`).
+
+1. In the {guilabel}`Storage` tab, expand the {guilabel}`Cookies` menu in the left panel.
+
+1. Look for an `autopkgtest.ubuntu.com` entry, and find the values for `session` and `SRVNAME`.
+
+1. Save the values in a local file (e.g., {file}`~/.cache/autopkgtest.cookie`) with the following contents:
+
+    ```none
+    autopkgtest.ubuntu.com	TRUE	/	TRUE	0	session	<YOUR_COOKIE_SESSION_VALUE_HERE>
+    autopkgtest.ubuntu.com	TRUE	/	TRUE	0	SRVNAME	<YOUR_COOKIE_SRVNAME_VALUE_HERE>
+    ```
+
+    Note that the delimiters used above are tabs (`\t`) and not spaces. If unsure, use the following commands to create the file with the right format:
+
+    ```none
+    $ printf "autopkgtest.ubuntu.com\\tTRUE\\t/\\tTRUE\\t0\\tsession\\t<YOUR_COOKIE_SESSION_VALUE_HERE>\\n" \
+      > ~/.cache/autopkgtest.cookie
+    $ printf "autopkgtest.ubuntu.com\\tTRUE\\t/\\tTRUE\\t0\\tSRVNAME\\t<YOUR_COOKIE_SRVNAME_VALUE_HERE>\\n" \
+      >> ~/.cache/autopkgtest.cookie
+    ```
+
+1. Set proper permissions on the `.cookie` file, so other users cannot read it, e.g. `0600`:
+
+    ```none
+    $ chmod 0600 ~/.cache/autopkgtest.cookie
+    ```
+
+You can now use {command}`curl` to trigger the autopkgtest URLs. For example:
+
+```none
+$ curl --cookie ~/.cache/autopkgtest.cookie <TEST_TRIGGER_URL>
+```
+
+To use a list of test-trigger URLs:
+
+```none
+$ cat <FILE_WITH_TEST_URL_LIST> | vipe | xargs -rn1 -P10 \
+  curl --cookie ~/.cache/autopkgtest.cookie -o /dev/null \
+       --silent --head --write-out '%{url_effective} : %{http_code}\\n'
+```

--- a/docs/contributors/advanced/resolve-a-migration-issue.md
+++ b/docs/contributors/advanced/resolve-a-migration-issue.md
@@ -20,19 +20,191 @@ Practical guidance:
 :::
 
 
-## Downloading test dependencies
+## Understand autopkgtest logs
+
+When examining a log of a failed autopkgtest run, start from the end of the file. This usually shows a summary of the test runs or an error message in case of an error. For example:
+
+```none
+done.
+done.
+(Reading database ... 50576 files and directories currently installed.)
+Removing autopkgtest-satdep (0) ...
+autopkgtest [21:40:55]: test command1: true
+autopkgtest [21:40:55]: test command1: [-----------------------
+autopkgtest [21:40:58]: test command1: -----------------------]
+command1             PASS
+autopkgtest [21:41:03]: test command1:  - - - - - - - - - - results - - - - - - - - - -
+autopkgtest [21:41:09]: @@@@@@@@@@@@@@@@@@@@ summary
+master-cron-systemd  FAIL non-zero exit status 1
+master-cgi-systemd   PASS
+node-systemd         PASS
+command1             PASS
+```
+
+This shows that the test named `master-cron-systemd` has failed. To see why it failed, search the page for `master-cron-systemd`, and iterate until you get to the last line of the test run. Then scroll up to find the failed test cases:
+
+```none
+autopkgtest [21:23:39]: test master-cron-systemd: preparing testbed
+...
+...
+autopkgtest [21:25:10]: test master-cron-systemd: [-----------------------
+...
+...
+not ok 3 - munin-html: no files in /var/cache/munin/www/ before first run
+#
+#   find /var/cache/munin/www/ -mindepth 1 >unwanted_existing_files
+#   test_must_be_empty unwanted_existing_files
+#
+...
+...
+autopkgtest [21:25:41]: test master-cron-systemd: -----------------------]
+master-cron-systemd  FAIL non-zero exit status 1
+autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - results - - - - - - - - - -
+autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - stderr - - - - - - - - - -
+rm: cannot remove '/var/cache/munin/www/localdomain/localhost.localdomain': Directory not empty
+```
+
+All autopkgtests follow this general format, although the output from different tests varies.
+
+Beyond "regular" test case failures like this one, autopkgtest failures also occur due to missing or incorrect dependencies, test framework timeouts, and other issues. See {ref}`autopkgtest-regressions` for details.
+
+
+## External test dependencies
 
 Autopkgtest runs tests in a controlled network environment, so if a test case expects to download material from the internet, it likely fails. This usually means the test case is attempting to download of one the following:
 
 Dependency (e.g. via PIP or Maven)
-: Try to work around this by adding the missing dependency to `debian/tests/control`.
+
+: Try to work around this by adding the missing dependency to {file}`debian/tests/control`.
 
 Example file
+
 : Try to make the test case use a local file, or load the file from the proxy network.
 
 
+## Learn to run autopkgtest
+
+The {term}`autopkgtest` infrastructure runs tests automatically. This section describes various ways to (re-)trigger test runs or request tests with non-standard dependencies.
+
+
+### Autopkgtest with non-standard dependencies
+
+When investigating an autopkgtest failure, try running the test against various versions of trigger packages. See [Test request format](https://autopkgtest-cloud.readthedocs.io/en/latest/architecture.html#test-request-format) in autopkgtest-cloud documentation for detailed reference.
+
+Every autopkgtest request URL uses this format:
+
+```none
+https://autopkgtest.ubuntu.com/request.cgi?<PARAM1>=<VALUE>&<PARAM2>=<VALUE>
+```
+
+Special characters, such as `+` in `<VERSION>`, must be URL-encoded. Use, for example, the {manpage}`urlencode(1)` tool from the {pkg}`gridsite-clients` package:
+
+```none
+$ urlencode 2.15+dfsg-2
+2.15%2Bdfsg-2
+```
+
+:::{list-table} Useful triggers for autopkgtest
+:widths: 25 35 40
+:header-rows: 1
+
+*   - Test setup
+    - Placement
+    - New URL parameter
+*   - Include other packages from `-proposed`
+    - Append as many as needed to end of URL
+    - `&trigger=<SRCPKG>/<VERSION>`
+*   - Install everything from `-proposed`
+    - Append to end of URL
+    - `&all-proposed=1`
+*   - Test against packages in `-release`
+    - Substitute for existing `&trigger` value
+    - `migration-reference/0`
+:::
+
+
+(against-other-packages-in-proposed)=
+#### Against other packages in `-proposed`
+
+By default, autopkgtest only uses only one trigger source package from the `-proposed` pocket. To specify more packages (i.e. to test a package with dependencies on other packages in the `-proposed` pocket), suffix `&trigger=<SRCPKG>/<VERSION>` to the test re-trigger URL for each additional source package to use from proposed (right-click the retry URL, copy & paste it into your browser, and append an appropriate string). To construct the URL, append the following after `https://autopkgtest.ubuntu.com/request.cgi?`:
+
+```none
+release=<RELEASE>&arch=<ARCH>&package=<SRCPKG>&trigger=<SRCPKG>/<VERSION>
+```
+
+To install *all* of the packages involved in your test from the `-proposed` pocket, append `&all-proposed=1` to the request URL (every package installed in the testbed is then installed from `-proposed`). To construct the URL, append the following after `https://autopkgtest.ubuntu.com/request.cgi?`:
+
+```none
+release=<RELEASE>&arch=<ARCH>&package=<SRCPKG>&trigger=<SRCPKG>/<VERSION>&all-proposed=1
+```
+
+
+#### Against packages in `-release`
+
+To test whether an autopkgtest regression is present in the package version that's already in the `-release` and `-updates` pocket, run autopkgtest against the `-release` and `-updates` pocket only (without considering any versions that are in `-proposed`).
+
+To do this, use the URL `&trigger` parameter with a value of `migration-reference/0` instead of specifying a trigger package and version. To construct the URL, append the following after `https://autopkgtest.ubuntu.com/request.cgi?`:
+
+```none
+release=<RELEASE>&arch=<ARCH>&package=<SRCPKG>&trigger=migration-reference/0
+```
+
+:::{note}
+When finished, this test run is visible on the autopkgtest result page for the package but not on the {term}`update excuses` page.
+:::
+
+**Possible results** with the `migration-reference/0` trigger:
+
+Test fails
+
+: The test failure for the `-proposed` version is ignored -- the result instructs the autopkgtest infrastructure that it shouldn't expect this test to pass. Other packages trying to migrate are also not required to pass.
+
+Test succeeds
+
+: The assumption that the regression is already present in the package version in `-proposed` is likely incorrect. The test faile has likely been caused by the new change (upload).
+
+
+#### Against a PPA
+
+To get autopkgtest results against PPA uploads (e.g. when attempting to test a regression fix), use the `&ppa=<LPUSER>/<PPA>` parameter to the test-trigger URL. To construct the URL, append the following after `https://autopkgtest.ubuntu.com/request.cgi?`:
+
+```none
+release=<RELEASE>&arch=<ARCH>&package=<SRCPKG>&trigger=<SRCPKG>/<VERSION>&ppa=<LPUSER>/<PPA>
+```
+
+:::{important}
+You must have upload rights for the package (`<SRCPKG>` above) for the test request to be successful.
+:::
+
+The test is then displayed at [autopkgtest.ubuntu.com/running](http://autopkgtest.ubuntu.com/running). Upon completion, the test result is available at an index page at `https://autopkgtest.ubuntu.com/results/autopkgtest-<RELEASE>-<LPUSER>-<PPA>/?format=plain`. The index contains the results for each autopkgtest run against this particular `<PPA>` for this `<RELEASE>`. To see a particular test, append the appropriate path from the index to
+
+```none
+https://autopkgtest.ubuntu.com/results/autopkgtest-<RELEASE>-<LPUSER>-<PPA>/
+```
+
+
+(generate-test-re-trigger-urls)=
+### Generate test re-trigger URLs
+
+Use the [`excuses-kicker`](https://code.launchpad.net/~bryce/+git/excuses-kicker) tool to generate `autopkgtest` re-trigger URLs.
+
+See [`INSTALL.md`](https://git.launchpad.net/~bryce/+git/excuses-kicker/tree/INSTALL.md) for installation instructions.
+
+Run as:
+
+```none
+$ excuses-kicker <package>
+```
+
+:::{note}
+The tool automatically adds packages to the test run that the requested package has been tested against in the past. These may not be direct dependencies for the requested package -- they serve as an informed guess.
+:::
+
+TODO: Add info about [retry-autopkgtest-regressions](https://git.launchpad.net/ubuntu-archive-tools/tree/retry-autopkgtest-regressions). See also [Re-running tests](https://autopkgtest-cloud.readthedocs.io/en/latest/administration.html#re-running-tests).
+
+
 (trigger-tests-from-the-command-line)=
-## Trigger tests from the command line
+### Trigger tests from the command line
 
 To (re-)trigger several tests at once, use your `autopkgtest.ubuntu.com` credentials from a browser cookie to perform the HTTP requests from the command line.
 
@@ -45,20 +217,30 @@ The credentials are available in a cookie for `autopkgtest.ubuntu.com`. There ar
 * `session`
 * `SRVNAME`
 
+1. Extract the `session` and `SRVNAME` values. See instructions on how to do it Firefox or Chromium-based browsers:
 
-### Using Firefox Developer Tools
+    :::::{tab-set}
+    ::::{tab-item} Firefox
+    :::{admonition} Using Firefox Developer Tools
+    1. Browse to [autopkgtest.ubuntu.com](https://autopkgtest.ubuntu.com/), and log in.
+    1. Open the {guilabel}`Developer Tools` (by pressing {kbd}`F12` or {kbd}`Ctrl+Shift+C`).
+    1. Open the {guilabel}`Storage` tab.
+    1. Expand the {guilabel}`Cookies` menu in the left panel.
+    1. Look for an `autopkgtest.ubuntu.com` entry, and find the values for `session` and `SRVNAME`.
+    :::
+    ::::
+    ::::{tab-item} Chromium-based
+    :::{admonition} Using Chrome Developer Tools
+    1. Browse to [autopkgtest.ubuntu.com](https://autopkgtest.ubuntu.com/), and log in.
+    1. Open the {guilabel}`Developer Tools` (by pressing {kbd}`F12` or {kbd}`Ctrl+Shift+I`).
+    1. Open the {guilabel}`Application` tab.
+    1. Under {guilabel}`Storage` in the left panel, expand the {guilabel}`Cookies` item.
+    1. Look for an `autopkgtest.ubuntu.com` entry, and find the values for `session` and `SRVNAME`.
+    :::
+    ::::
+    :::::
 
-In Firefox:
-
-1. Browse to [autopkgtest.ubuntu.com](https://autopkgtest.ubuntu.com/), and log in.
-
-1. Open the {guilabel}`Developer Tools` (by pressing {kbd}`F12` or {kbd}`Ctrl+Shift+C`).
-
-1. In the {guilabel}`Storage` tab, expand the {guilabel}`Cookies` menu in the left panel.
-
-1. Look for an `autopkgtest.ubuntu.com` entry, and find the values for `session` and `SRVNAME`.
-
-1. Save the values in a local file (e.g., {file}`~/.cache/autopkgtest.cookie`) with the following contents:
+1. Save the values in a local file (e.g., `~/.cache/autopkgtest.cookie`) with the following contents:
 
     ```none
     autopkgtest.ubuntu.com	TRUE	/	TRUE	0	session	<YOUR_COOKIE_SESSION_VALUE_HERE>
@@ -80,16 +262,16 @@ In Firefox:
     $ chmod 0600 ~/.cache/autopkgtest.cookie
     ```
 
-You can now use {command}`curl` to trigger the autopkgtest URLs. For example:
+1. Use `curl` to trigger the autopkgtest URLs. For example:
 
-```none
-$ curl --cookie ~/.cache/autopkgtest.cookie <TEST_TRIGGER_URL>
-```
+    ```none
+    $ curl --cookie ~/.cache/autopkgtest.cookie <TEST_TRIGGER_URL>
+    ```
 
-To use a list of test-trigger URLs:
+    To use a list of test-trigger URLs:
 
-```none
-$ cat <FILE_WITH_TEST_URL_LIST> | vipe | xargs -rn1 -P10 \
-  curl --cookie ~/.cache/autopkgtest.cookie -o /dev/null \
-       --silent --head --write-out '%{url_effective} : %{http_code}\\n'
-```
+    ```none
+    $ cat <FILE_WITH_TEST_URL_LIST> | vipe | xargs -rn1 -P10 \
+      curl --cookie ~/.cache/autopkgtest.cookie -o /dev/null \
+           --silent --head --write-out '%{url_effective} : %{http_code}\\n'
+    ```

--- a/docs/contributors/advanced/review-a-merge-proposal.md
+++ b/docs/contributors/advanced/review-a-merge-proposal.md
@@ -1,5 +1,5 @@
-(merge-proposal-review)=
-# Merge Proposal review
+(review-a-merge-proposal)=
+# How to review a merge proposal
 
 Establishing a review process before sponsoring or uploading content has helped
 to maintain consistently high quality. To do so, changes are proposed as
@@ -216,7 +216,7 @@ appropriate for the situation.
   proposed migrations.
 
 * New runtime dependencies might be added and could cause
-  {ref}`component mismatches <pm-main-universe-binary-mismatch>`. This would
+  {ref}`component mismatches <main-universe-binary-mismatch>`. This would
   block proposed migration and may necessitate either filing a
   {ref}`MIR <main-inclusion-review>` for them or adapting the upload to avoid
   that dependency.

--- a/docs/contributors/advanced/sponsor-an-upload.md
+++ b/docs/contributors/advanced/sponsor-an-upload.md
@@ -1,5 +1,5 @@
 (sponsor-an-upload)=
-# How to sponsor
+# How to sponsor an upload
 
 Members of the {term}`Ubuntu Sponsors` and {term}`Ubuntu Security Sponsors`
 teams have the right to sponsor patches or new packages. If you are interested

--- a/docs/contributors/bug-fix/fix-a-bug-in-a-package.md
+++ b/docs/contributors/bug-fix/fix-a-bug-in-a-package.md
@@ -1,4 +1,4 @@
-(fix-a-bug)=
+(fix-a-bug-in-a-package)=
 # Fix a bug in package
 
 ```{note}

--- a/docs/contributors/bug-fix/package-tests.md
+++ b/docs/contributors/bug-fix/package-tests.md
@@ -35,7 +35,7 @@ $ ppa tests \
 This prints to the console a bunch of lines like:
 
 ```none
- Using Release Packages ♻️ 
+ Using Release Packages ♻️
  http://autopkgtest.ubuntu.com/request.cgi?release=bionic&arch=amd64&package=postfix&ppa=kstenerud/postfix-postconf-segfault-1753470&trigger=postfix/3.3.0-1ubuntu0.1~ppa1
  http://autopkgtest.ubuntu.com/request.cgi?release=bionic&arch=s390x&package=postfix&ppa=kstenerud/postfix-postconf-segfault-1753470&trigger=postfix/3.3.0-1ubuntu0.1~ppa1
   ...
@@ -52,7 +52,7 @@ URLs in your web browser yourself, which will cause the appropriate
 autopkgtests to run. If you omit the `--show-url` parameter, `ppa tests` will
 instead display clickable links, making it even more convenient. Alternatively,
 it is possible to
-{ref}`trigger the tests through the command line <pm-triggering-tests-from-the-cli>`,
+{ref}`trigger the tests through the command line <trigger-tests-from-the-command-line>`,
 which is useful when you need to trigger several tests.
 
 After a while, run `ppa tests` again to see how the tests are coming along:

--- a/docs/contributors/index-advanced.md
+++ b/docs/contributors/index-advanced.md
@@ -22,9 +22,22 @@ advanced/check-reverse-dependencies
 ```{toctree}
 :titlesonly:
 
-advanced/merge-proposal-review
-advanced/merge-a-package
+Review a merge proposal <advanced/review-a-merge-proposal>
+Merge a package <advanced/merge-a-package>
 ```
+
+
+## Proposed migration
+
+Guidance on investigating and resolving issues that block automatic migration from the `-proposed` to the `-release `{term}`pocket`:
+
+```{toctree}
+:titlesonly:
+
+Resolve a migration issue <advanced/resolve-a-migration-issue>
+```
+
+See the {ref}`proposed-migration` series of articles for an explanation of the process, as well as a description of common blocking issues.
 
 
 ## Seed management
@@ -37,7 +50,7 @@ advanced/merge-a-package
 ```{toctree}
 :maxdepth: 1
 
-advanced/sponsor-an-upload
+Sponsor an upload <advanced/sponsor-an-upload>
 ```
 
 

--- a/docs/contributors/index-bug-fix.md
+++ b/docs/contributors/index-bug-fix.md
@@ -10,7 +10,7 @@
 bug-fix/download-new-upstream-version
 bug-fix/extract-packages
 bug-fix/install-built-packages
-bug-fix/fix-a-bug
+bug-fix/fix-a-bug-in-a-package
 bug-fix/build-packages
 bug-fix/package-building
 bug-fix/propose-changes

--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -74,7 +74,7 @@ index-new-package
 ```{toctree}
 :maxdepth: 1
 
-find-a-sponsor
+Find a sponsor <find-a-sponsor>
 ```
 
 
@@ -87,7 +87,7 @@ some working familiarity with Ubuntu development.
 ```{toctree}
 :maxdepth: 1
 
-index-advanced
+Advanced tasks <index-advanced>
 ```
 
 

--- a/docs/contributors/new-package/upload-packages-to-ppa.rst
+++ b/docs/contributors/new-package/upload-packages-to-ppa.rst
@@ -1,2 +1,4 @@
+.. _upload-packages-to-a-ppa:
+
 Upload packages to a PPA
 ========================

--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -192,6 +192,13 @@ Breezy
     See also:
     * [Breezy (Launchpad)](https://launchpad.net/brz)
 
+Britney
+    A software service that is responsible for continuously regenerating the {term}`update excuses` page, which lists all unresolved {term}`proposed migration` items.
+
+    See also:
+    * {ref}`proposed-migration`
+    * {ref}`resolve-a-migration-issue`
+
 Bug
     In software development a **bug** refers to unintended or unexpected
     behavior of a computer program or system that produce incorrect results, or
@@ -587,7 +594,7 @@ Expanded Security Maintenance
     * [Expanded Security Maintenance (homepage)](https://ubuntu.com/security/esm)
 
 FTBFS
-Failed to build from Source
+Failed to build from source
     *Work in Progress*
 
 FTI
@@ -1028,6 +1035,12 @@ Public Key Cryptography Standards
 
     See also:
     * [PKCS (Wikipedia)](https://en.wikipedia.org/wiki/PKCS)
+
+Proposed migration
+    The process of moving uploaded or merged packages from the `-proposed` {term}`pocket` into the `-release` pocket for users to consume.
+
+    See also:
+    * {term}`update excuses`
 
 Pull
     *Work in Progress*
@@ -1477,6 +1490,13 @@ Unix
 
     See also:
     * [Unix (Wikipedia)](https://en.wikipedia.org/wiki/Unix)
+
+Update excuses
+    A page showing all unresolved migration issues for the current development release.
+
+    See also:
+    * [Update excuses page](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_excuses.html)
+    * {term}`proposed migration`
 
 Upstream
     A software project (and associated entities), another software project

--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -415,6 +415,9 @@ Copyright File
     * [Basic overview of the `debian/` directory](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/reference/debian-dir-overview/)
     * [Section 4.5. Copyright (Debian Policy Manual v4.6.2.0)](https://www.debian.org/doc/debian-policy/ch-source.html#copyright-debian-copyright)
 
+Core Dev
+    *Work in Progress*
+
 Cryptographic Signature
     *Work in Progress*
 
@@ -471,7 +474,7 @@ DEP-8
     {term}`source <Source Package>` and {term}`binary packages <Binary Package>`.
 
     See also:
-    * [Current DEP-8 Specification](https://dep-team.pages.debian.net/deps/dep8/)
+    * [DEP-8 Specification](https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst)
 
 Detached Signature
     A detached signature is a {term}`Digital Signature <Signature>` that is separated

--- a/docs/how-ubuntu-is-made/index-processes.md
+++ b/docs/how-ubuntu-is-made/index-processes.md
@@ -43,7 +43,7 @@ The process of moving (uploaded or merged) packages from the `-proposed` {term}`
 ```{toctree}
 :maxdepth: 1
 
-processes/proposed-migration
+processes/proposed-migration/index
 ```
 
 Automatic migration may be blocked for many different reasons. The following article series explains the various migration failures:

--- a/docs/how-ubuntu-is-made/index-processes.md
+++ b/docs/how-ubuntu-is-made/index-processes.md
@@ -21,7 +21,7 @@ processes/freezes
 For the most part, development work on the distribution revolves around getting packages to build and adding them to the Archive.
 
 
-### Basic archive management and maintenance
+### Archive management and maintenance
 
 Getting new versions of packages from Debian, dealing with build dependencies, and resolving build and test failures.
 
@@ -31,9 +31,27 @@ Getting new versions of packages from Debian, dealing with build dependencies, a
 processes/merges-and-syncs
 processes/sync-process
 processes/transitions
-processes/proposed-migration
 processes/backports
+processes/automatic-package-testing-autopkgtest
 ```
+
+
+#### Proposed migration
+
+The process of moving (uploaded or merged) packages from the `-proposed` {term}`pocket` to the `-release` pocket to make them available to users:
+
+```{toctree}
+:maxdepth: 1
+
+processes/proposed-migration
+```
+
+Automatic migration may be blocked for many different reasons. The following article series explains the various migration failures:
+
+* {ref}`issues-preventing-migration`
+* {ref}`autopkgtest-regressions`
+* {ref}`failure-to-build-from-source-ftbfs`
+* {ref}`special-migration-cases`
 
 
 ### Contributor support

--- a/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
+++ b/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
@@ -1,0 +1,196 @@
+.. _automatic-package-testing-autopkgtest:
+
+Automatic package testing: autopkgtest
+======================================
+
+The `DEP 8 specification`_ defines how automatic testing can very easily be 
+integrated into packages. To integrate a test into a package, all you need to 
+do is:
+
+* add a file called ``debian/tests/control`` which specifies the requirements 
+  for the testbed,
+* add the tests in ``debian/tests/``.
+
+
+Testbed requirements
+--------------------
+
+In ``debian/tests/control`` you specify what to expect from the testbed. So 
+for example you list all the required packages for the tests, if the testbed
+gets broken during the build or if ``root`` permissions are required. The 
+DEP 8 specification lists all available options.
+
+Below we are having a look at the ``glib2.0`` source package. In a very 
+simple case the file would look like this::
+
+        Tests: build
+        Depends: libglib2.0-dev, build-essential
+
+For the test in ``debian/tests/build`` this would ensure that the packages 
+``libglib2.0-dev`` and ``build-essential`` are installed.
+
+.. note:: You can use ``@`` in the ``Depends`` line to indicate that you want
+        all the packages installed which are built by the source package in
+        question.
+
+
+The actual tests
+----------------
+
+The accompanying test for the example above might be:
+
+.. code-block:: sh
+
+        #!/bin/sh
+        # autopkgtest check: Build and run a program against glib, to verify that the
+        # headers and pkg-config file are installed correctly
+        # (C) 2012 Canonical Ltd.
+        # Author: Martin Pitt <martin.pitt@ubuntu.com>
+
+        set -e
+
+        WORKDIR=$(mktemp -d)
+        trap "rm -rf $WORKDIR" 0 INT QUIT ABRT PIPE TERM
+        cd $WORKDIR
+        cat <<EOF > glibtest.c
+        #include <glib.h>
+
+        int main()
+        {
+            g_assert_cmpint (g_strcmp0 (NULL, "hello"), ==, -1);
+            g_assert_cmpstr (g_find_program_in_path ("bash"), ==, "/bin/bash");
+            return 0;
+        }
+        EOF
+
+        gcc -o glibtest glibtest.c `pkg-config --cflags --libs glib-2.0`
+        echo "build: OK"
+        [ -x glibtest ]
+        ./glibtest
+        echo "run: OK"
+
+Here a very simple piece of C code is written to a temporary directory. Then 
+this is compiled with system libraries (using flags and library paths as 
+provided by `pkg-config`). Then the compiled binary, which just exercises some
+parts of core glib functionality, is run.
+
+While this test is very small and simple, it covers quite a lot: that your -dev
+package has all necessary dependencies, that your package installs working
+pkg-config files, headers and libraries are put into the right place, or that
+the compiler and linker work. This helps to uncover critical issues early on.
+
+
+Executing the test
+------------------
+
+While the test script can be easily executed on its own, it is strongly
+recommended to actually use ``autopkgtest`` from the ``autopkgtest`` package for
+verifying that your test works; otherwise, if it fails in the Ubuntu Continuous
+Integration (CI) system, it will not land in Ubuntu.  This also avoids cluttering
+your workstation with test packages or test configuration if the test does
+something more intrusive than the simple example above.
+
+The `README.running-tests <running_tests_>`_ documentation explains all
+available testbeds (schroot, LXD, QEMU, etc.) and the most common scenarios how
+to run your tests with ``autopkgtest``, e. g. with locally built binaries, locally
+modified tests, etc.
+
+The Ubuntu CI system uses the QEMU runner and runs the tests from the packages
+in the archive, with ``-proposed`` enabled. To reproduce the exact same
+environment, first install the necessary packages::
+
+        sudo apt install autopkgtest qemu-system qemu-utils autodep8
+
+Now build a testbed with::
+
+        autopkgtest-buildvm-ubuntu-cloud -v
+
+(Please see its manpage and ``--help`` output for selecting different releases,
+architectures, output directory, or using proxies). This will build e. g.
+``adt-trusty-amd64-cloud.img``.
+
+Then run the tests of a source package like ``libpng`` in that QEMU image::
+
+        autopkgtest libpng -- qemu adt-trusty-amd64-cloud.img
+
+The Ubuntu CI system runs packages with only selected packages from
+``-proposed`` available (the package which caused the test to be run); to
+enable that, run::
+
+        autopkgtest libpng -U --apt-pocket=proposed=src:foo -- qemu adt-release-amd64-cloud.img
+
+or to run with all packages from ``-proposed``::
+
+        autopkgtest libpng -U --apt-pocket=proposed -- qemu adt-release-amd64-cloud.img
+
+The ``autopkgtest`` manpage has a lot more valuable information on other
+testing options.
+
+
+Further examples
+----------------
+
+This list is not comprehensive, but might help you get a better idea of how
+automated tests are implemented and used in Ubuntu.
+
+* The `libxml2 tests <libxml2_>`_ are very similar. They also run a test-build of a 
+  simple piece of C code and execute it.
+* The `gtk+3.0 tests <gtk3_>`_ also do a compile/link/run check in the "build" test. 
+  There is an additional "python3-gi" test which verifies that the GTK 
+  library can also be used through introspection.
+* In the `ubiquity tests <ubiquity_>`_ the upstream test-suite is executed.
+* The `gvfs tests <gvfs_>`_ have comprehensive testing of their functionality and
+  are very interesting because they emulate usage of CDs, Samba, DAV and
+  other bits.
+
+
+Ubuntu infrastructure
+---------------------
+
+
+Packages which have ``autopkgtest`` enabled will have their tests run whenever
+they get uploaded or any of their dependencies change. The output of
+`automatically run autopkgtest tests <jenkins_>`_ can be viewed on the web and is 
+regularly updated.
+
+Debian also uses ``autopkgtest`` to run package tests, although currently only
+in schroots, so results may vary a bit. Results and logs can be seen on
+http://ci.debian.net. So please submit any test fixes or new tests to Debian as
+well.
+
+
+Getting the test into Ubuntu
+----------------------------
+
+The process of submitting an autopkgtest for a package is largely similar to 
+:ref:`fixing a bug in Ubuntu <fix-a-bug-in-a-package>`. Essentially you simply:
+
+* run ``bzr branch ubuntu:<packagename>``,
+* edit ``debian/control`` to enable the tests,
+* add the ``debian/tests`` directory,
+* write the ``debian/tests/control`` based on the `DEP 8 Specification <dep8_>`_,
+* add your test case(s) to ``debian/tests``,
+* commit your changes, push them to Launchpad, propose a merge and get it 
+  reviewed just like any other improvement in a source package.
+
+
+What you can do
+---------------
+
+The Ubuntu Engineering team put together a `list of required test-cases <requiredtests_>`_,
+where packages which need tests are put into different categories. Here you
+can find examples of these tests and easily assign them to yourself.
+
+If you should run into any problems, you can join the `<#devel:ubuntu.com_>`_ Matrix
+channel to get in touch with developers who can help you.
+
+.. wokeignore:rule=master
+.. _DEP8: https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst
+.. _libxml2: https://git.launchpad.net/ubuntu/+source/libxml2/tree/debian/tests
+.. _gvfs: https://git.launchpad.net/ubuntu/+source/gvfs/tree/debian/tests
+.. _gtk3: https://git.launchpad.net/ubuntu/+source/gtk+3.0/tree/debian/tests
+.. _ubiquity: https://git.launchpad.net/ubiquity/tree/debian/tests
+.. _jenkins: http://autopkgtest.ubuntu.com/
+.. wokeignore:rule=master
+.. _running_tests: https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.running-tests.rst
+.. _requiredtests: https://wiki.ubuntu.com/QATeam/RequiredTests

--- a/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
+++ b/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
@@ -3,13 +3,13 @@
 Automatic package testing: autopkgtest
 ======================================
 
-The `DEP 8 specification`_ defines how automatic testing can very easily be 
-integrated into packages. To integrate a test into a package, all you need to 
-do is:
+The :term:`DEP-8` specification defines how to integrate automatic testing into packages. To integrate a test into a package, add the following files:
 
-* add a file called ``debian/tests/control`` which specifies the requirements 
-  for the testbed,
-* add the tests in ``debian/tests/``.
+:file:`debian/tests/control`
+: Specifies the requirements for the testbed.
+
+:file:`debian/tests/`
+: The tests.
 
 
 Testbed requirements
@@ -162,30 +162,30 @@ well.
 Getting the test into Ubuntu
 ----------------------------
 
-The process of submitting an autopkgtest for a package is largely similar to 
-:ref:`fixing a bug in Ubuntu <fix-a-bug-in-a-package>`. Essentially you simply:
+The process of submitting an autopkgtest for a package is similar to :ref:`fixing a bug in Ubuntu <fix-a-bug-in-a-package>`:
 
-* run ``bzr branch ubuntu:<packagename>``,
-* edit ``debian/control`` to enable the tests,
-* add the ``debian/tests`` directory,
-* write the ``debian/tests/control`` based on the `DEP 8 Specification <dep8_>`_,
-* add your test case(s) to ``debian/tests``,
-* commit your changes, push them to Launchpad, propose a merge and get it 
-  reviewed just like any other improvement in a source package.
+#. Run ``bzr branch ubuntu:<packagename>``,
+#. Edit ``debian/control`` to enable the tests,
+#. Add the ``debian/tests`` directory,
+#. Write the ``debian/tests/control`` based on the :term:`DEP-8` specification,
+#. Add your test case(s) to ``debian/tests``,
+#. Commit your changes, push them to Launchpad, propose a merge, and get it reviewed like any other improvement in a source package.
 
 
 What you can do
 ---------------
 
-The Ubuntu Engineering team put together a `list of required test-cases <requiredtests_>`_,
-where packages which need tests are put into different categories. Here you
-can find examples of these tests and easily assign them to yourself.
+The Ubuntu Engineering team maintains a `list of required test-cases <requiredtests_>`_ with packages that need tests in different categories. Use it to find examples of tests and assign them to yourself.
 
-If you should run into any problems, you can join the `<#devel:ubuntu.com_>`_ Matrix
-channel to get in touch with developers who can help you.
+For help with resolving problems, join the `<#devel:ubuntu.com_>`_ Matrix channel to get in touch with developers.
+
+
+Further reading
+---------------
+
+* `Autopkgtest - Defining tests for Debian packages <https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>`_
 
 .. wokeignore:rule=master
-.. _DEP8: https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst
 .. _libxml2: https://git.launchpad.net/ubuntu/+source/libxml2/tree/debian/tests
 .. _gvfs: https://git.launchpad.net/ubuntu/+source/gvfs/tree/debian/tests
 .. _gtk3: https://git.launchpad.net/ubuntu/+source/gtk+3.0/tree/debian/tests

--- a/docs/how-ubuntu-is-made/processes/backports.rst
+++ b/docs/how-ubuntu-is-made/processes/backports.rst
@@ -2,3 +2,24 @@
 
 Backports
 =========
+
+Backporting allows for making new functionality (that is not connected to a critical bug fix) available in a stable release. For these scenarios, there are two options:
+
+* :ref:`Uploading to a PPA <upload-packages-to-a-ppa>`.
+* Preparing a backport.
+
+
+Official Ubuntu Backports
+-------------------------
+
+.. TODO: Add link to 'Security Update'
+
+The Backports Project is a means to provide new features to users. Because of the inherent stability risks in backporting packages, users do not get backported packages without some explicit action on their part. This generally makes backports an inappropriate avenue for fixing bugs. If a package in an Ubuntu release has a bug, it should be fixed either through the Security Update or the :ref:`stable-release-updates` process, as appropriate.
+
+All packages that are to be backported to a stable release must be built and tested on the given stable release. Use the :command:`pbuilder-dist` tool (from the :pkg:`ubuntu-dev-tools` package) for this.
+
+To report the backport request and get it processed by the Backporters team, use the :command:`requestbackport` tool (also in the :pkg:`ubuntu-dev-tools` package). The tool serves to:
+
+* Determine the intermediate releases that the package needs to be backported to.
+* List all reverse-dependencies.
+* File the backporting request (Launchpad bug). It also includes a testing checklist in the request.

--- a/docs/how-ubuntu-is-made/processes/merges-and-syncs.rst
+++ b/docs/how-ubuntu-is-made/processes/merges-and-syncs.rst
@@ -30,6 +30,8 @@ On request (via a :term:`Launchpad` ticket), :term:`archive admins <Archive admi
     After the Final Release, you must follow the :ref:`stable-release-updates` process. For additional details about the freezes, see the :ref:`release-cycle` article.
 
 
+.. _merges:
+
 Merges
 ~~~~~~
 
@@ -41,8 +43,6 @@ The Ubuntu Merge-o-Matic (MoM) service automatically performs merges and publish
 * `universe <https://merges.ubuntu.com/universe.html>`_
 * `restricted <https://merges.ubuntu.com/restricted.html>`_
 * `multiverse <https://merges.ubuntu.com/multiverse.html>`_
-
-.. TODO merging link
 
 To complete a merge, interaction and supervision by Ubuntu maintainers are required. See :ref:`merge-a-package` for details on performing a merge.
 

--- a/docs/how-ubuntu-is-made/processes/proposed-migration.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration.md
@@ -1,966 +1,128 @@
 (proposed-migration)=
 # Proposed migration
 
-Uploads of fixed or merged packages don't automatically get released to Ubuntu
-users, but rather go into a special pocket called `-proposed` for testing and
-integration. Once a package is deemed OK, it **migrates** into the `-release`
-pocket for users to consume. This is called the
-["proposed migration" process](https://wiki.ubuntu.com/ProposedMigration).
+Uploads of {ref}`fixed <fix-a-bug-in-a-package>` or {ref}`merged <merges>` packages are not automatically released to Ubuntu users. Instead, they go into a special {term}`pocket` called `-proposed` for testing and integration. Once a package is deemed OK, it **migrates** into the `-release` pocket for users to consume. This is called the "proposed migration" process.
 
-This page documents tips and tricks for solving migration issues, along with
-some guidance for people just starting the proposed migration duty.
+This article series outlines the upload and migration process.
+
+:::{admonition} **Proposed migration** series
+The article series explains the various migration failures and ways of investigating them.
+
+Process overview:
+: {ref}`proposed-migration` (this article)
+
+Issue types:
+:   * {ref}`issues-preventing-migration`
+    * {ref}`autopkgtest-regressions`
+    * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`special-migration-cases`
+
+Practical guidance:
+: {ref}`resolve-a-migration-issue`
+:::
+
+See {ref}`resolve-a-migration-issue` for guidance on how to deal with situations when the migration from `-proposed` to -`-release` does not proceed automatically.
 
 
-## Lifecycle for an upload
+(lifecycle-of-an-upload)=
+## Lifecycle of an upload
 
-1. Issue identified, fixed, and packaged
+1. Issue identified, fixed, and packaged.
 
-1. `*source.changes` uploaded
+1. The `*source.changes` file uploaded.
 
-1. If the fix is an SRU, or if we're in a {ref}`freeze <feature-freeze>`:
+1. If the fix is an {term}`SRU`, or if the release cycle is in a {ref}`feature-freeze-ff`:
 
-   * Upload goes into an `unapproved` queue
+   * Upload goes into the `unapproved` queue.
+   * The SRU team reviews and approves the upload (go to 4).
+   * The SRU team disapproves (go to 1).
 
-   * SRU team reviews and approves... (go to 4)
+1. The upload goes into the `[codename]-proposed` queue.
 
-   * ...or disapproves (go to 1)
+1. Launchpad builds binary package(s) the from source package.
 
-1. Upload goes into `[codename]-proposed` queue
+1. {ref}`Autopkgtests <automatic-package-testing-autopkgtest>` run on the Ubuntu infrastructure:
 
-1. Launchpad builds binary package(s) from source package
+   * Autopkgtests for the package itself.
+   * Autopkgtests for the reverse{-build}-dependencies.
 
-1. Run [autopkgtests](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/1.0/explanation/auto-pkg-test.html):
-
-   * Autopkgtests for the package itself
-
-   * Autopkgtests for the reverse{-build}-dependencies, as well
-
-1. Verify other archive consistency checks:
+1. Archive consistency checks:
 
    * Are binary packages installable?
-
    * Are all required dependencies at the right version?
-
    * Does it cause anything to become uninstallable?
-
    * etc.
 
 1. If (and only if) the fix is an SRU:
 
-   * [SRU bug](https://documentation.ubuntu.com/sru/en/latest/howto/common-issues/)
-     updated with request to verify
-
-   * Reporter or developer verifies fix, and updates tags
-
-1. Release package from `[codename]-proposed` to `[codename]`
-
-The migration often proceeds automatically, but when issues arise we need to
-step in to sort things out. Sometimes, the problematic package is one we've
-uploaded ourselves, and it is generally the responsibility of the uploader to
-analyze and solve the issue.
-
-However, there are other situations that can lead to migration trouble, for
-which there is no specific responsible party. These types of issues are focused
-on as part of the "Plus-One Maintenance" effort, where individuals across the
-distro team are tasked with examining and solving them. Some of these problems
-arise from items auto-synced from Debian, or via a side-effect of some other
-change in the distro.
-
-
-(pm-update-excuses)=
-## Update Excuses page
-
-All current migration issues for the current devel release are displayed on the
-[Update Excuses Page](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_excuses.html).
-[Similar pages](https://ubuntu-archive-team.ubuntu.com/proposed-migration/)
-exist for stable releases (these items generally relate to particular SRUs).
-These pages are created by a software service named "Britney", which updates
-the page after each batch of test runs, typically every 2--3 hours depending on
-load.
-
-The page is ordered from newest to oldest, so the items at the top of the page
-may still be processing (indicated by "Test in progress" marked for one or more
-architectures). In general, two things to watch for are "missing build", which
-can indicate a failure to build the source package ({term}`FTBFS`), and "autopkgtest
-regression", which indicates a test failure. Both of these situations are
-described in more depth below.
-
-Many of the items on the page are not actually broken, they're just blocked by
-something else that needs resolving. This often happens for new libraries or
-language runtimes, or really any package that a lot of other things depend on
-to build, install, or run tests against.
+   * [SRU bug](https://documentation.ubuntu.com/sru/en/latest/howto/common-issues/) updated with a request to verify.
+   * Reporter or developer verifies the fix and updates tags.
 
-If you are just coming up to speed on proposed migration duty, you'll likely be
-wondering "Where do I even start?!". A solid suggestion is to look for build
-failures towards the upper-middle of the page, particularly those affecting only
-one architecture. Single-arch build failures tend to be more localized and more
-deterministic in their cause. Items towards the top of the page (but after all
-the "Test in progress" items) are newer, and so have a higher chance of being
-something simple that fewer people have looked at yet, without being so new that
-it's still being actively worked on by someone.
-
-For tasks like `+1 maintenance` where the goal is to ensure not too much
-migration backlog builds up it can be helpful to use
-[tools visualizing](https://discourse.ubuntu.com/t/visualizing-and-exploring-ubuntu-excuses/59824)
-the excuses page in different ways.
-Such tools can help to unblock a lot with only a few changes - but be careful,
-only using such will cause less central cases to get stuck for quite a long
-time.
+1. Package released from `[codename]-proposed` to `[codename]`.
 
-If you want to double check whether someone is already looking at it, the
-[Ubuntu Devel Matrix channel](https://matrix.to/#/#devel:ubuntu.com) is a
-good place to ask. For any case that requires more effort or a deeper analysis
-an {ref}`update-excuses bug <pm-bug-reports-for-migration-problems>` will help to
-coordinate.
 
-On the other hand, all these are good hints but you don't have to worry or feel
-blocked too much about where to start; the Update Excuses page is like a wool
-sweater in that whichever thread you start pulling, you'll end up unraveling
-the whole affair.
+(migration-issues)=
+## Migration issues
 
+The migration often proceeds automatically, but when issues arise, someone needs to resolve the problem. It is generally the responsibility of the uploader to analyze and {ref}`resolve the issue <resolve-a-migration-issue>`.
 
-(pm-bug-reports-for-migration-problems)=
-## Bug reports for migration problems
+Other situations can also lead to migration trouble, for which there is no specific responsible party. These types of problems are focused on as part of the {ref}`plus-one-maintenance` effort, where individuals across the distribution team are tasked with examining and resolving issues. Some of these problems arise from items auto-synced from Debian, or via a side-effect of some other change in the distribution.
 
-If you file a bug report about a build or test failure shown on the Update
-Excuses page, tag the bug report `update-excuse`. Britney will include a link
-to the bug report next time it refreshes the `update_excuses.html` page. This
-helps other developers see the investigative work you've already done, and can
-be used to identify the next action. Mark yourself as the *Assignee* if you're
-actively working on the issue, and leave the bug unsubscribed if you aren't, so
-that others can carry things forward.
+See the articles in the series for details:
 
+* {ref}`issues-preventing-migration`
+* {ref}`autopkgtest-regressions`
+* {ref}`failure-to-build-from-source-ftbfs`
+* {ref}`special-migration-cases`
 
-(pm-failure-to-build-from-source)=
-## Failure to Build From Source (FTBFS)
 
-The build step can hit failures for several general classes of problems.
+(update-excuses-page)=
+## Update-excuses page
 
-* {ref}`First <pm-normal-build-issues>` are regular build problems that can be
-  easily reproduced locally (and that should have been addressed before
-  uploading).
+All unresolved migration issues for the current development release are displayed on the [Update Excuses page](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_excuses.html). Similar pages exist for stable releases: [proposed-migration](https://ubuntu-archive-team.ubuntu.com/proposed-migration/) (these items generally relate to particular SRUs). These pages are created by a software service named {term}`Britney`, which updates the page after each batch of test runs, typically every 2--3 hours depending on load.
 
-* {ref}`Second <pm-platform-specific-issues>` are platform-specific issues that
-  may have been overlooked due to being present only on unfamiliar hardware.
+The page is ordered from newest to oldest, so the items at the top of the page may still be processing (indicated by "Test in progress" marked for one or more architectures). There is also a variant of the page that groups the items by maintainer teams: [devel-proposed by team](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_excuses_by_team.html).
 
-* {ref}`Third <pm-intermittent-problems>` are intermittent network or framework
-  problems, where simply retrying the build once or twice can result in a
-  successful build.
+In general, there are two things to watch for:
 
-* {ref}`Fourth <pm-dependency-problems>` are dependency problems, where the
-  task is to get some other package to be the right version in the `-release`
-  pocket so that the build will succeed.
+"Missing builds"
+: Can indicate a failure to build the source package ({term}`FTBFS`).
 
-* {ref}`Fifth <pm-abi-changes>` are {term}`ABI` changes with dependencies;
-  these often just need a no-change rebuild.
+"Regressions"
+: Indicates a ({term}`autopkgtest`) test failure.
 
-* {ref}`Sixth <pm-package-specific-issues>` (and finally) are all the other
-  myriad package-specific build problems that usually require a tweak to the
-  package itself.
+Both of these situations are described in more depth below.
 
+Many of the items on the page are not actually broken -- they're just blocked by something else that needs resolving. This often happens for new libraries or language runtimes, or any package that a lot of other things depend on to build, install, or run tests against.
 
-(pm-normal-build-issues)=
-### Normal build issues
 
-The first case covers all the usual normal build issues like syntax errors and
-so on. In practice these tend to be quite rare, since developers tend to be
-very diligent in making sure their packages build before uploading them. Fixes
-for these is standard development work.
+(where-to-start)=
+### Where to start
 
+Look for build failures towards the upper-middle of the page, particularly those affecting only one architecture. Single-arch build failures tend to be more localized and more deterministic in their cause. Items towards the top of the page (but after all the **"Test in progress"** items) are newer, and so have a higher chance of being something simple that fewer people have looked at yet, without being so new that it's still being actively worked on by someone.
 
-(pm-platform-specific-issues)=
-### Platform-specific issues
+:::{tip}
+For tasks like {ref}`plus-one-maintenance` where the goal is to ensure not too much migration backlog builds up, it's helpful to use the {command}`visual-excuses` tool, which visualizes the excuses page in different ways. Such tools can help unblock a lot with only a few changes - but be careful, depending on these tools only causes less central cases to be stuck for a long time.
 
-The second case is similar to the first but pertains to issues that arise only
-on specific platforms. Common situations are tests or code that relies on
-[endianness](https://en.wikipedia.org/wiki/Endianness) of data types, and so
-breaks on big-endian systems (e.g. s390x), code expecting 64-bit data types that
-breaks on 32-bit (e.g. armhf), and so on.
-
-{term}`Canonistack` provides hardware for Canonical employees to use to try and reproduce these problems.
-
-```{note}
-i386 in particular fails less due to data type issues, but more because it is
-a partial port and has numerous limitations that require special handling, as
-described on the {ref}`i386 troubleshooting page <aa-i386>`.
-```
-
-
-(pm-intermittent-problems)=
-### Intermittent problems
-
-In the third case, local building was fine but the uploaded build may have
-failed on Launchpad due to a transitory issue such as a network outage, or a
-race condition, or other stressed resource. Alternatively, it might have failed
-due to a strange dependence on some variable like the day of the week.
-
-In these cases, clicking on the "Retry Build" button in Launchpad once or twice
-can sometimes cause the build to randomly succeed, thus allowing the transition
-to proceed (if you're not yet a Core Dev, ask for a Core Dev on the
-`#ubuntu-devel` IRC channel to click the link for you).
-
-Needless to say, we want the build process to be robust and predictable. If the
-problem is a recurring one, and you are able to narrow down the cause, it can
-be worthwhile to find the root cause and figure out how to fix it properly.
-
-
-(pm-dependency-problems)=
-### Dependency problems
-
-For the fourth case, where a dependency is not the right version or is not
-present in the right pocket, the question becomes one of identifying what's
-wrong with the dependency and fixing it.
-
-Be aware there may be some situations where the problem really is with the
-dependency itself. The solution then might be to change the version of the
-dependency, or adjust the dependency version requirement, or remove invalid
-binary packages, or so forth. The latter solutions often require asking an
-Archive Admin for help on the `#ubuntu-release` IRC channel.
-
-
-(pm-abi-changes)=
-### ABI changes
-
-The fifth case, of ABI changes, tends to come up when Ubuntu is introducing new
-versions of toolchains, language runtime environments or core libraries (i.e.
-new `glibc`, `gcc`, `glib2.0`, `ruby`, `python3`, `phpunit`, etc).
-
-This happens when the release of the underlying libraries/toolchains is newer
-than the project that uses it. Your package may fail to build because, for
-example, one of its dependencies was built against a different version of
-`glibc`, or with less strict `gcc` options (the
-[Ubuntu Defaults](https://wiki.ubuntu.com/ToolChain/CompilerFlags#Notes) can be
-checked here) etc, and it needs a (no-change) rebuild (and/or patched) to build
-with the new version or stricter options.
-
-Assuming the upstream project has already adapted to the changed behavior or
-function-prototypes **and** produced a release, then:
-
-* If we already have the release in Ubuntu a simple no-change rebuild may
-  suffice.
-
-* If we don't have the release, then it will need a sync or merge, or patching
-  in the changes to what we're carrying.
-  
-If upstream has not *released* the changes, then you could also consider
-packaging a snapshot of their git repository.
-
-If upstream has *not yet made* the changes, and there no existing bug reports or
-pull requests yet, it may be necessary to make the changes on our end.
-Communication with Debian and upstream can be effective here, and where it
-isn't, filing bug reports can be worth the effort.
-
-It's worth noting that with ABI changes, these updates often cause the same kind
-of errors in many places. It's worth asking in the `#ubuntu-devel` IRC channel
-in case standard solutions are already known that you can re-use, such as
-ignoring a new warning via a `-W...` option or switching to the old behavior
-via a `-f...` option. It's also worth reporting your findings in ways others can
-easily re-use when they run into more cases.
-
-
-(pm-package-specific-issues)=
-### Package-specific issues
-
-Finally, there are a myriad of other problems that can result in build
-failures. Many of these will be package-specific or situation-specific. As you
-run into situations that crop up more frequently than a couple of times please
-update these docs.
-
-
-(pm-autopkgtest-regressions)=
-## Autopkgtest regressions
-
-After a package has successfully built, the
-[autopkgtest infrastructure](https://autopkgtest.ubuntu.com/) will run its
-[DEP8 tests](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/1.0/explanation/auto-pkg-test.html)
-for each of its supported architectures. Failed tests can block the migration,
-and "Regression" listed for the failed architecture(s), worded in one of the
-following ways.
-
-
-### "Migration status for `aaa (x to y): <reason>`"
-
-This means package `aaa` has a new version `y` uploaded to `-proposed`, to
-replace the existing version `x`, but the change has not yet been permitted.
-The various reasons typically seen are outlined in the items below.
-
-
-### "Waiting for test results, another package or too young (no action required now - check later)"
-
-This means one or more tests still need to be run. These will be noted as 'Test
-in progress' under the 'Issues preventing migration' line item.
-
-
-### "Will attempt migration (Any information below is purely informational)"
-
-This is good -- it indicates the item is currently in process and will likely
-migrate soon (within a day or so).
-
-
-### "Waiting for another item to be ready to migrate (no action required now - check later)"
-
-This can be good if it's recent, but if it's more than a few days old then there
-may be a deeper issue going on with a dependency. If it's recent, just give it
-some time (maybe a day or so). If it's older, refer to the items listed under
-the 'Issues preventing migration:' line to see what specifically has gone wrong,
-and then see the {ref}`pm-issues-preventing-migration` section for diagnostic tips.
-
-
-### "BLOCKED: Cannot migrate due to another item, which is blocked (please check which dependencies are stuck)"
-
-The package itself is likely fine, but it's being blocked by some issue with
-some other package. Check beneath the 'Invalidated by dependency' line to see
-what package(s) need attention.
-
-
-### "BLOCKED: Maybe temporary, maybe blocked but Britney is missing information (check below)"
-
-One situation where this can occur is if one of the package's dependencies is
-failing to build, which will be indicated by a line stating "`missing build on
-<arch>`". Once the dependency's build failure is resolved, this package should
-migrate successfully; if it doesn't migrate within a day or so, a re-trigger may
-be needed.
-
-
-### "BLOCKED: Rejected/violates migration policy/introduces a regression"
-
-This indicates an "Autopkgtest Regression" with the given package, and is by far
-the most common situation where your attention will be required. A typical
-result will look something like:
-
-> autopkgtest for [package]/[version]: amd64: <span style="background-color:darkred">Regression</span>, arm64: <span style="background-color:yellow">Not a regression</span>, armhf: <span style="background-color:green">Pass</span>, ppc64el: <span style="background-color:#99DDFF">Test in progress</span>, ...
-
-The 'Regression' items indicate problems needing to be solved. See the
-{ref}`pm-issues-preventing-migration` section for diagnostic tips.
-
-Sometimes you'll see lines where all the tests have passed (or, at least, none
-are marked Regression). Passing packages are usually not shown. When they *are*
-shown, it generally means that the test ran against an outdated version of the
-dependency. For example, you may see:
+Install {command}`visual-excuses` with:
 
 ```none
-* python3-defaults (3.10.1-0ubuntu1 to 3.10.1-0ubuntu2)
-    - Migration status for python3-defaults (3.10.1-0ubuntu1 to 3.10.1-0ubuntu2): BLOCKED: Rejected/violates migration policy/introduces a regression
-    - Issues preventing migration:
-    - ...
-    - autopkgtest for netplan.io/0.104-0ubuntu1: amd64: Pass, arm64: Pass, armhf: Pass, ppc64el: Pass, s390x: Pass.
-    - ...
+$ sudo snap install visual-excuses
 ```
+:::
 
-In this case, check `rmadison`:
+To check whether someone is already working on an item, ask in the [Ubuntu Devel Matrix channel](https://matrix.to/#/#devel:ubuntu.com). For any case that requires more effort or a deeper analysis, submit an {ref}`update-excuses bug <bug-reports-for-migration-problems>` to help with coordination.
 
-```none
-$ rmad netplan.io
-netplan.io | 0.103-0ubuntu7   | impish
-netplan.io | 0.104-0ubuntu2   | jammy
 
-netplan.io | 0.103-3       | unstable
-```
+(bug-reports-for-migration-problems)=
+#### Bug reports for migration problems
 
-We can see our test ran against version `0.104-0ubuntu1`, but a newer version
-(`0.104-0ubuntu2`) is in the archive. If we look at the autopkgtest summary page
-for one of the architectures, we see:
+When you file a bug report about a build or test failure shown on the {ref}`update-excuses-page`, tag the bug report `update-excuse`. {term}`Britney` then includes a link to the bug report the next time it refreshes the {ref}`update-excuses-page` page. This helps other developers see the investigative work you've already done and can be used to identify the next action. Mark yourself as the *Assignee* if you're actively working on the issue, and leave the bug unsubscribed if you aren't, so that others can carry things forward.
 
-```none
-## https://autopkgtest.ubuntu.com/packages/n/netplan.io/jammy/amd64
-0.104-0ubuntu2    netplan.io/0.104-0ubuntu2   2022-03-10 11:38:36 UTC     1h 01m 59s  -   pass    log   artifacts
-...
-0.104-0ubuntu1    python3-defaults/3.10.1-0ubuntu2    2022-03-08 04:26:47 UTC     0h 44m 47s  -   pass    log   artifacts  
-...
-```
 
-Notice that version `0.104-0ubuntu1` was triggered against the `python3`-defaults
-version currently in `-proposed`, but version `0.104-0ubuntu2` was only run
-against `netplan.io` itself, and thus ran against the old `python3`-defaults. We
-need to have a test run against both these new versions (and against any other
-of `netplan.io`'s dependencies also in `-proposed`.)
 
-The ['excuses-kicker' tool](https://code.launchpad.net/~bryce/+git/excuses-kicker)
-is a convenient way to generate the re-trigger URLs:
 
-```none
-$ excuses-kicker netplan.io
-https://autopkgtest.ubuntu.com/request.cgi?release=jammy&arch=amd64&package=netplan.io&trigger=netplan.io%2F0.104-0ubuntu2&trigger=symfony%2F5.4.4%2Bdfsg-1ubuntu7&trigger=pandas%2F1.3.5%2Bdfsg-3&trigger=babl%2F1%3A0.1.90-1&trigger=python3-defaults%2F3.10.1-0ubuntu2&trigger=php-nesbot-carbon%2F2.55.2-1
-...
-```
+## Further reading
 
-Notice how it's picked up not only `python3`-defaults but also several additional
-packages that `netplan.io` has been run against in the recent past. These aren't
-necessarily direct dependencies for `netplan.io`, but serve as an informed guess.
-
-
-(pm-issues-preventing-migration)=
-## Issues preventing migration
-
-Packages can fail to migrate for a vast number of different reasons. Sometimes
-the clues listed under the 'Issues preventing migration:" line item on the
-'update_excuses' page will be enough to indicate the next action needed; that
-will be the focus of this section. In other cases, the autopkgtest log file will
-need to be analyzed; that is covered in a later section.
-
-
-(pm-main-universe-binary-mismatch)=
-### A `main`/`universe` binary mismatch
-
-A given source package may have some binaries in `main` and others in `universe`,
-but this can get mixed up for various reasons. This genre of issues, known as
-["component mismatches"](https://ubuntu-archive-team.ubuntu.com/component-mismatches.txt)
-is spotted from migration excuses like:
-
-```none
-"php8.1-dba/amd64 in main cannot depend on libqdbm14 in universe"
-```
-
-Check the prior release to see if `php8.1-dba` and `libqdbm14` were both in
-`main`, or both in `universe`. If both were in `universe` before, then most likely the
-package in `main` needs to be demoted to `universe`. Ask an Archive Admin to do
-this, and/or file a bug report (for an example, see
-[LP: #1962491](https://bugs.launchpad.net/ubuntu/+source/php8.1/+bug/1962491)).
-
-Conversely, if the dependency in `universe` actually needs to be in `main`, for
-example a newly introduced binary package, then a 'Main Inclusion Request' (MIR)
-bug report will need to be filed. See {ref}`main-inclusion-review` for details
-on this procedure.
-
-If both packages were previously in `main`, then some additional investigation
-should be done to see why the `universe` package was moved out of `main`. The
-resolution may be to move one or the other package so they're both in the same
-pocket, or find a way to remove the dependency between them.
-
-One very special case of these is unintended dependencies due to extra-includes.
-Be aware that while most dependencies seem obvious (seeds --> packages -->
-packages) there is an aspect of
-[germinate](https://ubuntu-archive-team.ubuntu.com/germinate-output/ubuntu.jammy/all)
-which will
-[automatically include](https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/ubuntu/tree/supported#n124)
-all `-dbg`, `-dev`, `-doc*` packages in a source archive that is in main. In
-germinate these will appear as `Rescued from <src>`. If a merge is affected,
-the solution without adding delta usually is to add an `Extra-exclude` like in
-this [example with `net-snmp`](https://code.launchpad.net/~sergiodj/ubuntu-seeds/+git/ubuntu/+merge/414063).
-
-For more information on component mismatches, from an Archive Administration
-perspective, see {ref}`aa-package-overrides`.
-
-
-(pm-impossible-depends)=
-### Impossible depends
-
-An excuse like this:
-
-```none
-"Impossible Depends: aaa -> bbb/x/<arch>"
-```
-
-means package `aaa` has a dependency on package `bbb`, version `x`, for
-architecture `<arch>`, but it is not possible to satisfy this.
-
-One reason this can occur is if the package `bbb` is in `universe` whereas `aaa`
-is in `main`. It may be that some of package `aaa`'s binaries need to be moved
-to `universe`. See {ref}`pm-main-universe-binary-mismatch` for directions.
-
-
-(pm-migrating-makes-something-uninstallable)=
-### Migrating makes something uninstallable
-
-A migration excuse in this format:
-
-```none
-"migrating [aaa]/[aaa-new-version]/[arch] to testing makes [bbb]/[bbb-version]/[arch] uninstallable"
-```
-
-means that package `bbb` has a versioned build dependency against the old
-version of package `aaa`. A no-change rebuild can be used in these cases to
-force a rebuild.
-
-
-### Depends: `aaa [bbb]` (not considered)
-
-Package `aaa` is blocked because it depends on `bbb`, however `bbb` is either
-invalid or rejected.
-
-If the dependency itself is not valid, this line will be followed by an
-'Invalidated by dependency' line. In this case, look at the situation with
-package `bbb` and resolve that first, in order to move package `aaa` forward.
-
-If there is no 'Invalidated by dependency' line, then the dependency may be
-rejected. There are three reasons why a rejection can occur:
-
-1. it needs approval, 
-2. cannot determine if permanent, or
-3. permanent rejection.
-
-
-### Implicit dependency: `aaa [bbb]`
-
-An implicit dependency is a pseudo dependency where Breaks/Conflicts creates an
-inverted dependency. For example, `pkg-b` Depends on `pkg-a`, but `pkg-a=2.0-1`
-breaks `pkg-b=1.0-1`, so `pkg-b=2.0-1` must migrate first (or they must migrate
-together). A way to handle this is to re-run `pkg-b`'s autopkgtest (for 2.0-1)
-and include a trigger for `pkg-a=2.0`. For example, run:
-
-```bash
-$ excuses-kicker -t pkg-a pkg-b
-```
-
-This can also occur if `pkg-b` has "Depends: pkg-a (<< 2.0)", due to the use of
-some non-stable internal interface.
-
-It can also occur if `pkg-a` has a Provides that changes from 1.0-1 to 2.0-1,
-but `pkg-b` has a Depends on the earlier version.
-
-
-### Implicit dependency: `aaa [bbb]` (not considered)
-
-Similar to above, `aaa` and `bbb` are intertwined, but `bbb` is also either
-invalid or rejected. For these cases, attention should first be paid to
-resolving the issue(s) for `bbb`, and then re-running the autopkgtest for it
-with a trigger included against package `aaa`.
-
-
-### Has no binaries on arch `<arch>`
-
-Usually this means the package has either failed to build or failed to upload
-the binaries for a build. Refer to the
-{ref}`failed to build from source <pm-failure-to-build-from-source>` section for
-tips on how to handle this class of problem.
-
-
-### Has no binaries on any arch (`- to x.y.z`)
-
-If the package doesn't have a current version, this error can indicate the
-package is not (yet) in the Archive, or it can mean its binaries were removed
-previously but not sync-blocklisted and thus reappeared.
-
-If the package should not be synced into the Archive, on `#ubuntu-release` ping
-`ubuntu-archive` with a request to remove the packages' binaries and add them to
-[sync-blocklist.txt](https://ubuntu-archive-team.ubuntu.com/sync-blocklist.txt).
-
-Otherwise, there are several things worth checking. Note that these links are
-for Jammy; modify them for the current development release:
-
-- [Stuck in New queue](https://launchpad.net/ubuntu/jammy/+queue?queue_state=0)
-- [Stuck in Unapproved queue](https://launchpad.net/ubuntu/jammy/+queue?queue_state=1)
-
-
-### No reason - still stuck?
-
-If the package, as shown in
-[excuses](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_excuses.html),
-looks good but is not migrating, it might mean an installability conflict.
-So, do not be confused by the status "Will attempt migration (Any information
-below is purely informational)" - there are more checks happening afterwards.
-This is checked and reported in
-[update output.txt](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_output.txt)
-
-Here is an example of `exim4` meeting this situation:
-
-```none
-trying: exim4
-skipped: exim4 (4, 0, 137)
-    got: 11+0: a-0:a-0:a-0:i-2:p-1:r-7:s-1
-    * riscv64: sa-exim
-```
-
-That output is hard to read
-([as explained here](https://wiki.ubuntu.com/ProposedMigration#The_update_output.txt_file_is_completely_unreadable.21)),
-but in this example it means that a few packages on those architectures became
-uninstallable.
-
-You can usually reproduce that in a `-proposed`-enabled container and in this
-example we see:
-
-```none
-root@k:~# apt install exim4 sa-exim
-...
-The following packages have unmet dependencies:
- sa-exim : Depends: exim4-localscanapi-4.1
-```
-
-Now we know that, let us compare the old and new `exim4`, which has:
-
-```none
-root@k:~# apt-cache show exim4-daemon-light | grep -e scanapi -e '^Versi'
-Version: 4.96-3ubuntu1
-Provides: exim4-localscanapi-6.0, mail-transport-agent
-Version: 4.95-4ubuntu3
-Provides: exim4-localscanapi-4.1, mail-transport-agent
-```
-
-So our example needs (as is most often the solution in these cases) a no-change
-rebuild to pick up the new dependency. After a test build to be sure it works,
-you can often upload and resolve this situation.
-
-
-(pm-autopkgtest-log-files)=
-## Autopkgtest log files
-
-You can view the recent test run history for a package's architecture by
-clicking on the respective architecture's name.
-
-Tests can fail for many reasons.
-
-Flaky tests, hardware instabilities, and intermittent network issues can cause
-false positive failures. Re-triggering the test run (via the '♻' symbol) is
-typically all that's needed to resolve these. Before doing this, it is
-worthwhile to check the recent test run history to see if someone else has
-already tried doing that.
-
-When examining a failed autopkgtest's log, start from the end of the file,
-which will usually either show a summary of the test runs, or an error message
-if a fault was hit. For example:
-
-```none
-done.
-done.
-(Reading database ... 50576 files and directories currently installed.)
-Removing autopkgtest-satdep (0) ...
-autopkgtest [21:40:55]: test command1: true
-autopkgtest [21:40:55]: test command1: [-----------------------
-autopkgtest [21:40:58]: test command1: -----------------------]
-command1             PASS
-autopkgtest [21:41:03]: test command1:  - - - - - - - - - - results - - - - - - - - - -
-autopkgtest [21:41:09]: @@@@@@@@@@@@@@@@@@@@ summary
-master-cron-systemd  FAIL non-zero exit status 1
-master-cgi-systemd   PASS
-node-systemd         PASS
-command1             PASS
-```
-
-Here we see that the test named `master-cron-systemd` has failed. To see why it
-failed, do a search on the page for `master-cron-systemd`, and iterate until
-you get to the last line of the test run, then scroll up to find the failed test
-cases:
-
-```none
-autopkgtest [21:23:39]: test master-cron-systemd: preparing testbed
-...
-...
-autopkgtest [21:25:10]: test master-cron-systemd: [-----------------------
-...
-...
-not ok 3 - munin-html: no files in /var/cache/munin/www/ before first run
-#
-#	  find /var/cache/munin/www/ -mindepth 1 >unwanted_existing_files
-#	  test_must_be_empty unwanted_existing_files
-#
-...
-...
-autopkgtest [21:25:41]: test master-cron-systemd: -----------------------]
-master-cron-systemd  FAIL non-zero exit status 1
-autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - results - - - - - - - - - -
-autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - stderr - - - - - - - - - -
-rm: cannot remove '/var/cache/munin/www/localdomain/localhost.localdomain': Directory not empty
-```
-
-All autopkgtests follow this general format, although the output from the tests
-themselves varies widely.
-
-Beyond "regular" test case failures like this one, autopkgtest failures can also
-occur due to missing or incorrect dependencies, test framework timeouts, and
-other issues. Each of these is discussed in more detail below.
-
-
-### Flaky or actually regressed in release
-
-Tests might break due to the changes we applied -- catching those is the reason
-the tests exist in the first place. But sometimes the tests do fail but are not
-flaky. In that case, it is often another unrelated change to the test
-environment that made it suddenly break permanently.
-
-If you have checked the recent test run history as suggested above and have
-retried the tests often enough that it seems unreasonable to continue retrying,
-then you might want to tell the autopkgtest infrastructure that it shouldn't
-expect this test to pass.
-
-This can now be done via a migration-reference run. To do that, open the same
-URL you'd normally use to re-run the test, but instead of `package` + `version`
-as the trigger, you would add `migration-reference/0`. This is a special key,
-which will re-run the tests with the version of the requested package in the
-target release, without any proposed packages.
-
-For example:
-
-```none
-https://autopkgtest.ubuntu.com/request.cgi?release=RELEASE&arch=ARCH&package=SRCPKG&trigger=migration-reference/0
-```
-
-If this fails too, it will update the expectations so that if other packages are
-trying to migrate they will not be required to pass.
-
-If this does not fail, then your assumption that your upload/change wasn't
-related to the failure is most likely wrong.
-
-More details about that can be found in the
-[How to run autopkgtests of a package against the version in the release pocket](https://wiki.ubuntu.com/ProposedMigration#How_to_run_autopkgtests_of_a_package_against_the_version_in_the_release_pocket).
-
-
-(pm-special-cases)=
-## Special cases
-
-
-### Circular build dependencies
-
-When two or more packages have new versions that depend on each other's new
-versions in order to build, this can lead to a
-[circular build dependency](https://wiki.debian.org/CircularBuildDependencies).
-There are a few different ways these come into being, which have unique
-characteristics that can help find a way to work through them.
-
-
-#### 1. Build-dependencies for test suites
-
-If package A's build process invokes a test suite as part of the build (i.e. in
-`debian/rules` under `override_dh_auto_test`), and the test suite requires
-package B, then if package B requires package A to build, this creates a
-situation where neither package will successfully build.
-
-The workaround in this case is to (temporarily) disable running the test suite
-during a build. This is usually OK when the package's autopkgtests (defined in
-`debian/tests/control`) also run the test suite. For instance:
-
-```none
-override_dh_auto_test:
-    echo "Disabled: phpunit --bootstrap vendor/autoload.php"
-```
-
-You may also need to delete test dependencies from `debian/control`, and/or move
-them to `debian/tests/control`.
-
-With package A's test suite thus disabled during build, it will build
-successfully but then fail its autopkgtest run. Next, from package B's Launchpad
-page, request rebuilds for each binary in a failed state. Once package B has
-successfully built on all supported architectures, package A's autopkgtests can
-be re-run using package B as a trigger.
-
-Once everything's migrated successfully, a clean-up step would be to re-enable
-package A's test suite and verify that it now passes.
-
-
-#### 2. Bootstrapping
-
-In this situation, packages A-1.0 and B-1.0 are in the archive. We're
-introducing new versions A-3.0 and B-3.0 (skipping 2.0); A-3.0 depends on B-3.0,
-and B-3.0 requires A-2.0 or newer. Both A-3.0 and B-3.0 will fail to build.
-
-One example of where this can occur is if code common to both A and B is
-refactored out to a new binary package that is provided in A starting at
-version 2.0.
-
-The most straightforward solution to this situation is to ask an Archive Admin
-to delete both A-3.0 and B-3.0 from the Archive, then upload version A-2.0 and
-allow it to build (and ideally migrate). Next reintroduce B-3.0, and then once
-that's built, do the same for A-3.0.
-
-With even larger version jumps, e.g. from A-1.0 to A-5.0, it may be necessary to
-do multiple bootstraps, along with some experimentation to see which
-intermediate version(s) need to be jumped to. Another common complication can be
-where the cycle involves more than two packages.
-
-
-### Test dependency irregularities
-
-The package's `debian/tests/control` file
-[defines what gets installed](https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst)
-in the test environment before executing the tests. You can review and verify
-the packages and versions in the DEP-8 test log, between the lines
-"`autopkgtest...: test integration: preparing testbed`" and
-"`Removing autopkgtest-satdep`".
-
-A common issue is that the test should be run against a version of a dependency
-present in the `-proposed` pocket, however it failed due to running against the
-version in `-release`. Often this is straightforward to prove by running the
-autopkgtests locally in a container.
-
-Another easy way to test this is to re-run the test but set it to preferentially
-pull packages from `-proposed` -- this is done by appending `&all-proposed=1` to
-the test URL. If that passes, but the package still does not migrate, then look
-in the test log for all packages that were pulled from `-proposed` and include
-those as triggers.
-[Excuses Kicker](https://git.launchpad.net/~bryce/+git/excuses-kicker) and
-[retry-autopkgtest-regressions](https://git.launchpad.net/ubuntu-archive-tools/tree/retry-autopkgtest-regressions)
-are handy tools for generating these URLs.
-
-As with rebuilds, these re-triggers also require Core Dev permissions, so if
-you're not yet a Core Dev give the links to someone who is for assistance.
-
-
-### Test framework timeouts and out of memory
-
-The autopkgtest framework will kill tests that take too long to run. In some
-cases it makes sense to just configure autopkgtest to let the test run longer.
-This is done by setting the `long_tests` option. Similarly, some tests may need
-more CPU or memory than in a standard worker. The `big_packages` option directs
-autopkgtest to run these on workers with more CPU and memory. Both these options
-are explained on the
-[Proposed Migration wiki](https://wiki.ubuntu.com/ProposedMigration#autopkgtests)
-page.
-
-It is worthwhile to mention that Debian test sizing is currently (as of 2021)
-equivalent to our `big_packages`.
-
-The configuration that associates source packages to either `big_packages` /
-`long_tests` and the actual deployment code was recently split.
-[The new docs](https://autopkgtest-cloud.readthedocs.io/en/latest/administration.html#give-a-package-more-time-or-more-resources)
-explain this and
-[link to a repository](https://code.launchpad.net/~ubuntu-release/autopkgtest-cloud/+git/autopkgtest-package-configs)
-which can now be merged by any Release Team member.
-
-
-### Disabling / skipping tests
-
-While (ideally) failing tests should receive fixes to enable them to pass
-properly, sometimes this is not feasible or possible. In such extreme situations
-it may be necessary to explicitly disable a test case or an entire test suite.
-For instance, if an unimportant package's test failure blocks a more important
-package from transitioning.
-
-As a general rule, try to be as surgical as possible and avoid disabling more
-than is absolutely required. For example, if a test has 10 sub-cases and only
-one sub-case fails, prefer to comment out or delete that sub-case rather than
-the entire test.
-
-There is no single method to disabling tests, unfortunately, since different
-programming languages take different design approaches for their test harnesses.
-Some test harnesses have provisions for marking tests "SKIP". In other
-situations it may be cleaner to add a Debian patch that simply deletes the
-test's code from the codebase. Sometimes it works best to insert an early return
-with a fake PASS in the particular code path that broke.
-
-Take care, when disabling a test, to include a detailed enough explanation as to
-why you're disabling it, which will inform a future packager when the test can
-be re-enabled. For instance, if a proper fix will be available in a future
-release, say so and indicate which version will have it. Or, if the test is
-being disabled just to get another package to transition, indicate what that
-package's name and expected version are. Bug reports, DEP-3 comments, and
-changelog entries can be good places to document these clues.
-
-
-### Disabling / skipping / customizing tests for certain architectures
-
-If you need to disable the entire test suite for a specific architecture, such as
-an arch that upstream doesn't include in their CI testing, and that sees
-frequent / ample failures on our end, then you can skip the testing via checks
-in the `debian/rules` file. For example (from `util-linux-2.34`):
-
-```none
-override_dh_auto_test:
-ifneq (,$(filter alpha armel armhf arm64,$(DEB_HOST_ARCH)))
-        @echo "WARNING: Making tests non-fatal because of arch $(DEB_HOST_ARCH)"
-        dh_auto_test --max-parallel=1 || true
-else ifeq ($(DEB_HOST_ARCH_OS), linux)
-        dh_auto_test --max-parallel=1
-endif
-```
-
-If the issue is the integer type size, here's a way to filter based on that
-(from `mash-2.2.2+dfsg`):
-
-```none
-override_dh_auto_test:
-ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-ifeq ($(DEB_HOST_ARCH_BITS),32)
-        echo "Do not test for 32 bit archs since test results were calculated for 64 bit."
-else
-        dh_auto_test --no-parallel
-endif
-endif
-```
-
-Or based on the CPU type itself (from `containerd-1.3.3-0ubuntu2.1`):
-
-```none
-override_dh_auto_test:
-ifneq (arm, $(DEB_HOST_ARCH_CPU)) # skip the tests on armhf ("--- FAIL: TestParseSelector/linux (0.00s)  platforms_test.go:292: arm support not fully implemented: not implemented")
-        cd '$(OUR_GOPATH)/src/github.com/containerd/containerd' && make test
-endif
-```
-
-
-### Skipping autopkgtesting entirely
-
-If an autopkgtest is badly written, it may be too challenging to get it to pass.
-In these extreme cases, it's possible to request that test failures be ignored
-for the sake of package migration.
-
-* Check out [`lp:~ubuntu-release/britney/hints-ubuntu`](https://git.launchpad.net/~ubuntu-release/britney/+git/hints-ubuntu)
-
-File an MP against it with a description indicating the Launchpad bug #, the rationale
-for why the test can and should be skipped, and an explanation of what will be
-unblocked in the migration.
-
-Reviewers should be `canonical-<your-team>` (e.g. `canonical-server-reporter`
-for Server team members), `ubuntu-release`, and any Archive Admins or
-Foundations team members you've discussed the issue with.
-
-
-## Other common issues
-
-Autopkgtest runs tests in a controlled network environment, so if a test case
-expects to download material from the internet, it will likely fail. If the test
-case is attempting to download a dependency (e.g. via PIP or Maven), sometimes
-this can be worked around by adding the missing dependency to
-`debian/tests/control`. If it is attempting to download an example file, then it
-may be possible to make the test case use a local file, or to load from the
-proxy network.
-
-
-(pm-triggering-tests-from-the-cli)=
-## Triggering tests from the CLI
-
-There will be times when you may need to (re-)trigger several tests at once. In
-such situations, opening the autopkgtest trigger URLs in a browser becomes a
-repetitive, time-consuming mechanical task. We could still use the CLI to feed
-the URLs to a browser, but this would still be error prone and time consuming
-depending on the number of trigger URLs we are dealing with.
-
-Instead of using a browser to trigger our tests, we could perform the HTTP
-requests through the CLI. However, since the autopkgtest requires
-authentication, we need to extract our credentials from a browser.
-
-```{warning}
-
-The steps below are to extract your credentials for the
-autopkgtest infrastructure from the browser. Make sure to secure those
-credentials and not to share them.
-```
-
-The credentials are available in a cookie for `autopkgtest.ubuntu.com`. There are
-two values we want to extract there: the `session` and the `SRVNAME`.
-
-There are different ways to extract those credentials from the browser, here,
-we show how to do it for Firefox using the Firefox Developer Tools menu.
-
-In Firefox, browse to
-[`autopkgtest.ubuntu.com`](https://autopkgtest.ubuntu.com/) and open the
-Developer Tools (by pressing {kbd}`F12` or {kbd}`Ctrl` + {kbd}`Shift` + {kbd}`C`).
-In the {guilabel}`Storage` tab, expand the {guilabel}`Cookies` menu on the left
-panel and look for an `autopkgtest.ubuntu.com` entry. There you should find the
-values for the `session` and `SRVNAME` entries mentioned above.
-
-Save those values in a local file (e.g., `~/.cache/autopkgtest.cookie`) with
-the following contents:
-
-```none
-autopkgtest.ubuntu.com	TRUE	/	TRUE	0	session	YOUR_COOKIE_SESSION_VALUE_HERE
-autopkgtest.ubuntu.com	TRUE	/	TRUE	0	SRVNAME	YOUR_COOKIE_SRVNAME_VALUE_HERE
-```
-
-Make sure the file has proper permissions so other users cannot read it, e.g.,
-`0600`, **it will carry your autopkgtest infrastructure credentials**.
-
-Note that the delimiters used above are tabs (`\t`) and not spaces. You can use
-the following commands to ensure your cookie file has the proper format:
-
-```none
-$ printf "autopkgtest.ubuntu.com\\tTRUE\\t/\\tTRUE\\t0\\tsession\\tYOUR_COOKIE_SESSION_VALUE_HERE\\n" > ~/.cache/autopkgtest.cookie
-$ printf "autopkgtest.ubuntu.com\\tTRUE\\t/\\tTRUE\\t0\\tSRVNAME\\tYOUR_COOKIE_SRVNAME_VALUE_HERE\\n" >> ~/.cache/autopkgtest.cookie
-```
-
-You can now use `curl` to trigger the autopkgtest URLs (e.g., `curl --cookie
-~/.cache/autopkgtest.cookie URL`). If you have a long list of test trigger
-URLs, you can trigger them all with:
-
-```none
-$ cat TEST_URL_LIST | vipe | xargs -rn1 -P10 curl --cookie ~/.cache/autopkgtest.cookie -o /dev/null --silent --head --write-out '%{url_effective} : %{http_code}\\n'
-```
-
+* {ref}`resolve-a-migration-issue`
+* [Visualizing and Exploring Ubuntu Excuses](https://discourse.ubuntu.com/t/visualizing-and-exploring-ubuntu-excuses/59824)

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/autopkgtest-regressions.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/autopkgtest-regressions.md
@@ -1,0 +1,247 @@
+---
+orphan: true
+---
+
+(autopkgtest-regressions)=
+# Autopkgtest regressions
+
+After a package has successfully built, the
+[autopkgtest infrastructure](https://autopkgtest.ubuntu.com/) will run its
+[DEP8 tests](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/1.0/explanation/auto-pkg-test.html)
+for each of its supported architectures. Failed tests can block the migration,
+and "Regression" listed for the failed architecture(s), worded in one of the
+following ways.
+
+:::{admonition} **Proposed migration** series
+The {ref}`proposed-migration` article series explains the various migration failures and ways of investigating them.
+
+Process overview:
+: {ref}`proposed-migration`
+
+Issue types:
+:   * {ref}`issues-preventing-migration`
+    * {ref}`autopkgtest-regressions` (this article)
+    * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`special-migration-cases`
+
+Practical guidance:
+: {ref}`resolve-a-migration-issue`
+:::
+
+
+## Common regression reasons
+
+
+### "Migration status for `aaa (x to y): <reason>`"
+
+This means package `aaa` has a new version `y` uploaded to `-proposed`, to
+replace the existing version `x`, but the change has not yet been permitted.
+The various reasons typically seen are outlined in the items below.
+
+
+### "Waiting for test results, another package or too young (no action required now - check later)"
+
+This means one or more tests still need to be run. These will be noted as 'Test
+in progress' under the 'Issues preventing migration' line item.
+
+
+### "Will attempt migration (Any information below is purely informational)"
+
+This is good -- it indicates the item is currently in process and will likely
+migrate soon (within a day or so).
+
+
+### "Waiting for another item to be ready to migrate (no action required now - check later)"
+
+This can be good if it's recent, but if it's more than a few days old then there
+may be a deeper issue going on with a dependency. If it's recent, just give it
+some time (maybe a day or so). If it's older, refer to the items listed under
+the 'Issues preventing migration:' line to see what specifically has gone wrong,
+and then see the {ref}`issues-preventing-migration` section for diagnostic tips.
+
+
+### "BLOCKED: Cannot migrate due to another item, which is blocked (please check which dependencies are stuck)"
+
+The package itself is likely fine, but it's being blocked by some issue with
+some other package. Check beneath the 'Invalidated by dependency' line to see
+what package(s) need attention.
+
+
+### "BLOCKED: Maybe temporary, maybe blocked but Britney is missing information (check below)"
+
+One situation where this can occur is if one of the package's dependencies is
+failing to build, which will be indicated by a line stating "`missing build on
+<arch>`". Once the dependency's build failure is resolved, this package should
+migrate successfully; if it doesn't migrate within a day or so, a re-trigger may
+be needed.
+
+
+### "BLOCKED: Rejected/violates migration policy/introduces a regression"
+
+This indicates an "Autopkgtest Regression" with the given package, and is by far
+the most common situation where your attention will be required. A typical
+result will look something like:
+
+> autopkgtest for [package]/[version]: amd64: <span style="background-color:darkred">Regression</span>, arm64: <span style="background-color:yellow">Not a regression</span>, armhf: <span style="background-color:green">Pass</span>, ppc64el: <span style="background-color:#99DDFF">Test in progress</span>, ...
+
+The 'Regression' items indicate problems needing to be solved. See the
+{ref}`issues-preventing-migration` section for diagnostic tips.
+
+Sometimes you'll see lines where all the tests have passed (or, at least, none
+are marked Regression). Passing packages are usually not shown. When they *are*
+shown, it generally means that the test ran against an outdated version of the
+dependency. For example, you may see:
+
+```none
+* python3-defaults (3.10.1-0ubuntu1 to 3.10.1-0ubuntu2)
+    - Migration status for python3-defaults (3.10.1-0ubuntu1 to 3.10.1-0ubuntu2): BLOCKED: Rejected/violates migration policy/introduces a regression
+    - Issues preventing migration:
+    - ...
+    - autopkgtest for netplan.io/0.104-0ubuntu1: amd64: Pass, arm64: Pass, armhf: Pass, ppc64el: Pass, s390x: Pass.
+    - ...
+```
+
+In this case, check `rmadison`:
+
+```none
+$ rmad netplan.io
+netplan.io | 0.103-0ubuntu7   | impish
+netplan.io | 0.104-0ubuntu2   | jammy
+
+netplan.io | 0.103-3       | unstable
+```
+
+We can see our test ran against version `0.104-0ubuntu1`, but a newer version
+(`0.104-0ubuntu2`) is in the archive. If we look at the autopkgtest summary page
+for one of the architectures, we see:
+
+```none
+## https://autopkgtest.ubuntu.com/packages/n/netplan.io/jammy/amd64
+0.104-0ubuntu2    netplan.io/0.104-0ubuntu2   2022-03-10 11:38:36 UTC     1h 01m 59s  -   pass    log   artifacts
+...
+0.104-0ubuntu1    python3-defaults/3.10.1-0ubuntu2    2022-03-08 04:26:47 UTC     0h 44m 47s  -   pass    log   artifacts  
+...
+```
+
+Notice that version `0.104-0ubuntu1` was triggered against the `python3`-defaults
+version currently in `-proposed`, but version `0.104-0ubuntu2` was only run
+against `netplan.io` itself, and thus ran against the old `python3`-defaults. We
+need to have a test run against both these new versions (and against any other
+of `netplan.io`'s dependencies also in `-proposed`.)
+
+The ['excuses-kicker' tool](https://code.launchpad.net/~bryce/+git/excuses-kicker)
+is a convenient way to generate the re-trigger URLs:
+
+```none
+$ excuses-kicker netplan.io
+https://autopkgtest.ubuntu.com/request.cgi?release=jammy&arch=amd64&package=netplan.io&trigger=netplan.io%2F0.104-0ubuntu2&trigger=symfony%2F5.4.4%2Bdfsg-1ubuntu7&trigger=pandas%2F1.3.5%2Bdfsg-3&trigger=babl%2F1%3A0.1.90-1&trigger=python3-defaults%2F3.10.1-0ubuntu2&trigger=php-nesbot-carbon%2F2.55.2-1
+...
+```
+
+Notice how it's picked up not only `python3`-defaults but also several additional
+packages that `netplan.io` has been run against in the recent past. These aren't
+necessarily direct dependencies for `netplan.io`, but serve as an informed guess.
+
+
+
+(pm-autopkgtest-log-files)=
+## Autopkgtest log files
+
+You can view the recent test run history for a package's architecture by
+clicking on the respective architecture's name.
+
+Tests can fail for many reasons.
+
+Flaky tests, hardware instabilities, and intermittent network issues can cause
+false positive failures. Re-triggering the test run (via the '♻' symbol) is
+typically all that's needed to resolve these. Before doing this, it is
+worthwhile to check the recent test run history to see if someone else has
+already tried doing that.
+
+When examining a failed autopkgtest's log, start from the end of the file,
+which will usually either show a summary of the test runs, or an error message
+if a fault was hit. For example:
+
+```none
+done.
+done.
+(Reading database ... 50576 files and directories currently installed.)
+Removing autopkgtest-satdep (0) ...
+autopkgtest [21:40:55]: test command1: true
+autopkgtest [21:40:55]: test command1: [-----------------------
+autopkgtest [21:40:58]: test command1: -----------------------]
+command1             PASS
+autopkgtest [21:41:03]: test command1:  - - - - - - - - - - results - - - - - - - - - -
+autopkgtest [21:41:09]: @@@@@@@@@@@@@@@@@@@@ summary
+master-cron-systemd  FAIL non-zero exit status 1
+master-cgi-systemd   PASS
+node-systemd         PASS
+command1             PASS
+```
+
+Here we see that the test named `master-cron-systemd` has failed. To see why it
+failed, do a search on the page for `master-cron-systemd`, and iterate until
+you get to the last line of the test run, then scroll up to find the failed test
+cases:
+
+```none
+autopkgtest [21:23:39]: test master-cron-systemd: preparing testbed
+...
+...
+autopkgtest [21:25:10]: test master-cron-systemd: [-----------------------
+...
+...
+not ok 3 - munin-html: no files in /var/cache/munin/www/ before first run
+#
+#	  find /var/cache/munin/www/ -mindepth 1 >unwanted_existing_files
+#	  test_must_be_empty unwanted_existing_files
+#
+...
+...
+autopkgtest [21:25:41]: test master-cron-systemd: -----------------------]
+master-cron-systemd  FAIL non-zero exit status 1
+autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - results - - - - - - - - - -
+autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - stderr - - - - - - - - - -
+rm: cannot remove '/var/cache/munin/www/localdomain/localhost.localdomain': Directory not empty
+```
+
+All autopkgtests follow this general format, although the output from the tests
+themselves varies widely.
+
+Beyond "regular" test case failures like this one, autopkgtest failures can also
+occur due to missing or incorrect dependencies, test framework timeouts, and
+other issues. Each of these is discussed in more detail below.
+
+
+### Flaky or actually regressed in release
+
+Tests might break due to the changes we applied -- catching those is the reason
+the tests exist in the first place. But sometimes the tests do fail but are not
+flaky. In that case, it is often another unrelated change to the test
+environment that made it suddenly break permanently.
+
+If you have checked the recent test run history as suggested above and have
+retried the tests often enough that it seems unreasonable to continue retrying,
+then you might want to tell the autopkgtest infrastructure that it shouldn't
+expect this test to pass.
+
+This can now be done via a migration-reference run. To do that, open the same
+URL you'd normally use to re-run the test, but instead of `package` + `version`
+as the trigger, you would add `migration-reference/0`. This is a special key,
+which will re-run the tests with the version of the requested package in the
+target release, without any proposed packages.
+
+For example:
+
+```none
+https://autopkgtest.ubuntu.com/request.cgi?release=RELEASE&arch=ARCH&package=SRCPKG&trigger=migration-reference/0
+```
+
+If this fails too, it will update the expectations so that if other packages are
+trying to migrate they will not be required to pass.
+
+If this does not fail, then your assumption that your upload/change wasn't
+related to the failure is most likely wrong.
+
+More details about that can be found in the
+[How to run autopkgtests of a package against the version in the release pocket](https://wiki.ubuntu.com/ProposedMigration#How_to_run_autopkgtests_of_a_package_against_the_version_in_the_release_pocket).

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/autopkgtest-regressions.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/autopkgtest-regressions.md
@@ -5,12 +5,9 @@ orphan: true
 (autopkgtest-regressions)=
 # Autopkgtest regressions
 
-After a package has successfully built, the
-[autopkgtest infrastructure](https://autopkgtest.ubuntu.com/) will run its
-[DEP8 tests](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/1.0/explanation/auto-pkg-test.html)
-for each of its supported architectures. Failed tests can block the migration,
-and "Regression" listed for the failed architecture(s), worded in one of the
-following ways.
+After a package has successfully built, the {term}`autopkgtest` infrastructure at [autopkgtest.ubuntu.com](https://autopkgtest.ubuntu.com/) runs its {term}`DEP-8` for each of its supported architectures. Failed tests can block the migration and result in a **Regression** listed for the failed architecture(s). The failed migrations, along with the reasons, are listed on the {term}`update excuses` page.
+
+This article explains common regression reasons.
 
 :::{admonition} **Proposed migration** series
 The {ref}`proposed-migration` article series explains the various migration failures and ways of investigating them.
@@ -18,230 +15,120 @@ The {ref}`proposed-migration` article series explains the various migration fail
 Process overview:
 : {ref}`proposed-migration`
 
-Issue types:
-:   * {ref}`issues-preventing-migration`
-    * {ref}`autopkgtest-regressions` (this article)
-    * {ref}`failure-to-build-from-source-ftbfs`
-    * {ref}`special-migration-cases`
-
 Practical guidance:
 : {ref}`resolve-a-migration-issue`
+
+Issue types:
+:   * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`autopkgtest-regressions` (this article)
+    * {ref}`issues-preventing-migration`
+    * {ref}`special-migration-cases`
+:::
+
+## Migration status
+
+Each package listed on the {term}`update excuses` page reports its **Migration status**. The line is in this format:
+
+**Migration status for &lt;package&gt; (&lt;version-x&gt; to &lt;version-y&gt;): &lt;reason&gt;**
+
+This means: package &lt;package&gt; has a new version &lt;version-y&gt; uploaded to the `-proposed` {term}`pocket`, which should replace the existing version &lt;version-x&gt;. But the change has not yet been permitted. The various reasons typically seen are outlined in the items below.
+
+BLOCKED: Rejected/violates migration policy/introduces a regression
+
+: This indicates an {command}`autopkgtest` **Regression** with the given package. It is by far the most common situation that requires attention. A typical result looks like this:
+
+   :::{card}
+   autopkgtest for &lt;package&gt;/&lt;version&gt;: amd64: <span style="color:#0000EE; text-decoration:underline;  background-color:#FF6565">Regression</span> ♻,  arm64: <span style="color:#0000EE; text-decoration:underline; background-color:#E5C445">Not a regression</span>, armhf: <span style="color:#0000EE; text-decoration:underline; background-color:#86D86B">Pass</span>, ppc64el: <span style="color:#0000EE; text-decoration:underline; background-color:#98DCFE">Test in progress</span>, ...
+   :::
+
+   The **Regression** items indicate problems needing to be solved. See the {ref}`issues-preventing-migration` section for diagnostic tips.
+
+Waiting for test results, another package or too young (no action required now - check later)
+
+: This means one or more tests still need to run. These are noted as **Test in progress** under the **Issues preventing migration:** line.
+
+Will attempt migration (Any information below is purely informational)
+
+: This is good -- it indicates the item is currently in process and is likely to migrate soon (within a day or so).
+
+Waiting for another item to be ready to migrate (no action required now - check later)
+
+: This is usually good if it's recent, but if it's more than a few days old, then there may be a deeper issue with a dependency. For items that are:
+
+   * Recent: wait (a day or so)
+   * Few days old: refer to the items listed under the **Issues preventing migration:** line to see what specifically has gone wrong, and then see the {ref}`issues-preventing-migration` article for diagnostic tips.
+
+BLOCKED: Cannot migrate due to another item, which is blocked (please check which dependencies are stuck)
+
+: The package itself is probably fine, but it's blocked by an issue with some other package. Check beneath the **Invalidated by dependency** line to see what package(s) need attention.
+
+BLOCKED: Maybe temporary, maybe blocked but Britney is missing information (check below)
+
+: This often occurs when one of the package's dependencies is failing to build, which is indicated by a line stating **missing build on &lt;arch&gt;**. Once the dependency's build failure is resolved, this package should migrate successfully. If it doesn't migrate within a day or so, re-trigger the test.
+
+:::{tip}
+In case of unreliable tests, hardware instabilities, and intermittent network issues, re-triggering a test run (by clicking the ♻ symbol) is often the only thing needed to achieve a **Pass** result. Before doing so, check the recent test-run history to see if someone else has already tried doing that. To view the recent test-run history for a specific architecture, click the respective name of the architecture.
 :::
 
 
-## Common regression reasons
+### All tests passing
 
+Passing packages are usually not shown. When no test is marked **Regression**, it generally means that the test ran against an outdated version of the dependency. For example, you may see:
 
-### "Migration status for `aaa (x to y): <reason>`"
-
-This means package `aaa` has a new version `y` uploaded to `-proposed`, to
-replace the existing version `x`, but the change has not yet been permitted.
-The various reasons typically seen are outlined in the items below.
-
-
-### "Waiting for test results, another package or too young (no action required now - check later)"
-
-This means one or more tests still need to be run. These will be noted as 'Test
-in progress' under the 'Issues preventing migration' line item.
-
-
-### "Will attempt migration (Any information below is purely informational)"
-
-This is good -- it indicates the item is currently in process and will likely
-migrate soon (within a day or so).
-
-
-### "Waiting for another item to be ready to migrate (no action required now - check later)"
-
-This can be good if it's recent, but if it's more than a few days old then there
-may be a deeper issue going on with a dependency. If it's recent, just give it
-some time (maybe a day or so). If it's older, refer to the items listed under
-the 'Issues preventing migration:' line to see what specifically has gone wrong,
-and then see the {ref}`issues-preventing-migration` section for diagnostic tips.
-
-
-### "BLOCKED: Cannot migrate due to another item, which is blocked (please check which dependencies are stuck)"
-
-The package itself is likely fine, but it's being blocked by some issue with
-some other package. Check beneath the 'Invalidated by dependency' line to see
-what package(s) need attention.
-
-
-### "BLOCKED: Maybe temporary, maybe blocked but Britney is missing information (check below)"
-
-One situation where this can occur is if one of the package's dependencies is
-failing to build, which will be indicated by a line stating "`missing build on
-<arch>`". Once the dependency's build failure is resolved, this package should
-migrate successfully; if it doesn't migrate within a day or so, a re-trigger may
-be needed.
-
-
-### "BLOCKED: Rejected/violates migration policy/introduces a regression"
-
-This indicates an "Autopkgtest Regression" with the given package, and is by far
-the most common situation where your attention will be required. A typical
-result will look something like:
-
-> autopkgtest for [package]/[version]: amd64: <span style="background-color:darkred">Regression</span>, arm64: <span style="background-color:yellow">Not a regression</span>, armhf: <span style="background-color:green">Pass</span>, ppc64el: <span style="background-color:#99DDFF">Test in progress</span>, ...
-
-The 'Regression' items indicate problems needing to be solved. See the
-{ref}`issues-preventing-migration` section for diagnostic tips.
-
-Sometimes you'll see lines where all the tests have passed (or, at least, none
-are marked Regression). Passing packages are usually not shown. When they *are*
-shown, it generally means that the test ran against an outdated version of the
-dependency. For example, you may see:
-
-```none
+:::{card}
+Example: All tests passing
+^^^
 * python3-defaults (3.10.1-0ubuntu1 to 3.10.1-0ubuntu2)
     - Migration status for python3-defaults (3.10.1-0ubuntu1 to 3.10.1-0ubuntu2): BLOCKED: Rejected/violates migration policy/introduces a regression
     - Issues preventing migration:
     - ...
-    - autopkgtest for netplan.io/0.104-0ubuntu1: amd64: Pass, arm64: Pass, armhf: Pass, ppc64el: Pass, s390x: Pass.
+    - autopkgtest for netplan\.io/1.1.2-2ubuntu1: amd64: <span style="color:#0000EE; text-decoration:underline; background-color:#86D86B">Pass</span>, arm64: <span style="color:#0000EE; text-decoration:underline; background-color:#86D86B">Pass</span>, armhf: <span style="color:#0000EE; text-decoration:underline; background-color:#86D86B">Pass</span>, ppc64el: <span style="color:#0000EE; text-decoration:underline; background-color:#86D86B">Pass</span>, s390x: <span style="color:#0000EE; text-decoration:underline; background-color:#86D86B">Pass</span>.
     - ...
-```
+:::
 
-In this case, check `rmadison`:
-
-```none
-$ rmad netplan.io
-netplan.io | 0.103-0ubuntu7   | impish
-netplan.io | 0.104-0ubuntu2   | jammy
-
-netplan.io | 0.103-3       | unstable
-```
-
-We can see our test ran against version `0.104-0ubuntu1`, but a newer version
-(`0.104-0ubuntu2`) is in the archive. If we look at the autopkgtest summary page
-for one of the architectures, we see:
+In this case, use the {command}`rmadison` tool to check versions of the package in the Ubuntu Archive:
 
 ```none
-## https://autopkgtest.ubuntu.com/packages/n/netplan.io/jammy/amd64
-0.104-0ubuntu2    netplan.io/0.104-0ubuntu2   2022-03-10 11:38:36 UTC     1h 01m 59s  -   pass    log   artifacts
-...
-0.104-0ubuntu1    python3-defaults/3.10.1-0ubuntu2    2022-03-08 04:26:47 UTC     0h 44m 47s  -   pass    log   artifacts  
-...
+$ rmadison netplan.io
+ netplan.io | 1.1.2-2ubuntu1    | plucky          | source, amd64, arm64, ...
+ netplan.io | 1.1.2-2ubuntu1.1  | plucky-updates  | source, amd64, arm64, ...
+ netplan.io | 1.1.2-7ubuntu2    | questing        | source, amd64, arm64, ...
 ```
 
-Notice that version `0.104-0ubuntu1` was triggered against the `python3`-defaults
-version currently in `-proposed`, but version `0.104-0ubuntu2` was only run
-against `netplan.io` itself, and thus ran against the old `python3`-defaults. We
-need to have a test run against both these new versions (and against any other
-of `netplan.io`'s dependencies also in `-proposed`.)
+Note the test ran against version `1.1.2-2ubuntu1`, but a newer version (`1.1.2-7ubuntu2`) is in the Archive. Look at the [autopkgtest summary page](https://autopkgtest.ubuntu.com/packages/n/netplan.io/jammy/amd64) for one of the architectures:
 
-The ['excuses-kicker' tool](https://code.launchpad.net/~bryce/+git/excuses-kicker)
-is a convenient way to generate the re-trigger URLs:
+:::{list-table} [`https://autopkgtest.ubuntu.com/packages/n/netplan.io/jammy/amd64`](https://autopkgtest.ubuntu.com/packages/n/netplan.io/jammy/amd64)
 
-```none
-$ excuses-kicker netplan.io
-https://autopkgtest.ubuntu.com/request.cgi?release=jammy&arch=amd64&package=netplan.io&trigger=netplan.io%2F0.104-0ubuntu2&trigger=symfony%2F5.4.4%2Bdfsg-1ubuntu7&trigger=pandas%2F1.3.5%2Bdfsg-3&trigger=babl%2F1%3A0.1.90-1&trigger=python3-defaults%2F3.10.1-0ubuntu2&trigger=php-nesbot-carbon%2F2.55.2-1
-...
-```
+*   - 0.104-0ubuntu2
+    - netplan\.io/0.104-0ubuntu2
+    - 2022-03-10<br>11:38:36<br>UTC
+    - 1h 01m<br>59s
+    - \-
+    - ✔ pass
+    - log
+    - artifacts
+*   - _[...]_
+    -
+    -
+    -
+    -
+    -
+    -
+    -
+*   - 0.104-0ubuntu1
+    - python3-defaults/3.10.1-0ubuntu2
+    - 2022-03-08<br>04:26:47<br>UTC
+    - 0h 44m<br>47s
+    - \-
+    - ✔ pass
+    - log
+    - artifacts
+:::
 
-Notice how it's picked up not only `python3`-defaults but also several additional
-packages that `netplan.io` has been run against in the recent past. These aren't
-necessarily direct dependencies for `netplan.io`, but serve as an informed guess.
+Notice:
 
+* Version `0.104-0ubuntu1` was triggered against the `python3-defaults` version currently in `-proposed` (`3.10.1-0ubuntu2`).
 
+* But version `0.104-0ubuntu2` only ran against `netplan.io` itself, and thus ran against the old `python3-defaults`.
 
-(pm-autopkgtest-log-files)=
-## Autopkgtest log files
-
-You can view the recent test run history for a package's architecture by
-clicking on the respective architecture's name.
-
-Tests can fail for many reasons.
-
-Flaky tests, hardware instabilities, and intermittent network issues can cause
-false positive failures. Re-triggering the test run (via the '♻' symbol) is
-typically all that's needed to resolve these. Before doing this, it is
-worthwhile to check the recent test run history to see if someone else has
-already tried doing that.
-
-When examining a failed autopkgtest's log, start from the end of the file,
-which will usually either show a summary of the test runs, or an error message
-if a fault was hit. For example:
-
-```none
-done.
-done.
-(Reading database ... 50576 files and directories currently installed.)
-Removing autopkgtest-satdep (0) ...
-autopkgtest [21:40:55]: test command1: true
-autopkgtest [21:40:55]: test command1: [-----------------------
-autopkgtest [21:40:58]: test command1: -----------------------]
-command1             PASS
-autopkgtest [21:41:03]: test command1:  - - - - - - - - - - results - - - - - - - - - -
-autopkgtest [21:41:09]: @@@@@@@@@@@@@@@@@@@@ summary
-master-cron-systemd  FAIL non-zero exit status 1
-master-cgi-systemd   PASS
-node-systemd         PASS
-command1             PASS
-```
-
-Here we see that the test named `master-cron-systemd` has failed. To see why it
-failed, do a search on the page for `master-cron-systemd`, and iterate until
-you get to the last line of the test run, then scroll up to find the failed test
-cases:
-
-```none
-autopkgtest [21:23:39]: test master-cron-systemd: preparing testbed
-...
-...
-autopkgtest [21:25:10]: test master-cron-systemd: [-----------------------
-...
-...
-not ok 3 - munin-html: no files in /var/cache/munin/www/ before first run
-#
-#	  find /var/cache/munin/www/ -mindepth 1 >unwanted_existing_files
-#	  test_must_be_empty unwanted_existing_files
-#
-...
-...
-autopkgtest [21:25:41]: test master-cron-systemd: -----------------------]
-master-cron-systemd  FAIL non-zero exit status 1
-autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - results - - - - - - - - - -
-autopkgtest [21:25:46]: test master-cron-systemd:  - - - - - - - - - - stderr - - - - - - - - - -
-rm: cannot remove '/var/cache/munin/www/localdomain/localhost.localdomain': Directory not empty
-```
-
-All autopkgtests follow this general format, although the output from the tests
-themselves varies widely.
-
-Beyond "regular" test case failures like this one, autopkgtest failures can also
-occur due to missing or incorrect dependencies, test framework timeouts, and
-other issues. Each of these is discussed in more detail below.
-
-
-### Flaky or actually regressed in release
-
-Tests might break due to the changes we applied -- catching those is the reason
-the tests exist in the first place. But sometimes the tests do fail but are not
-flaky. In that case, it is often another unrelated change to the test
-environment that made it suddenly break permanently.
-
-If you have checked the recent test run history as suggested above and have
-retried the tests often enough that it seems unreasonable to continue retrying,
-then you might want to tell the autopkgtest infrastructure that it shouldn't
-expect this test to pass.
-
-This can now be done via a migration-reference run. To do that, open the same
-URL you'd normally use to re-run the test, but instead of `package` + `version`
-as the trigger, you would add `migration-reference/0`. This is a special key,
-which will re-run the tests with the version of the requested package in the
-target release, without any proposed packages.
-
-For example:
-
-```none
-https://autopkgtest.ubuntu.com/request.cgi?release=RELEASE&arch=ARCH&package=SRCPKG&trigger=migration-reference/0
-```
-
-If this fails too, it will update the expectations so that if other packages are
-trying to migrate they will not be required to pass.
-
-If this does not fail, then your assumption that your upload/change wasn't
-related to the failure is most likely wrong.
-
-More details about that can be found in the
-[How to run autopkgtests of a package against the version in the release pocket](https://wiki.ubuntu.com/ProposedMigration#How_to_run_autopkgtests_of_a_package_against_the_version_in_the_release_pocket).
+A test needs to run against both of these new versions (and against any other dependencies of the {pkg}`netplan.io` package that are also in `-proposed`).

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/failure-to-build-from-source-ftbfs.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/failure-to-build-from-source-ftbfs.md
@@ -1,0 +1,152 @@
+---
+orphan: true
+---
+
+(failure-to-build-from-source-ftbfs)=
+# Failure to Build From Source (FTBFS)
+
+A package has to be buildable top be able to migrate from the `-proposed` to `-release` {term}`pocket`. This article describes a number of common reasons why a package build may fail.
+
+:::{admonition} **Proposed migration** series
+The {ref}`proposed-migration` article series explains the various migration failures and ways of investigating them.
+
+Process overview:
+: {ref}`proposed-migration`
+
+Issue types:
+:   * {ref}`issues-preventing-migration`
+    * {ref}`autopkgtest-regressions`
+    * {ref}`failure-to-build-from-source-ftbfs` (this article)
+    * {ref}`special-migration-cases`
+
+Practical guidance:
+: {ref}`resolve-a-migration-issue`
+:::
+
+General classes of problems during the build step:
+
+{ref}`normal-build-issues`
+: Locally reproducible build problems (that should have been addressed before uploading).
+
+{ref}`platform-specific-issues`
+: Issues that may have been overlooked due to being present only on unfamiliar hardware.
+
+{ref}`intermittent-problems`
+: Temporary network or framework problems that require retrying the build.
+
+{ref}`dependency-problems`
+: Requiring adding the right version of some other package to the `-release` pocket.
+
+{ref}`abi-changes`
+: {term}`ABI` changes with dependencies; often requiring a no-change rebuild.
+
+{ref}`package-specific-issues`
+: Other package-specific build problems that usually require a tweak to the package itself.
+
+
+(normal-build-issues)=
+## Normal build issues
+
+The first case covers all the usual normal build issues like syntax errors and
+so on. In practice these tend to be quite rare, since developers tend to be
+very diligent in making sure their packages build before uploading them. Fixes
+for these is standard development work.
+
+
+(platform-specific-issues)=
+## Platform-specific issues
+
+The second case is similar to the first but pertains to issues that arise only
+on specific platforms. Common situations are tests or code that relies on
+[endianness](https://en.wikipedia.org/wiki/Endianness) of data types, and so
+breaks on big-endian systems (e.g. s390x), code expecting 64-bit data types that
+breaks on 32-bit (e.g. armhf), and so on.
+
+{term}`Canonistack` provides hardware for Canonical employees to use to try and reproduce these problems.
+
+```{note}
+i386 in particular fails less due to data type issues, but more because it is
+a partial port and has numerous limitations that require special handling, as
+described on the {ref}`i386 troubleshooting page <aa-i386>`.
+```
+
+
+(intermittent-problems)=
+## Intermittent problems
+
+In the third case, local building was fine but the uploaded build may have
+failed on Launchpad due to a transitory issue such as a network outage, or a
+race condition, or other stressed resource. Alternatively, it might have failed
+due to a strange dependence on some variable like the day of the week.
+
+In these cases, clicking on the "Retry Build" button in Launchpad once or twice
+can sometimes cause the build to randomly succeed, thus allowing the transition
+to proceed (if you're not yet a Core Dev, ask for a Core Dev on the
+`#ubuntu-devel` IRC channel to click the link for you).
+
+Needless to say, we want the build process to be robust and predictable. If the
+problem is a recurring one, and you are able to narrow down the cause, it can
+be worthwhile to find the root cause and figure out how to fix it properly.
+
+
+(dependency-problems)=
+## Dependency problems
+
+For the fourth case, where a dependency is not the right version or is not
+present in the right pocket, the question becomes one of identifying what's
+wrong with the dependency and fixing it.
+
+Be aware there may be some situations where the problem really is with the
+dependency itself. The solution then might be to change the version of the
+dependency, or adjust the dependency version requirement, or remove invalid
+binary packages, or so forth. The latter solutions often require asking an
+Archive Admin for help on the `#ubuntu-release` IRC channel.
+
+
+(abi-changes)=
+## ABI changes
+
+The fifth case, of ABI changes, tends to come up when Ubuntu is introducing new
+versions of toolchains, language runtime environments or core libraries (i.e.
+new `glibc`, `gcc`, `glib2.0`, `ruby`, `python3`, `phpunit`, etc).
+
+This happens when the release of the underlying libraries/toolchains is newer
+than the project that uses it. Your package may fail to build because, for
+example, one of its dependencies was built against a different version of
+`glibc`, or with less strict `gcc` options (the
+[Ubuntu Defaults](https://wiki.ubuntu.com/ToolChain/CompilerFlags#Notes) can be
+checked here) etc, and it needs a (no-change) rebuild (and/or patched) to build
+with the new version or stricter options.
+
+Assuming the upstream project has already adapted to the changed behavior or
+function-prototypes **and** produced a release, then:
+
+* If we already have the release in Ubuntu a simple no-change rebuild may
+  suffice.
+
+* If we don't have the release, then it will need a sync or merge, or patching
+  in the changes to what we're carrying.
+
+If upstream has not *released* the changes, then you could also consider
+packaging a snapshot of their git repository.
+
+If upstream has *not yet made* the changes, and there no existing bug reports or
+pull requests yet, it may be necessary to make the changes on our end.
+Communication with Debian and upstream can be effective here, and where it
+isn't, filing bug reports can be worth the effort.
+
+It's worth noting that with ABI changes, these updates often cause the same kind
+of errors in many places. It's worth asking in the `#ubuntu-devel` IRC channel
+in case standard solutions are already known that you can re-use, such as
+ignoring a new warning via a `-W...` option or switching to the old behavior
+via a `-f...` option. It's also worth reporting your findings in ways others can
+easily re-use when they run into more cases.
+
+
+(package-specific-issues)=
+## Package-specific issues
+
+Finally, there are a myriad of other problems that can result in build
+failures. Many of these will be package-specific or situation-specific. As you
+run into situations that crop up more frequently than a couple of times please
+update these docs.

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/failure-to-build-from-source-ftbfs.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/failure-to-build-from-source-ftbfs.md
@@ -13,14 +13,14 @@ The {ref}`proposed-migration` article series explains the various migration fail
 Process overview:
 : {ref}`proposed-migration`
 
-Issue types:
-:   * {ref}`issues-preventing-migration`
-    * {ref}`autopkgtest-regressions`
-    * {ref}`failure-to-build-from-source-ftbfs` (this article)
-    * {ref}`special-migration-cases`
-
 Practical guidance:
 : {ref}`resolve-a-migration-issue`
+
+Issue types:
+:   * {ref}`failure-to-build-from-source-ftbfs` (this article)
+    * {ref}`autopkgtest-regressions`
+    * {ref}`issues-preventing-migration`
+    * {ref}`special-migration-cases`
 :::
 
 General classes of problems during the build step:

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/index.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/index.md
@@ -1,6 +1,16 @@
 (proposed-migration)=
 # Proposed migration
 
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+failure-to-build-from-source-ftbfs
+autopkgtest-regressions
+issues-preventing-migration
+special-migration-cases
+```
+
 Uploads of {ref}`fixed <fix-a-bug-in-a-package>` or {ref}`merged <merges>` packages are not automatically released to Ubuntu users. Instead, they go into a special {term}`pocket` called `-proposed` for testing and integration. Once a package is deemed OK, it **migrates** into the `-release` pocket for users to consume. This is called the "proposed migration" process.
 
 This article series outlines the upload and migration process.
@@ -11,17 +21,15 @@ The article series explains the various migration failures and ways of investiga
 Process overview:
 : {ref}`proposed-migration` (this article)
 
+Practical guidance:
+: {ref}`resolve-a-migration-issue`
+
 Issue types:
 :   * {ref}`issues-preventing-migration`
     * {ref}`autopkgtest-regressions`
     * {ref}`failure-to-build-from-source-ftbfs`
     * {ref}`special-migration-cases`
-
-Practical guidance:
-: {ref}`resolve-a-migration-issue`
 :::
-
-See {ref}`resolve-a-migration-issue` for guidance on how to deal with situations when the migration from `-proposed` to -`-release` does not proceed automatically.
 
 
 (lifecycle-of-an-upload)=
@@ -66,14 +74,7 @@ See {ref}`resolve-a-migration-issue` for guidance on how to deal with situations
 
 The migration often proceeds automatically, but when issues arise, someone needs to resolve the problem. It is generally the responsibility of the uploader to analyze and {ref}`resolve the issue <resolve-a-migration-issue>`.
 
-Other situations can also lead to migration trouble, for which there is no specific responsible party. These types of problems are focused on as part of the {ref}`plus-one-maintenance` effort, where individuals across the distribution team are tasked with examining and resolving issues. Some of these problems arise from items auto-synced from Debian, or via a side-effect of some other change in the distribution.
-
-See the articles in the series for details:
-
-* {ref}`issues-preventing-migration`
-* {ref}`autopkgtest-regressions`
-* {ref}`failure-to-build-from-source-ftbfs`
-* {ref}`special-migration-cases`
+Other situations, for which there is no specific responsible party, can also lead to migration trouble. These types of problems are focused on as part of the {ref}`plus-one-maintenance` effort, where individuals across the distribution team are tasked with examining and resolving issues. Some of these problems arise from items auto-synced from Debian, or via a side-effect of some other change in the distribution.
 
 
 (update-excuses-page)=
@@ -91,13 +92,20 @@ In general, there are two things to watch for:
 "Regressions"
 : Indicates a ({term}`autopkgtest`) test failure.
 
-Both of these situations are described in more depth below.
+Both of these situations are described in more depth in this article series.
 
 Many of the items on the page are not actually broken -- they're just blocked by something else that needs resolving. This often happens for new libraries or language runtimes, or any package that a lot of other things depend on to build, install, or run tests against.
 
+See the articles in the series for details on how to interpret the status reported on the {term}`update excuses` page:
 
-(where-to-start)=
-### Where to start
+* {ref}`failure-to-build-from-source-ftbfs`
+* {ref}`autopkgtest-regressions`
+* {ref}`issues-preventing-migration`
+* {ref}`special-migration-cases`
+
+
+(finding-issues-to-resolve)=
+### Finding issues to resolve
 
 Look for build failures towards the upper-middle of the page, particularly those affecting only one architecture. Single-arch build failures tend to be more localized and more deterministic in their cause. Items towards the top of the page (but after all the **"Test in progress"** items) are newer, and so have a higher chance of being something simple that fewer people have looked at yet, without being so new that it's still being actively worked on by someone.
 
@@ -118,8 +126,6 @@ To check whether someone is already working on an item, ask in the [Ubuntu Devel
 #### Bug reports for migration problems
 
 When you file a bug report about a build or test failure shown on the {ref}`update-excuses-page`, tag the bug report `update-excuse`. {term}`Britney` then includes a link to the bug report the next time it refreshes the {ref}`update-excuses-page` page. This helps other developers see the investigative work you've already done and can be used to identify the next action. Mark yourself as the *Assignee* if you're actively working on the issue, and leave the bug unsubscribed if you aren't, so that others can carry things forward.
-
-
 
 
 ## Further reading

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/issues-preventing-migration.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/issues-preventing-migration.md
@@ -1,0 +1,221 @@
+---
+orphan: true
+---
+
+(issues-preventing-migration)=
+# Issues preventing migration
+
+Packages can fail to migrate for a vast number of different reasons. Sometimes
+the clues listed under the 'Issues preventing migration:" line item on the
+'update_excuses' page will be enough to indicate the next action needed; that
+will be the focus of this section. In other cases, the autopkgtest log file will
+need to be analyzed.
+
+
+:::{admonition} **Proposed migration** series
+The {ref}`proposed-migration` article series explains the various migration failures and ways of investigating them.
+
+Process overview:
+: {ref}`proposed-migration`
+
+Issue types:
+:   * {ref}`issues-preventing-migration` (this article)
+    * {ref}`autopkgtest-regressions`
+    * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`special-migration-cases`
+
+Practical guidance:
+: {ref}`resolve-a-migration-issue`
+:::
+
+
+(main-universe-binary-mismatch)=
+## `main`/`universe` binary mismatch
+
+A given source package may have some binaries in `main` and others in `universe`,
+but this can get mixed up for various reasons. This genre of issues, known as
+["component mismatches"](https://ubuntu-archive-team.ubuntu.com/component-mismatches.txt)
+is spotted from migration excuses like:
+
+```none
+"php8.1-dba/amd64 in main cannot depend on libqdbm14 in universe"
+```
+
+Check the prior release to see if `php8.1-dba` and `libqdbm14` were both in
+`main`, or both in `universe`. If both were in `universe` before, then most likely the
+package in `main` needs to be demoted to `universe`. Ask an Archive Admin to do
+this, and/or file a bug report (for an example, see
+[LP: #1962491](https://bugs.launchpad.net/ubuntu/+source/php8.1/+bug/1962491)).
+
+Conversely, if the dependency in `universe` actually needs to be in `main`, for
+example a newly introduced binary package, then a 'Main Inclusion Request' (MIR)
+bug report will need to be filed. See {ref}`main-inclusion-review` for details
+on this procedure.
+
+If both packages were previously in `main`, then some additional investigation
+should be done to see why the `universe` package was moved out of `main`. The
+resolution may be to move one or the other package so they're both in the same
+pocket, or find a way to remove the dependency between them.
+
+One very special case of these is unintended dependencies due to extra-includes.
+Be aware that while most dependencies seem obvious (seeds --> packages -->
+packages) there is an aspect of
+[germinate](https://ubuntu-archive-team.ubuntu.com/germinate-output/ubuntu.jammy/all)
+which will
+[automatically include](https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/ubuntu/tree/supported#n124)
+all `-dbg`, `-dev`, `-doc*` packages in a source archive that is in main. In
+germinate these will appear as `Rescued from <src>`. If a merge is affected,
+the solution without adding delta usually is to add an `Extra-exclude` like in
+this [example with `net-snmp`](https://code.launchpad.net/~sergiodj/ubuntu-seeds/+git/ubuntu/+merge/414063).
+
+For more information on component mismatches, from an Archive Administration
+perspective, see {ref}`aa-package-overrides`.
+
+
+(impossible-depends)=
+## Impossible depends
+
+An excuse like this:
+
+```none
+"Impossible Depends: aaa -> bbb/x/<arch>"
+```
+
+means package `aaa` has a dependency on package `bbb`, version `x`, for
+architecture `<arch>`, but it is not possible to satisfy this.
+
+One reason this can occur is if the package `bbb` is in `universe` whereas `aaa`
+is in `main`. It may be that some of package `aaa`'s binaries need to be moved
+to `universe`. See {ref}`main-universe-binary-mismatch` for directions.
+
+
+(migrating-makes-something-uninstallable)=
+## Migrating makes something uninstallable
+
+A migration excuse in this format:
+
+```none
+"migrating [aaa]/[aaa-new-version]/[arch] to testing makes [bbb]/[bbb-version]/[arch] uninstallable"
+```
+
+means that package `bbb` has a versioned build dependency against the old
+version of package `aaa`. A no-change rebuild can be used in these cases to
+force a rebuild.
+
+
+## Depends: `aaa [bbb]` (not considered)
+
+Package `aaa` is blocked because it depends on `bbb`, however `bbb` is either
+invalid or rejected.
+
+If the dependency itself is not valid, this line will be followed by an
+'Invalidated by dependency' line. In this case, look at the situation with
+package `bbb` and resolve that first, in order to move package `aaa` forward.
+
+If there is no 'Invalidated by dependency' line, then the dependency may be
+rejected. There are three reasons why a rejection can occur:
+
+1. it needs approval, 
+2. cannot determine if permanent, or
+3. permanent rejection.
+
+
+## Implicit dependency: `aaa [bbb]`
+
+An implicit dependency is a pseudo dependency where Breaks/Conflicts creates an
+inverted dependency. For example, `pkg-b` Depends on `pkg-a`, but `pkg-a=2.0-1`
+breaks `pkg-b=1.0-1`, so `pkg-b=2.0-1` must migrate first (or they must migrate
+together). A way to handle this is to re-run `pkg-b`'s autopkgtest (for 2.0-1)
+and include a trigger for `pkg-a=2.0`. For example, run:
+
+```bash
+$ excuses-kicker -t pkg-a pkg-b
+```
+
+This can also occur if `pkg-b` has "Depends: pkg-a (<< 2.0)", due to the use of
+some non-stable internal interface.
+
+It can also occur if `pkg-a` has a Provides that changes from 1.0-1 to 2.0-1,
+but `pkg-b` has a Depends on the earlier version.
+
+
+## Implicit dependency: `aaa [bbb]` (not considered)
+
+Similar to above, `aaa` and `bbb` are intertwined, but `bbb` is also either
+invalid or rejected. For these cases, attention should first be paid to
+resolving the issue(s) for `bbb`, and then re-running the autopkgtest for it
+with a trigger included against package `aaa`.
+
+
+## Has no binaries on arch `<arch>`
+
+Usually this means the package has either failed to build or failed to upload
+the binaries for a build. Refer to the
+{ref}`failed to build from source <failure-to-build-from-source-ftbfs>` section for
+tips on how to handle this class of problem.
+
+
+## Has no binaries on any arch (`- to x.y.z`)
+
+If the package doesn't have a current version, this error can indicate the
+package is not (yet) in the Archive, or it can mean its binaries were removed
+previously but not sync-blocklisted and thus reappeared.
+
+If the package should not be synced into the Archive, on `#ubuntu-release` ping
+`ubuntu-archive` with a request to remove the packages' binaries and add them to
+[sync-blocklist.txt](https://ubuntu-archive-team.ubuntu.com/sync-blocklist.txt).
+
+Otherwise, there are several things worth checking. Note that these links are
+for Jammy; modify them for the current development release:
+
+- [Stuck in New queue](https://launchpad.net/ubuntu/jammy/+queue?queue_state=0)
+- [Stuck in Unapproved queue](https://launchpad.net/ubuntu/jammy/+queue?queue_state=1)
+
+
+## No reason - still stuck?
+
+If the package, as shown in
+[excuses](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_excuses.html),
+looks good but is not migrating, it might mean an installability conflict.
+So, do not be confused by the status "Will attempt migration (Any information
+below is purely informational)" - there are more checks happening afterwards.
+This is checked and reported in
+[update output.txt](https://ubuntu-archive-team.ubuntu.com/proposed-migration/update_output.txt)
+
+Here is an example of `exim4` meeting this situation:
+
+```none
+trying: exim4
+skipped: exim4 (4, 0, 137)
+    got: 11+0: a-0:a-0:a-0:i-2:p-1:r-7:s-1
+    * riscv64: sa-exim
+```
+
+That output is hard to read
+([as explained here](https://wiki.ubuntu.com/ProposedMigration#The_update_output.txt_file_is_completely_unreadable.21)),
+but in this example it means that a few packages on those architectures became
+uninstallable.
+
+You can usually reproduce that in a `-proposed`-enabled container and in this
+example we see:
+
+```none
+root@k:~# apt install exim4 sa-exim
+...
+The following packages have unmet dependencies:
+ sa-exim : Depends: exim4-localscanapi-4.1
+```
+
+Now we know that, let us compare the old and new `exim4`, which has:
+
+```none
+root@k:~# apt-cache show exim4-daemon-light | grep -e scanapi -e '^Versi'
+Version: 4.96-3ubuntu1
+Provides: exim4-localscanapi-6.0, mail-transport-agent
+Version: 4.95-4ubuntu3
+Provides: exim4-localscanapi-4.1, mail-transport-agent
+```
+
+So our example needs (as is most often the solution in these cases) a no-change
+rebuild to pick up the new dependency. After a test build to be sure it works,
+you can often upload and resolve this situation.

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/issues-preventing-migration.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/issues-preventing-migration.md
@@ -18,14 +18,14 @@ The {ref}`proposed-migration` article series explains the various migration fail
 Process overview:
 : {ref}`proposed-migration`
 
-Issue types:
-:   * {ref}`issues-preventing-migration` (this article)
-    * {ref}`autopkgtest-regressions`
-    * {ref}`failure-to-build-from-source-ftbfs`
-    * {ref}`special-migration-cases`
-
 Practical guidance:
 : {ref}`resolve-a-migration-issue`
+
+Issue types:
+:   * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`autopkgtest-regressions`
+    * {ref}`issues-preventing-migration` (this article)
+    * {ref}`special-migration-cases`
 :::
 
 
@@ -128,7 +128,7 @@ breaks `pkg-b=1.0-1`, so `pkg-b=2.0-1` must migrate first (or they must migrate
 together). A way to handle this is to re-run `pkg-b`'s autopkgtest (for 2.0-1)
 and include a trigger for `pkg-a=2.0`. For example, run:
 
-```bash
+```none
 $ excuses-kicker -t pkg-a pkg-b
 ```
 

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/special-migration-cases.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/special-migration-cases.md
@@ -5,6 +5,7 @@ orphan: true
 (special-migration-cases)=
 # Special migration cases
 
+This article describes cases when automatic migration from the `-proposed` to `-release` pocket is blocked due to situations other than common build or test failures.
 
 :::{admonition} **Proposed migration** series
 The {ref}`proposed-migration` article series explains the various migration failures and ways of investigating them.
@@ -12,159 +13,127 @@ The {ref}`proposed-migration` article series explains the various migration fail
 Process overview:
 : {ref}`proposed-migration`
 
-Issue types:
-:   * {ref}`issues-preventing-migration`
-    * {ref}`autopkgtest-regressions`
-    * {ref}`failure-to-build-from-source-ftbfs`
-    * {ref}`special-migration-cases` (this article)
-
 Practical guidance:
 : {ref}`resolve-a-migration-issue`
+
+Issue types:
+:   * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`autopkgtest-regressions`
+    * {ref}`issues-preventing-migration`
+    * {ref}`special-migration-cases` (this article)
 :::
 
 
 ## Circular build dependencies
 
-When two or more packages have new versions that depend on each other's new
-versions in order to build, this can lead to a
-[circular build dependency](https://wiki.debian.org/CircularBuildDependencies).
-There are a few different ways these come into being, which have unique
-characteristics that can help find a way to work through them.
+When two or more packages have new versions that depend on each other's new versions in order to build, it can lead to a [circular build dependency](https://wiki.debian.org/CircularBuildDependencies). This section describes the different ways these happen, which have unique characteristics that can help find a way to resolve them.
 
 
 ### Build-dependencies for test suites
 
-If package A's build process invokes a test suite as part of the build (i.e. in
-`debian/rules` under `override_dh_auto_test`), and the test suite requires
-package B, then if package B requires package A to build, this creates a
-situation where neither package will successfully build.
+If the build process for package `A` invokes a test suite as part of the build (i.e. in `debian/rules` under `override_dh_auto_test`), and the test suite requires package `B`, then if package `B` requires package `A` to build, this creates a situation where neither package successfully builds.
 
-The workaround in this case is to (temporarily) disable running the test suite
-during a build. This is usually OK when the package's autopkgtests (defined in
-`debian/tests/control`) also run the test suite. For instance:
+The workaround is to (temporarily) disable running the test suite during a build (this is usually OK when the package's autopkgtests (defined in `debian/tests/control`) also run the test suite).
 
-```none
-override_dh_auto_test:
-    echo "Disabled: phpunit --bootstrap vendor/autoload.php"
-```
+1. Disable test suite in package `A`. For example:
 
-You may also need to delete test dependencies from `debian/control`, and/or move
-them to `debian/tests/control`.
+    ```none
+    override_dh_auto_test:
+        echo "Disabled: phpunit --bootstrap vendor/autoload.php"
+    ```
 
-With package A's test suite thus disabled during build, it will build
-successfully but then fail its autopkgtest run. Next, from package B's Launchpad
-page, request rebuilds for each binary in a failed state. Once package B has
-successfully built on all supported architectures, package A's autopkgtests can
-be re-run using package B as a trigger.
+   You may also need to delete test dependencies from `debian/control`, and/or move them to `debian/tests/control`.
 
-Once everything's migrated successfully, a clean-up step would be to re-enable
-package A's test suite and verify that it now passes.
+   With the test suite of package `A` disabled during build, it builds successfully but then fails its autopkgtest run.
+
+1. From the Launchpad page of package `B`, request rebuilds for each binary in a failed state. Wait for package `B` to
+successfully build on all supported architectures.
+
+1. Re-run autopkgtests for package `A` using package `B` as the trigger:
+
+    ```none
+    https://autopkgtest.ubuntu.com/request.cgi?release=<RELEASE>&arch=<ARCH>&package=<A>&trigger=<B>/<VERSION>
+    ```
+
+1. Once everything migrates successfully, re-enable the test suite for package `A`, and verify that it now passes.
 
 
 ### Bootstrapping
 
-In this situation, packages A-1.0 and B-1.0 are in the archive. We're
-introducing new versions A-3.0 and B-3.0 (skipping 2.0); A-3.0 depends on B-3.0,
-and B-3.0 requires A-2.0 or newer. Both A-3.0 and B-3.0 will fail to build.
+In this situation, packages `A-1.0` and `B-1.0` are in the archive. We're introducing new versions `A-3.0 `and `B-3.0` (skipping both `A-2.0` and `B-2.0`); `A-3.0` depends on `B-3.0`, and `B-3.0` requires `A-2.0` or newer. Both `A-3.0` and `B-3.0` fail to build.
 
-One example of where this can occur is if code common to both A and B is
-refactored out to a new binary package that is provided in A starting at
-version 2.0.
+One example of where this can occur is if code common to both `A` and `B` is refactored out to a new binary package that is provided in `A` starting at version `A-2.0`.
 
-The most straightforward solution to this situation is to ask an Archive Admin
-to delete both A-3.0 and B-3.0 from the Archive, then upload version A-2.0 and
-allow it to build (and ideally migrate). Next reintroduce B-3.0, and then once
-that's built, do the same for A-3.0.
+To resolve this situation:
 
-With even larger version jumps, e.g. from A-1.0 to A-5.0, it may be necessary to
-do multiple bootstraps, along with some experimentation to see which
-intermediate version(s) need to be jumped to. Another common complication can be
-where the cycle involves more than two packages.
+1. Ask an Archive Admin to delete both `A-3.0` and `B-3.0` from the Archive.
+1. Upload version `A-2.0` and allow it to build (and ideally migrate).
+1. Reintroduce `B-3.0`, and wait for it to build.
+1. Reintroduce `A-3.0`.
+
+With even larger version jumps, e.g. from `A-1.0` to `A-5.0`, it may be necessary to do multiple bootstraps, along with some experimentation to see which intermediate version(s) need to be jumped to. Another common complication can be where the cycle involves more than two packages.
 
 
-## Test dependency irregularities
+## Test-dependency irregularities
 
-The package's `debian/tests/control` file
-[defines what gets installed](https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst)
-in the test environment before executing the tests. You can review and verify
-the packages and versions in the DEP-8 test log, between the lines
-"`autopkgtest...: test integration: preparing testbed`" and
-"`Removing autopkgtest-satdep`".
+The package's `debian/tests/control` file defines what is installed in the test environment before executing the tests (see [Autopkgtest - Defining tests for Debian packages](https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst)). To review and verify the packages and versions, check the DEP-8 test log between these lines:
 
-A common issue is that the test should be run against a version of a dependency
-present in the `-proposed` pocket, however it failed due to running against the
-version in `-release`. Often this is straightforward to prove by running the
+```none
+autopkgtest...: test integration: preparing testbed
+
+[...]
+
+Removing autopkgtest-satdep
+```
+
+A common issue is that the test should run against a version of a dependency present in the `-proposed` pocket, however, it fails due to running against the version in `-release`. This is often straightforward to prove by running the
 autopkgtests locally in a container.
 
-Another easy way to test this is to re-run the test but set it to preferentially
-pull packages from `-proposed` -- this is done by appending `&all-proposed=1` to
-the test URL. If that passes, but the package still does not migrate, then look
-in the test log for all packages that were pulled from `-proposed` and include
-those as triggers.
-[Excuses Kicker](https://git.launchpad.net/~bryce/+git/excuses-kicker) and
-[retry-autopkgtest-regressions](https://git.launchpad.net/ubuntu-archive-tools/tree/retry-autopkgtest-regressions)
-are handy tools for generating these URLs.
+Another easy way to test this is to re-run the test but set it to preferentially pull packages from `-proposed` -- this is done by appending `&all-proposed=1` to the test URL (see {ref}`against-other-packages-in-proposed`). If that passes, but the package still does not migrate, look in the test log for all packages that were pulled from `-proposed`, and include those as triggers.
 
-As with rebuilds, these re-triggers also require Core Dev permissions, so if
-you're not yet a Core Dev give the links to someone who is for assistance.
+See {ref}`generate-test-re-trigger-urls` for guidance on how to generate autopkgtest URLs.
+
+As with rebuilds, these re-triggers also require {term}`core dev` permissions, so if you're not yet a Core Dev, give the links to someone who is for assistance.
 
 
 ## Test framework timeouts and out of memory
 
-The autopkgtest framework will kill tests that take too long to run. In some
-cases it makes sense to just configure autopkgtest to let the test run longer.
-This is done by setting the `long_tests` option. Similarly, some tests may need
-more CPU or memory than in a standard worker. The `big_packages` option directs
-autopkgtest to run these on workers with more CPU and memory. Both these options
-are explained on the
-[Proposed Migration wiki](https://wiki.ubuntu.com/ProposedMigration#autopkgtests)
-page.
+The autopkgtest framework kills tests that run too long. In some cases, it makes sense to configure autopkgtest to let the test run longer. This is done by setting the `long_tests` option.
 
-It is worthwhile to mention that Debian test sizing is currently (as of 2021)
-equivalent to our `big_packages`.
+Similarly, some tests may need more CPU or memory than in a standard worker. The `big_packages` option directs autopkgtest to run these on workers with more CPU and memory.
 
-The configuration that associates source packages to either `big_packages` /
-`long_tests` and the actual deployment code was recently split.
-[The new docs](https://autopkgtest-cloud.readthedocs.io/en/latest/administration.html#give-a-package-more-time-or-more-resources)
-explain this and
-[link to a repository](https://code.launchpad.net/~ubuntu-release/autopkgtest-cloud/+git/autopkgtest-package-configs)
-which can now be merged by any Release Team member.
+TODO: Add info from [Proposed Migration wiki](https://wiki.ubuntu.com/ProposedMigration#autopkgtests):
+
+autopkgtest tests are run in ephemeral cloud instances as described on /AutopkgtestInfrastructure. The autopkgtests can be configured to run on different types of workers in https://code.launchpad.net/~ubuntu-release/autopkgtest-cloud/+git/autopkgtest-package-configs. The README.md provides more details, but briefly, this repo specifies which VM worker should be used for a given autopkgtest execution. The big_packages file specifies packages which need more memory and CPU - by default tests run on something similar to an m1.small unit (1 vCPU and 1592 MiB Memory), while big_packages run on an m1.large (4 vCPU and 8192 Mib Memory) unit. The Debian Continuous Intergration test environment runs tests on systems with 8G of memory so if a package is passing in Debian but not Ubuntu consider running the test with more memory. The list of packages in long_tests are passed an increased timeout value ('--timeout-test=40000') to autopkgtest. Additionally, any big_packages are passed '--timeout-test=20000'. 
+
+Changes to ^ can be merged by any Release Team member.
+
+See also [Give a package more time or more resources](https://autopkgtest-cloud.readthedocs.io/en/latest/administration.html#give-a-package-more-time-or-more-resources)
 
 
-## Disabling / skipping tests
+## Disabling or skipping tests
 
-While (ideally) failing tests should receive fixes to enable them to pass
-properly, sometimes this is not feasible or possible. In such extreme situations
-it may be necessary to explicitly disable a test case or an entire test suite.
-For instance, if an unimportant package's test failure blocks a more important
-package from transitioning.
+While failing tests should receive fixes to enable them to pass properly, sometimes this is not feasible or possible. In such extreme situations, it may be necessary to explicitly disable a test case or an entire test suite. For instance, if an unimportant package's test failure blocks a more important package from transitioning.
 
-As a general rule, try to be as surgical as possible and avoid disabling more
-than is absolutely required. For example, if a test has 10 sub-cases and only
-one sub-case fails, prefer to comment out or delete that sub-case rather than
-the entire test.
+As a general rule, try to be as surgical as possible and avoid disabling more than is absolutely required. For example, if a test has 10 sub-cases and only one sub-case fails, comment out or delete that sub-case rather than the entire test.
 
-There is no single method to disabling tests, unfortunately, since different
-programming languages take different design approaches for their test harnesses.
-Some test harnesses have provisions for marking tests "SKIP". In other
-situations it may be cleaner to add a Debian patch that simply deletes the
-test's code from the codebase. Sometimes it works best to insert an early return
-with a fake PASS in the particular code path that broke.
+There is no single method to disabling tests as since different programming languages take different design approaches for their test harnesses:
 
-Take care, when disabling a test, to include a detailed enough explanation as to
-why you're disabling it, which will inform a future packager when the test can
-be re-enabled. For instance, if a proper fix will be available in a future
-release, say so and indicate which version will have it. Or, if the test is
-being disabled just to get another package to transition, indicate what that
-package's name and expected version are. Bug reports, DEP-3 comments, and
-changelog entries can be good places to document these clues.
+* Some test harnesses have provisions for marking tests `SKIP`
+* In other situations, it may be cleaner to add a Debian patch that simply deletes the test's code from the codebase.
+* Sometimes, it works best to insert an early return with a fake `PASS` in the particular code path that broke.
+
+When disabling a test, include a detailed enough explanation why you're disabling it, which informs a future packager when the test can be re-enabled. For instance:
+
+* If a proper fix will be available in a future release, explain that and indicate which version will have it.
+* If the test is being disabled to get another package to transition, indicate that package's name and expected version.
+
+Document these clues in bug reports, DEP-3 comments, or changelog entries.
 
 
-## Disabling / skipping / customizing tests for certain architectures
+## Disabling, skipping, or customizing tests for certain architectures
 
-If you need to disable the entire test suite for a specific architecture, such as
-an arch that upstream doesn't include in their CI testing, and that sees
-frequent / ample failures on our end, then you can skip the testing via checks
+To disable the entire test suite for a specific architecture, such as an architecture that upstream doesn't include in their CI testing, and that sees frequent or ample failures in Ubuntu, skip the testing via checks
 in the `debian/rules` file. For example (from `util-linux-2.34`):
 
 ```none
@@ -177,8 +146,7 @@ else ifeq ($(DEB_HOST_ARCH_OS), linux)
 endif
 ```
 
-If the issue is the integer type size, here's a way to filter based on that
-(from `mash-2.2.2+dfsg`):
+If the issue is the integer type size, filter based on that (from `mash-2.2.2+dfsg`):
 
 ```none
 override_dh_auto_test:
@@ -203,16 +171,18 @@ endif
 
 ## Skipping autopkgtesting entirely
 
-If an autopkgtest is badly written, it may be too challenging to get it to pass.
-In these extreme cases, it's possible to request that test failures be ignored
-for the sake of package migration.
+If an autopkgtest is badly written, it may be too challenging to get it to pass. In these extreme cases, it's possible to request that test failures be ignored to enable package migration.
 
-* Check out [`lp:~ubuntu-release/britney/hints-ubuntu`](https://git.launchpad.net/~ubuntu-release/britney/+git/hints-ubuntu)
+Check [`lp:~ubuntu-release/britney/hints-ubuntu`](https://git.launchpad.net/~ubuntu-release/britney/+git/hints-ubuntu)
 
-File an MP against it with a description indicating the Launchpad bug #, the rationale
-for why the test can and should be skipped, and an explanation of what will be
-unblocked in the migration.
+File an MP against it with a description indicating:
 
-Reviewers should be `canonical-<your-team>` (e.g. `canonical-server-reporter`
-for Server team members), `ubuntu-release`, and any Archive Admins or
-Foundations team members you've discussed the issue with.
+* Launchpad bug number
+* Rationale for why the test can and should be skipped
+* Explanation of what will be unblocked in the migration
+
+As reviewers, select:
+
+* `canonical-<your-team>` (e.g. `canonical-server-reporter` for Server team members)
+* `ubuntu-release`
+* Any Archive Admins or Foundations team members you've discussed the issue with

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/special-migration-cases.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/special-migration-cases.md
@@ -1,0 +1,218 @@
+---
+orphan: true
+---
+
+(special-migration-cases)=
+# Special migration cases
+
+
+:::{admonition} **Proposed migration** series
+The {ref}`proposed-migration` article series explains the various migration failures and ways of investigating them.
+
+Process overview:
+: {ref}`proposed-migration`
+
+Issue types:
+:   * {ref}`issues-preventing-migration`
+    * {ref}`autopkgtest-regressions`
+    * {ref}`failure-to-build-from-source-ftbfs`
+    * {ref}`special-migration-cases` (this article)
+
+Practical guidance:
+: {ref}`resolve-a-migration-issue`
+:::
+
+
+## Circular build dependencies
+
+When two or more packages have new versions that depend on each other's new
+versions in order to build, this can lead to a
+[circular build dependency](https://wiki.debian.org/CircularBuildDependencies).
+There are a few different ways these come into being, which have unique
+characteristics that can help find a way to work through them.
+
+
+### Build-dependencies for test suites
+
+If package A's build process invokes a test suite as part of the build (i.e. in
+`debian/rules` under `override_dh_auto_test`), and the test suite requires
+package B, then if package B requires package A to build, this creates a
+situation where neither package will successfully build.
+
+The workaround in this case is to (temporarily) disable running the test suite
+during a build. This is usually OK when the package's autopkgtests (defined in
+`debian/tests/control`) also run the test suite. For instance:
+
+```none
+override_dh_auto_test:
+    echo "Disabled: phpunit --bootstrap vendor/autoload.php"
+```
+
+You may also need to delete test dependencies from `debian/control`, and/or move
+them to `debian/tests/control`.
+
+With package A's test suite thus disabled during build, it will build
+successfully but then fail its autopkgtest run. Next, from package B's Launchpad
+page, request rebuilds for each binary in a failed state. Once package B has
+successfully built on all supported architectures, package A's autopkgtests can
+be re-run using package B as a trigger.
+
+Once everything's migrated successfully, a clean-up step would be to re-enable
+package A's test suite and verify that it now passes.
+
+
+### Bootstrapping
+
+In this situation, packages A-1.0 and B-1.0 are in the archive. We're
+introducing new versions A-3.0 and B-3.0 (skipping 2.0); A-3.0 depends on B-3.0,
+and B-3.0 requires A-2.0 or newer. Both A-3.0 and B-3.0 will fail to build.
+
+One example of where this can occur is if code common to both A and B is
+refactored out to a new binary package that is provided in A starting at
+version 2.0.
+
+The most straightforward solution to this situation is to ask an Archive Admin
+to delete both A-3.0 and B-3.0 from the Archive, then upload version A-2.0 and
+allow it to build (and ideally migrate). Next reintroduce B-3.0, and then once
+that's built, do the same for A-3.0.
+
+With even larger version jumps, e.g. from A-1.0 to A-5.0, it may be necessary to
+do multiple bootstraps, along with some experimentation to see which
+intermediate version(s) need to be jumped to. Another common complication can be
+where the cycle involves more than two packages.
+
+
+## Test dependency irregularities
+
+The package's `debian/tests/control` file
+[defines what gets installed](https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst)
+in the test environment before executing the tests. You can review and verify
+the packages and versions in the DEP-8 test log, between the lines
+"`autopkgtest...: test integration: preparing testbed`" and
+"`Removing autopkgtest-satdep`".
+
+A common issue is that the test should be run against a version of a dependency
+present in the `-proposed` pocket, however it failed due to running against the
+version in `-release`. Often this is straightforward to prove by running the
+autopkgtests locally in a container.
+
+Another easy way to test this is to re-run the test but set it to preferentially
+pull packages from `-proposed` -- this is done by appending `&all-proposed=1` to
+the test URL. If that passes, but the package still does not migrate, then look
+in the test log for all packages that were pulled from `-proposed` and include
+those as triggers.
+[Excuses Kicker](https://git.launchpad.net/~bryce/+git/excuses-kicker) and
+[retry-autopkgtest-regressions](https://git.launchpad.net/ubuntu-archive-tools/tree/retry-autopkgtest-regressions)
+are handy tools for generating these URLs.
+
+As with rebuilds, these re-triggers also require Core Dev permissions, so if
+you're not yet a Core Dev give the links to someone who is for assistance.
+
+
+## Test framework timeouts and out of memory
+
+The autopkgtest framework will kill tests that take too long to run. In some
+cases it makes sense to just configure autopkgtest to let the test run longer.
+This is done by setting the `long_tests` option. Similarly, some tests may need
+more CPU or memory than in a standard worker. The `big_packages` option directs
+autopkgtest to run these on workers with more CPU and memory. Both these options
+are explained on the
+[Proposed Migration wiki](https://wiki.ubuntu.com/ProposedMigration#autopkgtests)
+page.
+
+It is worthwhile to mention that Debian test sizing is currently (as of 2021)
+equivalent to our `big_packages`.
+
+The configuration that associates source packages to either `big_packages` /
+`long_tests` and the actual deployment code was recently split.
+[The new docs](https://autopkgtest-cloud.readthedocs.io/en/latest/administration.html#give-a-package-more-time-or-more-resources)
+explain this and
+[link to a repository](https://code.launchpad.net/~ubuntu-release/autopkgtest-cloud/+git/autopkgtest-package-configs)
+which can now be merged by any Release Team member.
+
+
+## Disabling / skipping tests
+
+While (ideally) failing tests should receive fixes to enable them to pass
+properly, sometimes this is not feasible or possible. In such extreme situations
+it may be necessary to explicitly disable a test case or an entire test suite.
+For instance, if an unimportant package's test failure blocks a more important
+package from transitioning.
+
+As a general rule, try to be as surgical as possible and avoid disabling more
+than is absolutely required. For example, if a test has 10 sub-cases and only
+one sub-case fails, prefer to comment out or delete that sub-case rather than
+the entire test.
+
+There is no single method to disabling tests, unfortunately, since different
+programming languages take different design approaches for their test harnesses.
+Some test harnesses have provisions for marking tests "SKIP". In other
+situations it may be cleaner to add a Debian patch that simply deletes the
+test's code from the codebase. Sometimes it works best to insert an early return
+with a fake PASS in the particular code path that broke.
+
+Take care, when disabling a test, to include a detailed enough explanation as to
+why you're disabling it, which will inform a future packager when the test can
+be re-enabled. For instance, if a proper fix will be available in a future
+release, say so and indicate which version will have it. Or, if the test is
+being disabled just to get another package to transition, indicate what that
+package's name and expected version are. Bug reports, DEP-3 comments, and
+changelog entries can be good places to document these clues.
+
+
+## Disabling / skipping / customizing tests for certain architectures
+
+If you need to disable the entire test suite for a specific architecture, such as
+an arch that upstream doesn't include in their CI testing, and that sees
+frequent / ample failures on our end, then you can skip the testing via checks
+in the `debian/rules` file. For example (from `util-linux-2.34`):
+
+```none
+override_dh_auto_test:
+ifneq (,$(filter alpha armel armhf arm64,$(DEB_HOST_ARCH)))
+        @echo "WARNING: Making tests non-fatal because of arch $(DEB_HOST_ARCH)"
+        dh_auto_test --max-parallel=1 || true
+else ifeq ($(DEB_HOST_ARCH_OS), linux)
+        dh_auto_test --max-parallel=1
+endif
+```
+
+If the issue is the integer type size, here's a way to filter based on that
+(from `mash-2.2.2+dfsg`):
+
+```none
+override_dh_auto_test:
+ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+ifeq ($(DEB_HOST_ARCH_BITS),32)
+        echo "Do not test for 32 bit archs since test results were calculated for 64 bit."
+else
+        dh_auto_test --no-parallel
+endif
+endif
+```
+
+Or based on the CPU type itself (from `containerd-1.3.3-0ubuntu2.1`):
+
+```none
+override_dh_auto_test:
+ifneq (arm, $(DEB_HOST_ARCH_CPU)) # skip the tests on armhf ("--- FAIL: TestParseSelector/linux (0.00s)  platforms_test.go:292: arm support not fully implemented: not implemented")
+        cd '$(OUR_GOPATH)/src/github.com/containerd/containerd' && make test
+endif
+```
+
+
+## Skipping autopkgtesting entirely
+
+If an autopkgtest is badly written, it may be too challenging to get it to pass.
+In these extreme cases, it's possible to request that test failures be ignored
+for the sake of package migration.
+
+* Check out [`lp:~ubuntu-release/britney/hints-ubuntu`](https://git.launchpad.net/~ubuntu-release/britney/+git/hints-ubuntu)
+
+File an MP against it with a description indicating the Launchpad bug #, the rationale
+for why the test can and should be skipped, and an explanation of what will be
+unblocked in the migration.
+
+Reviewers should be `canonical-<your-team>` (e.g. `canonical-server-reporter`
+for Server team members), `ubuntu-release`, and any Archive Admins or
+Foundations team members you've discussed the issue with.

--- a/docs/how-ubuntu-is-made/processes/transitions.md
+++ b/docs/how-ubuntu-is-made/processes/transitions.md
@@ -100,7 +100,7 @@ The main complication you may run into during this phase are build failures. For
 example, upstream may have introduced some new dependencies not yet in the
 Ubuntu Archive. Resolving these issues can involve
 {ref}`MIRs <main-inclusion-review>`, pulling patches from upstream, and other
-{ref}`fix-a-bug` activities.
+{ref}`fix-a-bug-in-a-package` activities.
 
 
 (transitions-update-default-version)=

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ sphinx-hoverxref
 sphinx-prompt
 sphinxext-rediraffe
 sphinx-sitemap
+sphinx-togglebutton

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -16,3 +16,5 @@
 .. _Xubuntu: https://xubuntu.org/
 
 .. _DEP3Spec: https://dep-team.pages.debian.net/deps/dep3/
+
+.. _#devel:ubuntu.com: https://matrix.to/#/#devel:ubuntu.com

--- a/docs/who-makes-ubuntu/joining/membership-in-core-dev.md
+++ b/docs/who-makes-ubuntu/joining/membership-in-core-dev.md
@@ -34,7 +34,7 @@ processes to make sure you'll be fulfilling their requirements.
 
 In addition to understanding common tasks documented in this guide, including
 {ref}`Debian patching <work-with-debian-patches>`,
-{ref}`Stable Release Updates (SRUs) <fix-a-bug>`,
+{ref}`Stable Release Updates (SRUs) <fix-a-bug-in-a-package>`,
 and so on, Core Dev applicants must also have a good understanding of these
 advanced packaging skills, and ideally direct experience with a few of them:
 

--- a/docs/who-makes-ubuntu/joining/membership-in-packageset.md
+++ b/docs/who-makes-ubuntu/joining/membership-in-packageset.md
@@ -77,7 +77,7 @@ Ideally, you should have a solid mastery of the
 basic packaging skills for Debian/Ubuntu
 distributions, including the following:
 
-* {ref}`Fixing bugs in packages <fix-a-bug>`
+* {ref}`Fixing bugs in packages <fix-a-bug-in-a-package>`
 * Building binary packages from source, using `sbuild` or `debuild` in a
   `chroot` or `lxc` environment
 * Creating the initial packaging for new software


### PR DESCRIPTION
  * Lotsa edits, markup, formatting, language
  * Split into 'process' and 'howto' articles
  * Process article chunked into an 'article' series
  * Introduced series navig in all parts
  * 'Process' and 'Advanced tasks' landing pages updated
  * Added deps: articles (to-be-edited) on:
    - autopkgtests
    - backports (process expl.)
  * Misc. edits/renames/additions in other parts

@s-makin, please, have a look at the 'article series' navig. The rest (much editing and fixes still left to do) to follow.