### PR TITLE
Release Team doc review

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -430,18 +430,6 @@ Core Dev
 Cryptographic Signature
     *Work in Progress*
 
-Current Release in Development
-    {term}`Ubuntu` follows a strict time-based release cycle. Every six months a
-    new Ubuntu version is released.
-
-    The "Current Release in Development" is the Ubuntu version in development
-    for the next release at any given time. It is also often referred
-    to as "devel".
-
-    Disambiguation: The acronym CRD could also refer to {term}`Coordinated Release Date`
-    See also:
-    * [Ubuntu Releases (explanation)](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/explanation/releases/)
-
 Debian
     **Debian** is a widely-used community-driven
     {term}`Free and Open Source <Free and Open Source Software>`
@@ -492,7 +480,17 @@ Detached Signature
     or entity. 
 
 Devel
-    Shorthand term for the {term}`Current Release in Development`.
+Current Release in Development
+    {term}`Ubuntu` follows a strict time-based release cycle. Every six months a
+    new Ubuntu version is released.
+
+    The "Current Release in Development" is the Ubuntu version in development
+    for the next release at any given time. It is also often referred
+    to as "devel".
+
+    Disambiguation: The acronym CRD could also refer to {term}`Coordinated Release Date`
+    See also:
+    * {ref}`Ubuntu Releases (explanation) <ubuntu-releases>`
 
 DMB
 Developer Membership Board

--- a/docs/how-ubuntu-is-made/concepts/package-archive.rst
+++ b/docs/how-ubuntu-is-made/concepts/package-archive.rst
@@ -183,7 +183,7 @@ The packages of an Ubuntu series are categorized according to whether they are :
 | **Community packages**     | :ref:`archive-components-universe` | :ref:`archive-components-multiverse` |
 +----------------------------+------------------------------------+--------------------------------------+
 
-:term:`Canonical` maintains the base packages and provides security updates. See :ref:`release-lifespan` for more information about the official support provided by Canonical.
+:term:`Canonical` maintains the base packages and provides security updates. See :ref:`ubuntu-releases` for more information about the official support provided by Canonical.
 
 For example, if you look into any of the :ref:`archive-pockets` of the ``devel`` series (|devel-release|_, |devel-updates|_, |devel-security|_, |devel-proposed|_, |devel-backports|_) you see the four components (main, restricted, universe, multiverse) as directories.
 

--- a/docs/how-ubuntu-is-made/processes/proposed-migration/index.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/index.md
@@ -39,7 +39,7 @@ Issue types:
 
 1. The `*source.changes` file uploaded.
 
-1. If the fix is an {term}`SRU`, or if the release cycle is in a {ref}`feature-freeze-ff`:
+1. If the fix is an {term}`SRU`, or if the release cycle is in a {ref}`feature-freeze`:
 
    * Upload goes into the `unapproved` queue.
    * The SRU team reviews and approves the upload (go to 4).

--- a/docs/release-team/freezes.md
+++ b/docs/release-team/freezes.md
@@ -1,63 +1,69 @@
 (freezes)=
 # Freezes
 
-This article provides an overview of the stabilization milestones that lead to
-the release of a new version of Ubuntu. The series of milestones (freezes) means
+This article provides an overview of the stabilization freezes that lead to
+the release of a new version of Ubuntu. The series of freezes means
 the gradual introduction of restrictions on modifications in certain areas, so
 that the distribution can stabilize as it nears the final release.
 
 See {ref}`release-cycle` for an overview of the entire release process.
 
 
-(testing-weeks)=
-## Testing weeks
-
-During a release's development phase, the {ref}`release-team` organizes testing
-weeks to focus the Ubuntu community's efforts on testing Ubuntu's latest daily
-{term}`ISO images <Image>` and its {term}`flavors <Ubuntu flavors>`. These weeks
-are crucial for discovering bugs and getting early feedback about new features.
-
-```{note}
-The testing weeks replaced the older practice of alpha and beta milestones. For
-example, Ubuntu 14.04 LTS (Trusty Tahr) had Alpha 1, Alpha 2, Beta 1, and Beta 2
-milestones.
-
-See [the email](https://lists.ubuntu.com/archives/ubuntu-release/2018-April/004434.html)
-that announced the process change.
-```
-
 (debian-import-freeze)=
 ## Debian Import Freeze
 
