### PR TITLE
Remove empty section

### DIFF
--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -69,15 +69,6 @@ Check accessibility <check-accessibility>
 ```
 
 
-## Testing
-
-```{toctree}
-:maxdepth: 1
-
-index-testing
-```
-
-
 ## New packages
 
 ```{toctree}


### PR DESCRIPTION
The "testing" section was replaced by "QA and testing", so this toctree points to a non-existing page which results in errors in local builds