### PR TITLE
Remove unsupported 'cron' syntax highlighting

### DIFF
--- a/docs/maintainers/AA/aa-archive-related-services.md
+++ b/docs/maintainers/AA/aa-archive-related-services.md
@@ -41,7 +41,7 @@ To disable auto-import, the usual procedure is to edit the
 `ubuntu-archive-toolbox` crontab to add a `--dry-run` parameter to the
 appropriate line, e.g.
 
-```cron
+```
 # Before
 0 5,11,17,23 * * *      PYTHONPATH=/home/ubuntu-archive/python auto-sync --log-directory ~/public_html/auto-sync --batch
 # After


### PR DESCRIPTION
Hi AA team,

A quick fix that removes unsupported `cron` syntax highlighting (that is causing a build warning).