-Archive Admins disable the automatic import of new packages and versions of
-existing packages from Debian. The import of a new package or version of an
-existing package from Debian needs to be requested.
+**Prior** to the Debian Import Freeze date, new versions of packages are
+automatically imported from Debian's `unstable` branch (where they have not been
+customized for Ubuntu). Entirely new packages (those not in Ubuntu at all) are
+also automatically imported.
+
+The import is done by copying the source package verbatim from Debian and
+building fresh binary packages on the Ubuntu autobuilders.
+
+**After** the Debian Import Freeze date, the Release Team disables the
+automatic import of new packages and versions from Debian. The import of a new
+package (or package version) from Debian after the Debian Import Freeze must be
+explicitly requested by a developer.
+
+If the package needs to be modified for Ubuntu, or is not in Debian, then a
+developer can still upload it directly.
+
+```{admonition} Historical note
+:class: tip
+For some LTS release (12.04 and lower) imports were done from `testing`, but
+since the introduction of {ref}`proposed-migration`, syncs happen from
+`unstable` all the time. 
+```
+
+
+(feature-freeze)=
+## Feature Freeze
+
+During Feature Freeze (FF), Ubuntu developers stop introducing new features,
+packages, and {term}`API`/{term}`ABI` changes, and instead concentrate on fixing
+bugs in the current release in development (`devel`).
+
+It is possible to apply for {ref}`exceptions <freeze-exceptions>` under some
+circumstances -- such exceptions must be approved by the Ubuntu Release Team.
 
 ```{note}
 The general development activity is still unrestricted until the Feature Freeze;
 however, the Feature Freeze is often scheduled for the same day.
 ```
 
-(feature-freeze-ff)=
-## Feature Freeze (FF)
 
-At this point, Ubuntu developers should stop introducing new features, packages,
-and {term}`API`/{term}`ABI` changes, and instead concentrate on fixing bugs in
-the current release in development.
-
-
-(user-interface-freeze-uif)=
-## User Interface Freeze (UIF)
+(user-interface-freeze)=
+## User Interface Freeze
 
 The user interface (UI) should be finalized to allow documentation writers and
 translators to work on a consistent target that doesn't render screenshots or
 documentation obsolete.
 
-After the User Interface Freeze, the following things are not allowed to change
-without a {ref}`freeze exception <freeze-exceptions>`:
+After the User Interface Freeze (UIF), the following things are not allowed to
+change without a {ref}`freeze exception <freeze-exceptions>`:
 
 * User Interface of individual applications installed by default
-* Appearance of the desktop
+* Appearance of the Desktop
 * Distribution-specific artwork
 * All user-visible strings in the Desktop and applications installed by default
 
@@ -65,11 +71,22 @@ without a {ref}`freeze exception <freeze-exceptions>`:
 (documentation-string-freeze)=
 ## Documentation String Freeze
 
-Documentation strings should no longer be created or modified. This freeze
-ensures the documentation can be accurately translated.
+At this point, documentation strings should no longer be created or changed.
+This freeze ensures the documentation can be accurately translated.
 
 Exceptions to this rule may be considered before the release for significant and
 glaring errors or exceptional circumstances.
+
+A string change must be discussed (and approved) on the
+[`ubuntu-doc` mailing list](mailto:ubuntu-doc@lists.ubuntu.com). If a string is
+changed after the freeze, it must be communicated to the translators (by writing
+to the `ubuntu-translators` mailing list) *with enough time to update the
+translations before the
+{ref}`translation freeze <non-language-pack-translation-deadline>`*.
+
+After release, any fixes must comply with the {ref}`stable-release-updates`
+process, and where necessary must be accompanied by translations before
+uploading. 
 
 
 (kernel-feature-freeze)=
