### PR TITLE
Add contributor/role table

### DIFF
--- a/docs/who-makes-ubuntu/index-roles.md
+++ b/docs/who-makes-ubuntu/index-roles.md
@@ -1,42 +1,54 @@
 (roles-and-pathways)=
 # Roles and responsibilities
 
+There are many roles and teams that contribute to Ubuntu development. In general,
+the roles can be sorted according to the level of upload permissions (and
+associated responsibilities). This table summarizes various roles in order of
+increasing upload permissions. The three Archive handling teams have the same
+level of upload permissions, but different responsibilities. See the sections
+below the table for more information on the specific teams. 
 
-This section will allow us to split out explanation content specifically needed
-by the teams/roles to fulfill their tasks, new members to learn, and for
-prospective members to understand what the role entails
+```{raw} html
+<table border="1" style="border-collapse: collapse; text-align: center; width: 100%;">
+  <tr>
+    <td><strong>Contributors</strong></td>
+    <td style="text-align: left;" colspan="3"><strong>&nbsp;Anyone</strong><br>&nbsp;Report bugs, test fixes, suggest changes</td>
+  </tr>
+  <tr>
+    <!-- Row 2: start of merged col 1 -->
+    <td rowspan="3" style="vertical-align: middle;"><strong>Uploaders</strong></td>
+    <td style="text-align: left;" colspan="3"><strong>&nbsp;Core Dev</strong><br>&nbsp;Can upload to all packages, can make seed changes</td>
+  </tr>
+  <tr>
+    <td style="text-align: left;" colspan="3"><strong>&nbsp;MOTU</strong><br>&nbsp;Can upload to packages in universe and multiverse</td>
+  </tr>
+  <tr>
+    <td style="text-align: left;" colspan="3"><strong>&nbsp;Per-package / Package Set</strong><br>&nbsp;Can upload to single package(s) or sets of packages</td>
+  </tr>
+  <tr>
+    <!-- Row 1 -->
+    <td><strong>Archive<br>handling</strong></td>
+    <td><strong>Archive Admin</strong><br>Removals, license checks,<br>fix component mismatches, ...</td>
+    <td><strong>MIR member</strong><br>Gates entry to<br>packages in main<br></td>
+    <td><strong>SRU member</strong><br>Gates updates to stable<br>releases</td>
+  </tr>
+</table>
+```
 
-Each of these sections can have a team-specific landing page to act as a
-secondary layer of drop-down menus
-
-## Uploaders
+## Ubuntu uploaders
 
 ```{toctree}
 :maxdepth: 1
 
-about-roles/index-uploaders
+About uploader roles <about-roles/index-uploaders>
 ```
 
-## MIR membership
-
-```{toctree}
-:maxdepth: 1
-
-about-roles/index-MIR
-```
-
-## SRU membership
-
-```{toctree}
-:maxdepth: 1
-
-about-roles/index-SRU
-```
-
-## Archive Admins
+## Archive handling
 
 ```{toctree}
 :maxdepth: 1
 
 about-roles/archive-administration
+about-roles/index-MIR
+about-roles/index-SRU
 ```


### PR DESCRIPTION
### Description

@cpaelzer once helpfully explained to me (with the help of a diagram) the hierarchy of roles in terms of their level of upload rights. I found it useful to visualize how the roles are sorted, and have added it here as a table.

I did try and create a Mermaid diagram to represent the information, but I couldn't get it to look as neat as the table format.

Once we are ready to move the DMB content (which has far more information about the various roles) I will also add crosslinking and any roles that are missing from the table.


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