@@ -80,18 +97,19 @@ can be considered feature-complete for the release. From now on, only bug-fix
 changes are expected.
 
 ```{note}
-The Kernel Feature Freeze occurs after the {ref}`feature-freeze-ff` because the
+The Kernel Feature Freeze occurs after the {ref}`feature-freeze` because the
 Linux Kernel is typically released upstream after the Feature Freeze.
 Additionally, the Kernel Feature Freeze is deliberately scheduled so that the
 Beta images have a fully featured kernel suitable for testing.
 ```
+
 
 (hardware-enablement-freeze)=
 ## Hardware Enablement Freeze
 
 All new hardware enablement tasks for devices targeting the given release should
 be finished, and all the respective packages should be in the Ubuntu Package
-Archive. The release team no longer accepts changes in the Ubuntu Package
+Archive. The Release Team no longer accepts changes in the Ubuntu Package
 Archive related to supporting new image types or platforms. This freeze ensures
 that any new platforms are already available for testing of the beta images and
 in the weeks leading to the {ref}`final-freeze`.
@@ -105,22 +123,26 @@ Freeze.
 ## Beta Freeze
 
 In preparation for the beta release, all uploads are queued and subject to
-manual approval by the release team. Changes to packages that affect beta
-release images (flavours included) require the release team's approval before
-uploading. Uploads for packages that do not affect images are generally accepted
-as time permits.
+manual approval by the Release Team.
+
+**Before** Beta Freeze, all uploads enter the Archive without any approval.
+
+**After** the Beta Freeze date, any changes to packages that will affect beta
+release images (i.e. seeded packages) require the Release Team's approval
+because they've entered the unapproved queue after uploading.
+
+Uploads for packages that do *not* affect beta release images (un-seeded
+packages) will still be auto-accepted until {ref}`final-freeze`.
 
 ```{tip}
 Use the {manpage}`seeded-in-ubuntu(1)` tool, provided by the `ubuntu-dev-tools`
 package, to list all current daily images containing a specified package or to
-determine whether the specified package is part of the supported seed.
-
-If the list output is empty, uploading it during a freeze should be safe.
+determine whether the specified package is seeded or not.
 ```
 
-The freeze allows Archive Admins to fix package inconsistencies or critical bugs
-quickly and in an isolated manner. Once the beta release is shipped, the Beta
-Freeze restrictions no longer apply.
+This freeze allows the Release Team to fix package inconsistencies or critical
+bugs quickly and in an isolated manner. Once the beta release is shipped, we
+roll back to {ref}`feature-freeze` and {ref}`user-interface-freeze` status.
 
 
 (kernel-freeze)=
@@ -130,7 +152,7 @@ The Kernel Freeze is the final date for kernel updates because they require
 several lockstep actions that must be folded into the image-building process.
 
 Exceptional circumstances may justify exemptions to the freeze at the discretion
-of the release managers.
+of the Release Team.
 
 
 (non-language-pack-translation-deadline)=
@@ -141,12 +163,26 @@ mechanism. Because these items require more disruptive integration work, they
 are subject to an earlier deadline to give developers time to manually export
 translations from Launchpad and integrate them into the package.
 
-This marks the date after which translations for such packages are not
+This deadline marks the date after which translations for such packages are not
 guaranteed to be included in the final release. Depending on the package and its
 maintainers' workflow, they may be exported later.
 
+```{note}
+The [wiki page](https://wiki.ubuntu.com/NonLanguagePackTranslationDeadline)
+lists the packages this affects: do we want to include this?
+```
+
 Other packages can still be translated until the
 {ref}`language-pack-translation-deadline`.
+
+
+(language-pack-translation-deadline)=
+## Language pack translation deadline
+
+Translations done up until this date are included in the final release's
+language packs. See the
+[language pack creation schedule](https://dev.launchpad.net/Translations/LanguagePackSchedule)
+for more.
 
 
 (final-freeze)=
@@ -155,19 +191,20 @@ Other packages can still be translated until the
 This freeze marks an **extremely** high-caution period until the
 {ref}`final-release`. Only bug fixes for release-critical, security-critical or
 otherwise "exceptional circumstance" bugs are included in the Final Release,
-which the release team and relevant section teams must confirm.
+which the Release Team and (and the relevant team looking after the package)
+must confirm.
 
 
 ### Unseeded packages
 
 Packages in {ref}`archive-components-universe` that aren't seeded in any of the
-Ubuntu flavours remain in {ref}`feature-freeze-ff` because they do not affect
+Ubuntu flavours remain in {ref}`feature-freeze` because they do not affect
 the release; however, when the Ubuntu Package Archive is frozen, fixes must be
-manually reviewed and accepted by the release team members.
+manually reviewed and accepted by the Release Team members.
 
-When the Final Release is close (~1.5 days out), developers should consider
+When the Final Release is close (~2 days out), developers should consider
 uploading to the {ref}`-proposed pocket <archive-pockets-proposed>`, from which
-the release team cherry-picks into the
+the Release Team cherry-picks into the
 {ref}`-release pocket <archive-pockets-release>` if circumstances allow. All
 packages uploaded to the `-proposed` pocket that do not make it into the
 `-release` pocket until the Final Release become candidates for
@@ -176,30 +213,20 @@ during Final Freeze should meet the requirements of Stable Release Updates if
 the upload is not accepted into the `-release` pocket. In particular, the upload
 must reference at least one bug, which is used to track the stable update.
 
-```{note}
-If you are sure that your upload will be accepted during Final Freeze, you can
-upload directly to the `-release` pocket, but be aware that you must re-upload
-after Final Release if the upload is rejected.
-```
-
 
 (release-candidate)=
 ## Release Candidate
 
-The images produced during the week before the {ref}`final-release` are
-considered "release candidates". In an ideal world, the first release candidate
-would end up being the Final Release; however, we don't live in a perfect world,
-and this week is used to get rid of the last release-critical bugs and do as
-much testing as possible. Until the Final Release, changes are only permitted at
-the release team's discretion and will only be allowed for high-priority bugs
-that might justify delaying the release.
+The images produced during the monday of the release week before
+{ref}`final-release` are considered "release candidates".
 
+In an ideal world, the first release candidate would end up being the Final
+Release; however, we don't live in a perfect world, and this week is used to
+get rid of the last release-critical bugs and do as much testing as possible.
 
-(language-pack-translation-deadline)=
-## Language pack translation deadline
-
-Translations done up until this date are included in the final release's
-language packs.
+Until the Final Release, changes are only permitted at the Release Team's
+discretion and will only be allowed for high-priority bugs that might justify
+delaying the release.
 
 
 ## Further reading

--- a/docs/release-team/freezes.md
+++ b/docs/release-team/freezes.md
@@ -132,7 +132,8 @@ release images (i.e. seeded packages) require the Release Team's approval
 because they've entered the unapproved queue after uploading.
 
 Uploads for packages that do *not* affect beta release images (un-seeded
-packages) will still be auto-accepted until {ref}`final-freeze`.
+packages) will still be auto-accepted until {ref}`final-freeze`. So be
+careful with what you upload.
 
 ```{tip}
 Use the {manpage}`seeded-in-ubuntu(1)` tool, provided by the `ubuntu-dev-tools`
@@ -217,7 +218,7 @@ must reference at least one bug, which is used to track the stable update.
 (release-candidate)=
 ## Release Candidate
 
-The images produced during the monday of the release week before
+The images produced on the Monday of the release week before
 {ref}`final-release` are considered "release candidates".
 
 In an ideal world, the first release candidate would end up being the Final

--- a/docs/release-team/release-cycle.md
+++ b/docs/release-team/release-cycle.md
@@ -54,8 +54,8 @@ The automatic import of new package versions from Debian ends at the
 {ref}`debian-import-freeze`.
 
 
-(release-snapshots)=
-## Snapshots
+(monthly-snapshots)=
+## Monthly Snapshots
 
 During a release's development phase, the
 {ref}`Canonical Release Management team <release-team>` organizes

--- a/docs/release-team/release-cycle.md
+++ b/docs/release-team/release-cycle.md
@@ -54,7 +54,17 @@ The automatic import of new package versions from Debian ends at the
 {ref}`debian-import-freeze`.
 
 
-## Stabilization and milestones (freezes)
+(release-snapshots)=
+## Snapshots
+
+During a release's development phase, the
+{ref}`Canonical Release Management team <release-team>` organizes
+[monthly snapshot releases](https://discourse.ubuntu.com/t/supercharging-ubuntu-releases-monthly-snapshots-automation/61876). These releases are not intended to
+be used in production, but rather are curated, testable milestones that can be
+used to detect failure modes during the development cycle.
+
+
+## Stabilization and freezes
 
 Developers should increasingly exercise caution in making changes to Ubuntu to
 ensure a stable state is reached in time for the final release date. Archive
@@ -63,7 +73,7 @@ effectively freezing it. The milestones when these restrictions get enabled are
 called "freezes".
 
 During freezes, developers must request {ref}`freeze-exceptions` to approve
-changes (see also {ref}`request-a-freeze-exception`). The release team posts the
+changes (see also {ref}`request-a-freeze-exception`). The Release Team posts the
 current Release Schedule as a Discourse article under the
 ["Release" topic](https://discourse.ubuntu.com/c/project/release). It shows the
 typical order and length of the various freezes.
@@ -87,7 +97,7 @@ Updates.
 (final-release)=
 ## Final Release
 
-Once the release team declares the {ref}`release-candidate` ISO stable and names
+Once the Release Team declares the {ref}`release-candidate` ISO stable and names
 it the "Final Release", a representative of the team announces it on the
 [`ubuntu-announce` mailing list](https://lists.ubuntu.com/archives/ubuntu-announce/).
 

--- a/docs/release-team/ubuntu-releases.md
+++ b/docs/release-team/ubuntu-releases.md
@@ -3,22 +3,31 @@
 
 ## Release cadence
 
-{term}`Ubuntu` follows a strict time-based release cycle. Every six months
-since 2004, {term}`Canonical` publishes a new Ubuntu version and its set of
+Ubuntu follows a strict time-based release cycle. Every six months since 2004,
+Canonical publishes a new Ubuntu version ({term}`series`) and its set of
 {term}`packages <Package>` are declared stable (production-quality).
+
 Simultaneously, a new version begins development; it is given its own
-{term}`Code name`, but also referred to as the
-"{term}`Current Release in Development`" or "{term}`Devel`".
+{term}`Code name`, but is also referred to as the "Current Release in
+Development" or "{term}`Devel`" for short.
+
+Every Ubuntu series receives the same production-grade support quality,
+but different types of release receive support for different lengths of time.
 
 
 (lts-releases)=
 ### LTS releases
 
 Since 2006, every fourth release, made every two years in April, receives
-{ref}`long-term-support-lts`. This is the origin of the term {term}`LTS` for
-stable, maintained releases.
+Long Term Support ({term}`LTS`). An estimated 95% of all Ubuntu installations
+are LTS releases.
 
-An estimated 95% of all Ubuntu installations are LTS releases.
+LTS releases receive five years of standard security maintenance for all
+packages in the `main` {ref}`component <archive-components>`. An
+[Ubuntu Pro](https://ubuntu.com/pro) subscription provides access to
+[Expanded Security Maintenance](https://ubuntu.com/security/esm) (ESM),
+which includes security fixes for packages in the `universe` component,
+and covers both `main` and `universe` beyond the five years of standard support.
 
 ```{note}
 Due to the strict time-based six-monthly release cycle, LTS releases only happen
@@ -26,17 +35,18 @@ in even-numbered years (e.g. `20`, `22`, `24`) in April (`04`). The only
 exception to this rule was Ubuntu 6.06 LTS (Dapper Drake).
 ```
 
+
 (point-releases)=
 ### Point releases
 
-To ensure that a fresh install of an {ref}`lts-releases` works on newer hardware
-and does not require a big download of additional updates, Canonical publishes
-**point releases** that include all the updates made so far.
+To ensure that a fresh install of an {ref}`LTS release <lts-releases>` works on
+newer hardware and does not require a large download of additional updates,
+Canonical publishes **point releases** that include all the updates made so far.
 
 The first point release of an LTS is published three months after the initial
-release, and repeated every six months at least until the next LTS is published.
-In practice, Canonical may publish even more point releases for an LTS series,
-depending on the popularity of that LTS series.
+release, and repeated approximately every six months at least until the next LTS
+is published. In practice, Canonical may publish even more point releases for an
+LTS series, if it turns out to be popular.
 
 For example, the Ubuntu 16.04.7 LTS (Xenial Xerus) point release was published
 more than four years after the initial release of Ubuntu 16.04 LTS.
@@ -53,6 +63,10 @@ access to newer {term}`kernels <Kernel>` and newer libraries. They are often
 used inside rapid DevOps processes like {term}`CI`/{term}`CD` pipelines where
 the lifespan of an artifact is likely to be shorter than the support period of
 the interim release.
+
+Interim releases are production-quality and supported for nine months, with
+enough time provided for users to update -- but these releases do not receive
+the long-term commitment of LTS releases.
 
 
 ### Why does Ubuntu use time-based releases?
@@ -86,54 +100,18 @@ components, which are:
   assumed.
 
 `LTS`
-: Any Ubuntu release that receives long term support is marked with `LTS` (see
-  the {ref}`release-lifespan` section for more information).
+: Any Ubuntu release that receives Long Term Support is marked with `LTS`.
 
   Any Ubuntu release that does not receive long term support omits this
   component.
 
 
-### Examples
-
-| Version ID    | Release date     | Support   | End of Standard Support | End of Life   |
-| :---          | :---             | :---      | :---                    | :---          |
-| `22.04 LTS`   | 21 April 2022    | Long term | April 2027              | April 2032    |
-| `22.04.1 LTS` | 11 August 2022   | Long term | April 2027              | April 2032    |
-| `22.10`       | 22 October 2022  | Regular   | July 2023               | July 2023     |
-| `22.04.2 LTS` | 13 February 2023 | Long term | April 2027              | April 2032    |
-| `23.04`       | 20 April 2022    | Regular   | January 2024            | January 2024  |
-
-
-
-(release-lifespan)=
-## Release lifespan
-
-Every Ubuntu {term}`series` receives the same production-grade support quality,
-but the length of time for which an Ubuntu series receives support varies.
-
-
-(regular-support)=
-### Regular support
-
-{ref}`interim-releases` are production-quality releases and are supported for
-nine months, with sufficient time provided for users to update, but these
-releases do not receive the long-term commitment of LTS releases.
-
-
-(long-term-support-lts)=
-### Long Term Support (LTS)
-
-LTS releases receive five years of standard security maintenance for all
-packages in the {term}`main` {term}`component`. With an {term}`Ubuntu Pro`
-subscription, you get access to {term}`Expanded Security Maintenance` (ESM),
-covering security fixes for packages in the {term}`universe` {term}`component`.
-ESM also extends the lifetime of an LTS series from five years to ten years.
+A full list of all the current releases, their codenames, release notes, and
+supported lifetimes can be found on the {ref}`available releases <releases>`
+page.
 
 
 ## Editions
-
-Every Ubuntu release is provided as both a {term}`Server <Ubuntu Server>` and
-{term}`Desktop <Ubuntu Desktop>` edition.
 
 Ubuntu Desktop provides a Graphical User Interface ({term}`GUI`) for everyday
 computing tasks, making it suitable for personal computers and laptops.
@@ -146,11 +124,15 @@ Additionally, each release of Ubuntu is available in minimal configurations,
 which have the fewest possible packages installed: available in the installer
 for Ubuntu Server, Ubuntu Desktop, and as separate cloud images.
 
-Canonical publishes Ubuntu on all major public clouds, and the latest
-{term}`image` for each LTS version will always include any security updates
-provided since the LTS release date, until two weeks prior to the image creation
-date.
+Canonical publishes Ubuntu on all major public clouds, and the
+[latest image](https://cloud-images.ubuntu.com/) for each LTS version will
+always include any security updates provided since the LTS release date, until
+two weeks prior to the image creation date.
 
+```{note}
+TODO: add WSL images to this section
+```
+ 
 
 ## Ubuntu flavors
 


### PR DESCRIPTION
### Description

Updated the `ubuntu-releases.md` and `freezes.md` pages following Release Team review with @utkarsh2102.
Following this, we will be able to begin redirecting most of the corresponding wiki pages.

During this work, noticed an opportunity for consolidation in the glossary, and updated some headers/anchors for brevity.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected


