### PR TITLE
Fix "path to upload rights" diagram

### DIFF
--- a/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
+++ b/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
@@ -4,47 +4,159 @@
 ```{note}
 The links shown on this page are subject to sudden changes over the next
 few months as more of the documentation it refers to is migrated here. Please
-expect inconsistencies -- and feel welcome to correct any links you believe are
-incorrect.
+expect inconsistencies -- and feel welcome to correct any links you find that
+are incorrect.
 ```
 
-This interactive chart shows the skills needed to obtain permissions for
-uploading changes to the Ubuntu Package Archive. It can be used as a guide
+These interactive charts show the skills needed to obtain permissions for
+uploading changes to the Ubuntu Package Archive. They can be used as a guide
 to help build your applications for upload rights on:
 
 * {ref}`Package Sets <membership-in-packageset>`
 * {ref}`MOTU <membership-in-motu>`, 
 * {ref}`Core Developer <membership-in-core-dev>`
 
+
+## The overall journey
+
+Since Ubuntu is based on Debian, they share a similar technical skillset. This
+means that as a contributor, you may want to contribute to Debian as well as
+Ubuntu, or just focus on one (as you prefer).
+
+This diagram shows the overall expected progression paths you can take as a
+contributor. Click any of the nodes to learn more.
+
+
+:::{mermaid}
+block-beta
+  columns 8
+
+%% Column 1
+  block:col1
+  columns 1
+    space:3
+    Start(("Start"))
+    space
+  end
+
+%% Column 2
+  block:col2
+  columns 1
+    space
+    space
+    Ubuntu{{"<b>Ubuntu<br>path</br>"}}
+    space
+    Debian{{"<b>Debian<br>path</b>"}}
+  end
+
+  Start --> Ubuntu
+  Start --> Debian
+
+%% Column 3
+  block:col3
+  columns 1
+    UploadRights{{"<b>Upload<br>rights</b>"}}
+    space
+    Basics("<a href='#upload-path-basics'>Basics</a>")
+    space
+    Contributor("<a href="https://www.debian.org/doc/manuals/maint-guide/">Contributor</a>")
+  end
+
+%% Column 4
+  block:col4
+  columns 1
+    PPU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PPU<br>PackageSet</a>"]
+    space
+    Intermediate("<a href='#upload-path-intermediate'>Intermediate</a>")
+    space
+    Maintainer("<a href='https://wiki.debian.org/DebianMaintainer'>Maintainer</a>")
+  end
+
+%% Column 5
+  block:col5
+  columns 1
+    MOTU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-MOTU/'>MOTU</a>"]
+    space
+    Advanced("<a href='#upload-path-advanced'>Advanced</a>")
+    space
+    Developer("<a href='https://wiki.debian.org/DebianDeveloper'>Developer</a>")
+  end
+
+%% Column 6
+  block:col6
+  columns 1
+    CoreDev["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-core-dev/'>Core Dev</a>"]
+    space
+    Expert("<a href='#upload-path-expert'>Expert</a>")
+    space:2
+  end
+
+%% Connections
+Basics --> Intermediate
+Intermediate --> Advanced
+Intermediate --> PPU
+Advanced --> Expert
+Advanced --> MOTU
+Expert --> CoreDev
+
+Contributor --> Maintainer
+Maintainer --> Developer
+
+%% Styling
+classDef debianStyle fill: #F8A3C0, stroke: #DD1155
+  class Debian debianStyle
+  class Contributor debianStyle
+  class Maintainer debianStyle
+  class Developer debianStyle
+
+classDef ubuntuStyle fill: #FFDAB9, stroke: #E95420,stroke-width:1px;
+  class Ubuntu ubuntuStyle
+  class Basics ubuntuStyle
+  class Intermediate ubuntuStyle
+  class Advanced ubuntuStyle
+  class Expert ubuntuStyle
+
+classDef uploaderStyle fill: #FFDF7E, stroke: #FBAB13
+  class UploadRights uploaderStyle
+  class PPU uploaderStyle
+  class MOTU uploaderStyle
+  class CoreDev uploaderStyle
+
+classDef invisible fill: transparent, stroke: transparent
+  class col1,col2,col3,col4,col5,col6 invisible
+:::
+
+
 (upload-path-basics)=
 ## Basics
 
-These topics will get you started with a good foundation for your future work.
+These topics will get you started with a good foundation for your future
+contributions to Ubuntu.
 
-```{mermaid}
+:::{mermaid}
 block-beta
 columns 2
-    block
-        InitialStudies("Initial studies")
-        columns 1
-        Concepts{{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook>Concepts</a>"}}
-        GitUbuntu{{"git-ubuntu"}}
-        DebianPolicy{{"<a href=https://www.debian.org/doc/debian-policy/>Debian Policy</a>"}}
-    end
+  block
+    InitialStudies("Initial studies")
+    columns 1
+    Concepts{{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook>Concepts</a>"}}
+    GitUbuntu{{"git-ubuntu"}}
+    DebianPolicy{{"<a href=https://www.debian.org/doc/debian-policy/>Debian Policy</a>"}}
+  end
 
-    block
-        InitialTasks("Initial tasks")
-        columns 1
-        BugTriage["Bug triage"]
-        BiteSizedBugs["Bite-sized bugs"]
-        TrivialPackgeMerges["Trivial package merges"]
-    end
+  block
+    InitialTasks("Initial tasks")
+    columns 1
+    BugTriage["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/bug-triage/'>Bug triage</a>"]
+    BiteSizedBugs["Bite-sized bugs"]
+    TrivialPackgeMerges["Trivial package merges"]
+  end
 
-    InitialStudies --> InitialTasks
+  InitialStudies --> InitialTasks
 
-    style InitialStudies fill: #FFDAB9, stroke:#F4A460
-    style InitialTasks fill:#FFDAB9, stroke:#F4A460
-```
+  style InitialStudies fill: #FFDAB9, stroke:#F4A460
+  style InitialTasks fill:#FFDAB9, stroke:#F4A460
+:::
 
 Once your team and/or mentor says you are ready for more, you can move onto the
 intermediate tasks.
@@ -53,8 +165,8 @@ intermediate tasks.
 (upload-path-intermediate)=
 ## Intermediate
 
-This set of topics and tasks will prepare you to apply for single-package or
-package set uploads.
+This set of topics and tasks will prepare you to apply for single-package (PPU)
+or Package Set upload rights.
 
 ```{mermaid}
 block-beta
@@ -66,6 +178,7 @@ block-beta
         UnderstandDep8{{"<a href=https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>Understand DEP8</a>"}}
         ComplexPackageMerges{{"Complex package merges"}}
         SRU{{"<a href=https://canonical-sru-docs.readthedocs-hosted.com/>Study SRU</a>"}}
+        BlockA{{" "}}
     end
    
     block
@@ -74,6 +187,7 @@ block-beta
         AddAUTOPKGTESTS["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/bug-fix/package-tests/>Add Autopkgtest</a>"]
         ProposeMigration["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/how-ubuntu-is-made/processes/proposed-migration/>Proposed Migration</a>"]
         DoSRUS["Do SRUS"]
+        WorkOnBugs["Work on packaging bugs/features"]
     end
     
     %% Transitions
@@ -81,13 +195,17 @@ block-beta
     ComplexPackageMerges --> ProposeMigration
     SRU --> DoSRUS
 
-    style IntermediateStudies fill: #FFDAB9, stroke:#F4A460
-    style IntermediateTasks fill:#FFDAB9, stroke:#F4A460
+    style IntermediateStudies fill: #FFDAB9, stroke:#F4A460;
+    style IntermediateTasks fill:#FFDAB9, stroke:#F4A460;
+    style BlockA fill:transparent,stroke:transparent;
 ```
 
 Once you have done enough of these tasks that your team/mentor says you are
-ready to move onto the Advanced topics, you should be ready to apply for PPU
-or Package Set. 
+ready to continue your journey, you can move onto the Advanced topics.
+
+At this time, you can also consider yourself ready to apply for PPU or
+Package Set upload rights if there are particular packages or sets of packages
+you are particularly focused on. 
 
 
 (upload-path-advanced)=
@@ -130,29 +248,18 @@ block-beta
 
 ```
 
+With enough of these tasks under your belt to demonstrate your skills and
+experience, you can move onto the Expert topics.
 
-### (Optional) Activities in Debian
-
-At this point, while you are applying for MOTU, you may also want to branch out
-and contribute more to Debian.
-
-```{mermaid}
-flowchart LR
-    Contribute(("<a href=https://www.debian.org/doc/manuals/maint-guide/>Contribute</a>"))
-    DM[["<a href=https://wiki.debian.org/DebianMaintainer>Debian Maintainer</a>"]]
-    DD[["<a href=https://wiki.debian.org/DebianDeveloper>Debian Developer</a>"]]
-
-    Contribute --> DM
-    DM --> DD
-```
+At this point, you can consider yourself ready to apply for MOTU.
 
 
 (upload-path-expert)=
 ## Expert 
 
-Once you are a member of MOTU, the following tasks and topics will guide you
-towards becoming a Core Developer. Keep doing enough of these tasks until you
-have the experience you need to apply for Core Dev.
+As a member of MOTU, the following tasks and topics will guide you towards
+becoming a Core Developer. Keep doing enough of these tasks until you have the
+experience you need to apply for Core Dev.
 
 ```{mermaid}
 block-beta

--- a/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
+++ b/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
@@ -3,134 +3,157 @@
 
 This interactive chart shows the skills needed to obtain permissions for
 uploading changes to the Ubuntu Package Archive. It can be used as a guide
-to help build your application for upload rights on:
+to help build your applications for upload rights on:
 
 * Package Sets
 * [MOTU](https://wiki.ubuntu.com/MOTU), 
 * [Core Developer](https://wiki.ubuntu.com/UbuntuDevelopers#Ubuntu_Core_Developers) 
 
 
+## Basics
+
+These topics will get you started with a good foundation for your future work.
+
 ```{mermaid}
 %% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
 %%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
 flowchart TD
+    direction TB
+    subgraph InitialStudies["Topics for study"]
+        direction BT
+        Concepts{{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook>Concepts</a>"}}
+        Git-Ubuntu{{"git-ubuntu"}}
+        Debian-Policy{{"<a href=https://www.debian.org/doc/debian-policy/>Debian Policy</a>"}}
+    end
 
-    Start((" ")):::Invisible
-    Start --> |"Path to Distro Contribution"| Basics
-
-    subgraph Basics
-        direction TB
-        subgraph InitialStudies["Initial Studies"]
-            direction BT
-            %% Concepts{{"Concepts"}}
-            Concepts{{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook>Concepts</a>"}}:::study
-            Git-Ubuntu{{"Git-Ubuntu"}}:::study
-            Debian-Policy{{"<a href=https://www.debian.org/doc/debian-policy/>Debian Policy</a>"}}:::study
-        end
-        subgraph InitialTasks["Initial Tasks"]
-            direction BT
-            BiteSizedBugs((Bite Sized Bugs)):::task
-            TrivialPackgeMerges(("Trivial Package Merges")):::task
-        end
+    subgraph InitialTasks["Initial tasks"]
+        direction BT
+        BiteSizedBugs["Bite-sized bugs"]
+        TrivialPackgeMerges["Trivial package merges"]
     end
 
     InitialStudies --> InitialTasks
+```
 
-    BasicsToIntermediate{"Team/Mentor Says ready for more"}:::concept
+Once your team and/or mentor says you are ready for more, you can move onto the
+intermediate tasks.
 
-    Basics --> BasicsToIntermediate --> Intermediate
-    subgraph Intermediate
+
+## Intermediate
+
+This set of topics and tasks will prepare you to apply for single-package or
+package set uploads.
+
+```{mermaid}
+%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
+%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
+flowchart TD
+    direction TB
+    subgraph IntermediateStudies[" "]
+        direction BT
+        UnderstandDep8{{"<a href=https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>Understand DEP8</a>"}}
+        ComplexPackageMerges{{"Complex package merges"}}
+        SRU{{"<a href=https://canonical-sru-docs.readthedocs-hosted.com/>Study SRU</a>"}}
+
+    end
+    
+    subgraph IntermediateTasks[" "]
+        AddAUTOPKGTESTS["<a href=https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/PackageTests.md>Add Autopkgtest</a>"]
+        ProposeMigration["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/how-ubuntu-is-made/processes/proposed-migration/>Proposed Migration</a>"]
+        DoSRUS["Do SRUS"]
+    end
+    
+    %% Transitions
+    UnderstandDep8 --> AddAUTOPKGTESTS
+    ComplexPackageMerges --> ProposeMigration
+    SRU --> DoSRUS
+```
+
+Once you have done enough of these tasks that your team/mentor says you are
+ready to move onto the Advanced topics, you should be ready to apply for PPU
+or Package Set. 
+
+
+## Advanced
+
+```{mermaid}
+%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
+%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
+flowchart TD
+    subgraph AdvancedStudies[" "]
         direction TB
-        subgraph IntermediateTasks[Intermediate Tasks]
-            direction TB
-            %% States
-            ComplexPackageMerges(("Complex Package Merges")):::task
-            ProposeMigration(("<a href=https://wiki.ubuntu.com/ProposedMigration>Proposed Migration</a>")):::task
-            UnderstandDep8{{"<a href=https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>Understand DEP8</a>"}}:::study
-            AddAUTOPKGTESTS(("<a href=https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/PackageTests.md>Add Autopkgtest</a>")):::task
-            SRU{{"<a href=https://canonical-sru-docs.readthedocs-hosted.com/>Study SRU</a>"}}:::study
-            DoSRUS(("Do SRUS")):::task
-
-            %% Transitions
-            UnderstandDep8 --> AddAUTOPKGTESTS
-            ComplexPackageMerges --> ProposeMigration
-            SRU --> DoSRUS
-        end
-        IntermediateKeepGoing["Do enough of these to apply for package or group uploads"]:::task
-        IntermediateTasks --> IntermediateKeepGoing --> IntermediateTasks
+        
     end
 
-    IntermediateToAdvanced{"Team/Mentor Says ready for more"}:::concept
-    Intermediate --> IntermediateToAdvanced --> Advanced
-
-    subgraph Advanced
-    direction LR
-        subgraph AdvancedTasks[Advanced Tasks]
-            direction LR
-            %% States
-            UpstreamSubmissionFixes(("Upstream Submission Fixes/Features")):::task
-            UpstreamSubmissionDelta(("Upstream Submission of Delta")):::task
-            MilestonesAndExceptions(("Milestones And Exceptions")):::task
-            StudyFFE{{"<a href=https://wiki.ubuntu.com/FreezeExceptionProcess>Study FFE</a>"}}:::study
-            DoAnFFE(("Do An FFE")):::task
-            PlusOne{{"<a href=https://wiki.ubuntu.com/PlusOneMaintenanceTeam>Study +1</a>"}}:::study
-            PlusOneShadowing(("+1 Shadowing")):::task
-
-            %% Transitions
-            StudyFFE-->DoAnFFE
-            PlusOne-->PlusOneShadowing
-        end
-        AdvancedKeepGoing["Do enough of these to apply for MOTU"]:::task
-        AdvancedTasks --> AdvancedKeepGoing --> AdvancedTasks
-    end
-
-    Advanced --> optionalDebian
-    MOTU{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/MembershipInMOTU.md>MOTU</a>"}:::concept
-    Advanced --> MOTU --> Expert
-
-    subgraph optionalDebian[Optional Activites in Debian]
+    subgraph AdvancedTasks[" "]
+        direction TB
         %% States
-        Contribute(("<a href=https://www.debian.org/doc/manuals/maint-guide/>Contribute</a>")):::task
-        DM{"<a href=https://wiki.debian.org/DebianMaintainer>DM</a>"}:::concept
-        DD{"<a href=https://wiki.debian.org/DebianDeveloper>DD</a>"}:::concept
+        UpstreamSubmissionFixes(("Upstream submission<br>fixes/features"))
+        UpstreamSubmissionDelta(("Upstream submission<br>of delta"))
+        MilestonesAndExceptions(("Milestones<br>and exceptions"))
+        StudyFFE{{"<a href=https://wiki.ubuntu.com/FreezeExceptionProcess>Study FFE</a>"}}
+        DoAnFFE(("Do An FFE"))
+        PlusOne{{"<a href=https://wiki.ubuntu.com/PlusOneMaintenanceTeam>Study +1</a>"}}
+        PlusOneShadowing(("+1 Shadowing"))
+
+        %% Transitions
+        StudyFFE-->DoAnFFE
+        PlusOne-->PlusOneShadowing
+    end
+```
+
+
+### (Optional) Activities in Debian
+
+At this point, while you are applying for MOTU, you may also want to branch out
+and contribute more to Debian.
+
+```{mermaid}
+%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
+%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
+flowchart TD
+    subgraph optionalDebian[Optional activites in Debian]
+        %% States
+        Contribute(("<a href=https://www.debian.org/doc/manuals/maint-guide/>Contribute</a>"))
+        DM[["<a href=https://wiki.debian.org/DebianMaintainer>Debian Maintainer</a>"]]
+        DD[["<a href=https://wiki.debian.org/DebianDeveloper>Debian Developer</a>"]]
 
         %% Transitions
         Contribute --> DM
         DM --> DD
     end
+```
 
-    subgraph Expert
-        direction LR
-        subgraph ExpertTasks
-            direction TB
 
-            %% States
-            StudyLibaryTransitions{{"<a href=https://wiki.debian.org/Teams/ReleaseTeam/Transitions>Study Libary Transitions</a>"}}:::study
-            DoLibaryTransitions(("Do Libary Transitions")):::task
-            StudyPackageTransitions{{"<a href=https://wiki.debian.org/PackageTransition>Study Package Transitions</a>"}}:::study
-            DoPackageTransitions(("Do Package Transitions")):::task
-            StudyMIR{{"<a href=https://github.com/canonical/ubuntu-mir/edit/main/README.md>Study MIR</a>"}}:::study
-            DoMIR(("Do a MIR")):::task
-            SeedChange(("Seed Change")):::task
+## Expert 
 
-            %% Transitions
-            StudyLibaryTransitions-->DoLibaryTransitions
-            StudyPackageTransitions-->DoPackageTransitions
-            StudyMIR-->DoMIR
-            StudyMIR-->SeedChange
-        end
-        ExpertKeepGoing["Do enough to apply for core-dev"]:::task
-        ExpertTasks-->ExpertKeepGoing-->ExpertTasks
-    end
+Once you are a member of MOTU, the following tasks and topics will guide you
+towards becoming a Core Developer. Keep doing enough of these tasks until you
+have the experience you need to apply for Core Dev.
 
-    CoreDev{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/MembershipInCoreDev.md>Core Developer</a>"}:::concept
+```{mermaid}
+%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
+%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
+flowchart TD
+    direction LR
+    subgraph ExpertTasks["Expert tasks"]
+        direction TB
 
-    Expert --> CoreDev --> Duties
+        %% States
+        StudyLibaryTransitions{{"<a href=https://wiki.debian.org/Teams/ReleaseTeam/Transitions>Study Libary Transitions</a>"}}
+        DoLibaryTransitions(("Do Libary Transitions"))
+        StudyPackageTransitions{{"<a href=https://wiki.debian.org/PackageTransition>Study Package Transitions</a>"}}
+        DoPackageTransitions(("Do Package Transitions"))
+        StudyMIR{{"<a href=https://github.com/canonical/ubuntu-mir/edit/main/README.md>Study MIR</a>"}}
+        DoMIR(("Do a MIR"))
+        SeedChange(("Seed Change"))
 
-    subgraph Duties
-        direction LR
-        CoreDevPlusOne(("+1")):::task
-        Sponsoring(("Sponsoring")):::task
-        Mentoring(("Mentoring")):::task
+        %% Transitions
+        StudyLibaryTransitions-->DoLibaryTransitions
+        StudyPackageTransitions-->DoPackageTransitions
+        StudyMIR-->DoMIR
+        StudyMIR-->SeedChange
     end
 ```
+
+

--- a/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
+++ b/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
@@ -58,8 +58,8 @@ block-beta
 %% Column 3
   block:col3
   columns 2
-    space
     UploadRights{{"<b>Upload<br>rights</b>"}}
+    PPU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PPU*</a>"]
     space:2
     Intermediate("<a href='#upload-path-intermediate'>Intermediate</a>")
     id2((" "))
@@ -71,8 +71,9 @@ block-beta
 %% Column 4
   block:col4
   columns 2
-    PPU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PPU<br>PackageSet</a>"]
-    space:3
+    space
+    PackageSet["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PPU*<br>PackageSet</a>"]
+    space:2
     Advanced("<a href='#upload-path-advanced'>Advanced</a>")
     id3((" "))
     space:2
@@ -83,8 +84,9 @@ block-beta
 %% Column 5
   block:col5
   columns 2
+    space
     MOTU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-MOTU/'>MOTU</a>"]
-    space:3
+    space:2
     Expert("<a href='#upload-path-expert'>Expert</a>")
     id4((" "))
     space:4
@@ -93,19 +95,26 @@ block-beta
 %% Column 6
   block:col6
     columns 2
+    space
     CoreDev["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-core-dev/'>Core Dev</a>"]
-    space:8
+    space:2
+    Main("<a href='#upload-path-expert'>Expert<br>in main</a>")
+    id5((" "))
+    space:4
   end
+
 
 %% Connections
 Basics --> Intermediate
 Intermediate --> Advanced
 Advanced --> Expert
+Expert --> Main
 
 id2 --> PPU
-id3 --> MOTU
-Expert --- id4
-id4 --> CoreDev
+id3 --> PackageSet
+id4 --> MOTU
+Main --- id5
+id5 --> CoreDev
 
 Contributor --> Maintainer
 Maintainer --> Developer
@@ -115,16 +124,16 @@ classDef debianStyle fill: #F8A3C0, stroke: #DD1155
   class Debian,Contributor,Maintainer,Developer debianStyle
 
 classDef ubuntuStyle fill: #FFDAB9, stroke: #E95420,stroke-width:1px;
-  class Ubuntu,Basics,Intermediate,Advanced,Expert ubuntuStyle
+  class Ubuntu,Basics,Intermediate,Advanced,Expert,Main ubuntuStyle
 
 classDef uploaderStyle fill: #FFDF7E, stroke: #FBAB13
-  class UploadRights,PPU,MOTU,CoreDev uploaderStyle
+  class UploadRights,PPU,PackageSet,MOTU,CoreDev uploaderStyle
 
 classDef invisible fill: transparent, stroke: transparent
-  class id1,col1,col2,col3,col4,col5,col6 invisible
+  class id1,col1,col2,col3,col4,col5,col6,col7 invisible
 
 classDef solid fill: #000, stroke: transparent
-  class id2,id3,id4 solid
+  class id2,id3,id4,id5 solid
 :::
 
 
@@ -137,7 +146,7 @@ contributions to Ubuntu.
 :::{mermaid}
 block-beta
 columns 2
-  block
+  block:left
     InitialStudies("Initial studies")
     columns 1
     Concepts{{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook>Concepts</a>"}}
@@ -145,7 +154,7 @@ columns 2
     DebianPolicy{{"<a href=https://www.debian.org/doc/debian-policy/>Debian Policy</a>"}}
   end
 
-  block
+  block:right
     InitialTasks("Initial tasks")
     columns 1
     BugTriage["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/bug-triage/'>Bug triage</a>"]
@@ -155,57 +164,68 @@ columns 2
 
   InitialStudies --> InitialTasks
 
-  style InitialStudies fill: #FFDAB9, stroke:#F4A460
-  style InitialTasks fill:#FFDAB9, stroke:#F4A460
+  classDef Studies fill: #FFDAB9, stroke:#F4A460;
+    class InitialStudies,InitialTasks Studies
+  classDef invisible fill:transparent,stroke:transparent;
+    class left,right invisible
 :::
 
 Once your team and/or mentor says you are ready for more, you can move onto the
-intermediate tasks.
+Intermediate-level tasks.
 
 
 (upload-path-intermediate)=
 ## Intermediate
 
-This set of topics and tasks will prepare you to apply for single-package (PPU)
-or Package Set upload rights.
+This set of topics are more in-depth, as well as being quite hands-on.
+Completing the tasks in this set will prepare you for Advanced-level work.
 
 :::{mermaid}
 block-beta
-  columns 2
+  columns 3
 
-  block
-    IntermediateStudies("Intermediate studies")
+  block:left
     columns 1
+    IntermediateStudies("Intermediate studies")
     UnderstandDep8{{"<a href=https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>Understand DEP8</a>"}}
     ComplexPackageMerges{{"Complex package merges"}}
     SRU{{"<a href=https://canonical-sru-docs.readthedocs-hosted.com/>Study SRU</a>"}}
-    BlockA{{" "}}
+    space:1
   end
    
-  block
-    IntermediateTasks("Intermediate tasks")
+  block:middle
     columns 1
+    IntermediateTasks("Intermediate tasks")
     AddAUTOPKGTESTS["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/bug-fix/package-tests/>Add Autopkgtest</a>"]
     ProposeMigration["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/how-ubuntu-is-made/processes/proposed-migration/>Proposed Migration</a>"]
     DoSRUS["Do SRUS"]
     WorkOnBugs["Work on packaging bugs/features"]
   end
-    
+
+  block:right
+    columns 2
+    space
+    PPU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PPU*</a>"]
+    space:8
+  end
+
   UnderstandDep8 --> AddAUTOPKGTESTS
   ComplexPackageMerges --> ProposeMigration
   SRU --> DoSRUS
+  IntermediateTasks --> PPU
 
-  style IntermediateStudies fill: #FFDAB9, stroke:#F4A460;
-  style IntermediateTasks fill:#FFDAB9, stroke:#F4A460;
-  style BlockA fill:transparent,stroke:transparent;
+  classDef Studies fill: #FFDAB9, stroke:#F4A460;
+    class IntermediateStudies,IntermediateTasks Studies
+  classDef invisible fill:transparent,stroke:transparent;
+    class left,middle,right invisible
 :::
 
 Once you have done enough of these tasks that your team/mentor says you are
 ready to continue your journey, you can move onto the Advanced topics.
 
-At this time, you can also consider yourself ready to apply for PPU or
-Package Set upload rights if there are particular packages or sets of packages
-you are particularly focused on. 
+At this time, you may also be ready to apply for Per-Package Upload (PPU) rights.
+This will depend very much on the package you are interested in gaining upload
+rights for. Some packages will need you to complete the Advanced path first.
 
 
 (upload-path-advanced)=
@@ -213,21 +233,17 @@ you are particularly focused on.
 
 :::{mermaid}
 block-beta
-  columns 2
+  columns 3
 
-  block
+  block:left
     AdvancedStudies("Advanced studies")
     columns 1
-
-    BlockA(" ")
-    BlockB(" ")
-    BlockC(" ")
-
+    space:3
     StudyFFE{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/staging/release-team/freeze-exceptions/>Study FFE</a>"}}
     PlusOne{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/advanced/plus-one-maintenance/>Study +1</a>"}}
   end
 
-  block
+  block:middle
     AdvancedTasks("Advanced tasks")
     columns 1
     UpstreamSubmissionFixes["Upstream submission fixes/features"]
@@ -237,61 +253,117 @@ block-beta
     PlusOneShadowing["+1 Shadowing"]
   end
 
+  block:right
+    columns 2
+    space
+    PPU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PPU*</a>"]
+    space
+    PackageSet["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PackageSet</a>"]
+    space:8
+  end
+
+  AdvancedTasks --> PPU
+  AdvancedTasks --> PackageSet
   StudyFFE --> DoAnFFE
   PlusOne --> PlusOneShadowing
 
-  style AdvancedStudies fill: #FFDAB9, stroke:#F4A460;
-  style AdvancedTasks fill:#FFDAB9, stroke:#F4A460;
-  style BlockA fill:transparent,stroke:transparent;
-  style BlockB fill:transparent,stroke:transparent;
-  style BlockC fill:transparent,stroke:transparent;
+  classDef Studies fill: #FFDAB9, stroke:#F4A460;
+    class AdvancedStudies,AdvancedTasks Studies
+  classDef invisible fill:transparent,stroke:transparent;
+    class left,middle,right invisible
 :::
 
 With enough of these tasks under your belt to demonstrate your skills and
 experience, you can move onto the Expert topics.
 
-At this point, you can consider yourself ready to apply for MOTU.
+At this point, you are likely to be ready to apply for Per-Package Upload (PPU)
+rights, or if there is a set of packages you are interested in working on, you
+can apply for Package Set instead.
 
 
 (upload-path-expert)=
 ## Expert 
 
-As a member of MOTU, the following tasks and topics will guide you towards
-becoming a Core Developer. Keep doing enough of these tasks until you have the
-experience you need to apply for Core Dev.
+The Expert-level studies will prepare you for becoming a member of MOTU, where
+you will help to maintain packages in `universe`.
+
+If you want to, you can continue your Expert-level studies by further
+specializing in `main` -- you need to do this if you want to apply for
+the Core Developer role.
 
 :::{mermaid}
 block-beta
-  columns 2
-    
-  block 
+  columns 3
+
+  block:topleft 
     columns 1
     ExpertStudies("Expert studies")
-
     StudyLibaryTransitions{{"<a href=https://wiki.debian.org/Teams/ReleaseTeam/Transitions>Study libary transitions</a>"}}
     StudyPackageTransitions{{"<a href=https://wiki.debian.org/PackageTransition>Study package transitions</a>"}}
-    BlockA(" ")
-    StudyMIR{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/MIR/main-inclusion-review/>Study MIR</a>"}}
+    id1((" "))
   end
 
-  block
+  block:topright
     columns 1
     ExpertTasks("Expert tasks")
-
     DoLibaryTransitions["Do libary transitions"]
-    DoPackageTransitions["Do package sransitions"]
+    DoPackageTransitions["Do package transitions"]
+    space:1
+  end
+
+  block:motu
+    columns 2
+    id2((" "))
+    MOTU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-MOTU/'>MOTU</a>"]
+    space:4
+    id3((" "))
+    space
+  end
+
+  ExpertTasks --> MOTU
+
+  block:lowerleft
+    columns 1
+    ExpertinMainStudies("Expert in <code>main</code> studies")
+    space
+    StudyMIR{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/MIR/main-inclusion-review/>Study MIR</a>"}}
+    space:1
+  end
+
+  block:lowerright
+    columns 1
+    ExpertinMainTasks("Expert in <code>main</code> tasks")
     DoMIR["Do an MIR"]
+    space
     SeedChange["Seed change"]
   end
+
+  block:coredev
+    columns 2
+    space
+    CoreDev["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-core-dev/'>Core Dev</a>"]
+    space:6
+  end
+ 
+  ExpertinMainTasks --> CoreDev
+
+  id1 --> ExpertinMainStudies
+  id2 --- id3
+  id3 --- id1
 
   StudyLibaryTransitions-->DoLibaryTransitions
   StudyPackageTransitions-->DoPackageTransitions
   StudyMIR-->DoMIR
   StudyMIR-->SeedChange
 
-  style ExpertStudies fill: #FFDAB9, stroke:#F4A460;
-  style ExpertTasks fill:#FFDAB9, stroke:#F4A460;
-  style BlockA fill:transparent,stroke:transparent;
+  classDef Studies fill: #FFDAB9, stroke:#F4A460;
+    class ExpertStudies,ExpertTasks,ExpertinMainStudies,ExpertinMainTasks Studies
+
+  classDef invisible fill: transparent, stroke: transparent
+    class topleft,topright,lowerleft,lowerright,motu,coredev invisible
+
+  classDef solid fill: #000, stroke: transparent
+    class id1,id2,id3 solid
 :::
 
 

--- a/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
+++ b/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
@@ -29,101 +29,102 @@ contributor. Click any of the nodes to learn more.
 
 :::{mermaid}
 block-beta
-  columns 8
+  columns 6
 
 %% Column 1
   block:col1
-  columns 1
-    space:3
-    Start(("Start"))
-    space
-  end
-
-%% Column 2
-  block:col2
-  columns 1
-    space
-    space
+  columns 2
+    space:5
     Ubuntu{{"<b>Ubuntu<br>path</br>"}}
-    space
+    Start(("Start"))
+    space:2
     Debian{{"<b>Debian<br>path</b>"}}
   end
 
   Start --> Ubuntu
   Start --> Debian
 
+%% Column 2
+  block:col2
+  columns 2
+    space:4
+    Basics("<a href='#upload-path-basics'>Basics</a>")
+    id1((" "))
+    space:2
+    Contributor("<a href="https://www.debian.org/doc/manuals/maint-guide/">Contributor</a>")
+    space
+  end
+
 %% Column 3
   block:col3
-  columns 1
+  columns 2
+    space
     UploadRights{{"<b>Upload<br>rights</b>"}}
+    space:2
+    Intermediate("<a href='#upload-path-intermediate'>Intermediate</a>")
+    id2((" "))
+    space:2
+    Maintainer("<a href='https://wiki.debian.org/DebianMaintainer'>Maintainer</a>")
     space
-    Basics("<a href='#upload-path-basics'>Basics</a>")
-    space
-    Contributor("<a href="https://www.debian.org/doc/manuals/maint-guide/">Contributor</a>")
   end
 
 %% Column 4
   block:col4
-  columns 1
+  columns 2
     PPU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-packageset/'>PPU<br>PackageSet</a>"]
+    space:3
+    Advanced("<a href='#upload-path-advanced'>Advanced</a>")
+    id3((" "))
+    space:2
+    Developer("<a href='https://wiki.debian.org/DebianDeveloper'>Developer</a>")
     space
-    Intermediate("<a href='#upload-path-intermediate'>Intermediate</a>")
-    space
-    Maintainer("<a href='https://wiki.debian.org/DebianMaintainer'>Maintainer</a>")
   end
 
 %% Column 5
   block:col5
-  columns 1
+  columns 2
     MOTU["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-MOTU/'>MOTU</a>"]
-    space
-    Advanced("<a href='#upload-path-advanced'>Advanced</a>")
-    space
-    Developer("<a href='https://wiki.debian.org/DebianDeveloper'>Developer</a>")
+    space:3
+    Expert("<a href='#upload-path-expert'>Expert</a>")
+    id4((" "))
+    space:4
   end
 
 %% Column 6
   block:col6
-  columns 1
+    columns 2
     CoreDev["<a href='https://canonical-ubuntu-project.readthedocs-hosted.com/who-makes-ubuntu/joining/membership-in-core-dev/'>Core Dev</a>"]
-    space
-    Expert("<a href='#upload-path-expert'>Expert</a>")
-    space:2
+    space:8
   end
 
 %% Connections
 Basics --> Intermediate
 Intermediate --> Advanced
-Intermediate --> PPU
 Advanced --> Expert
-Advanced --> MOTU
-Expert --> CoreDev
+
+id2 --> PPU
+id3 --> MOTU
+Expert --- id4
+id4 --> CoreDev
 
 Contributor --> Maintainer
 Maintainer --> Developer
 
 %% Styling
 classDef debianStyle fill: #F8A3C0, stroke: #DD1155
-  class Debian debianStyle
-  class Contributor debianStyle
-  class Maintainer debianStyle
-  class Developer debianStyle
+  class Debian,Contributor,Maintainer,Developer debianStyle
 
 classDef ubuntuStyle fill: #FFDAB9, stroke: #E95420,stroke-width:1px;
-  class Ubuntu ubuntuStyle
-  class Basics ubuntuStyle
-  class Intermediate ubuntuStyle
-  class Advanced ubuntuStyle
-  class Expert ubuntuStyle
+  class Ubuntu,Basics,Intermediate,Advanced,Expert ubuntuStyle
 
 classDef uploaderStyle fill: #FFDF7E, stroke: #FBAB13
-  class UploadRights uploaderStyle
-  class PPU uploaderStyle
-  class MOTU uploaderStyle
-  class CoreDev uploaderStyle
+  class UploadRights,PPU,MOTU,CoreDev uploaderStyle
 
 classDef invisible fill: transparent, stroke: transparent
-  class col1,col2,col3,col4,col5,col6 invisible
+  class id1,col1,col2,col3,col4,col5,col6 invisible
+
+classDef solid fill: #000, stroke: transparent
+  class id2,id3,id4 solid
 :::
 
 

--- a/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
+++ b/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
@@ -168,37 +168,36 @@ intermediate tasks.
 This set of topics and tasks will prepare you to apply for single-package (PPU)
 or Package Set upload rights.
 
-```{mermaid}
+:::{mermaid}
 block-beta
-    columns 2
+  columns 2
 
-    block
-        IntermediateStudies("Intermediate studies")
-        columns 1
-        UnderstandDep8{{"<a href=https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>Understand DEP8</a>"}}
-        ComplexPackageMerges{{"Complex package merges"}}
-        SRU{{"<a href=https://canonical-sru-docs.readthedocs-hosted.com/>Study SRU</a>"}}
-        BlockA{{" "}}
-    end
+  block
+    IntermediateStudies("Intermediate studies")
+    columns 1
+    UnderstandDep8{{"<a href=https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>Understand DEP8</a>"}}
+    ComplexPackageMerges{{"Complex package merges"}}
+    SRU{{"<a href=https://canonical-sru-docs.readthedocs-hosted.com/>Study SRU</a>"}}
+    BlockA{{" "}}
+  end
    
-    block
-        IntermediateTasks("Intermediate tasks")
-        columns 1
-        AddAUTOPKGTESTS["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/bug-fix/package-tests/>Add Autopkgtest</a>"]
-        ProposeMigration["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/how-ubuntu-is-made/processes/proposed-migration/>Proposed Migration</a>"]
-        DoSRUS["Do SRUS"]
-        WorkOnBugs["Work on packaging bugs/features"]
-    end
+  block
+    IntermediateTasks("Intermediate tasks")
+    columns 1
+    AddAUTOPKGTESTS["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/bug-fix/package-tests/>Add Autopkgtest</a>"]
+    ProposeMigration["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/how-ubuntu-is-made/processes/proposed-migration/>Proposed Migration</a>"]
+    DoSRUS["Do SRUS"]
+    WorkOnBugs["Work on packaging bugs/features"]
+  end
     
-    %% Transitions
-    UnderstandDep8 --> AddAUTOPKGTESTS
-    ComplexPackageMerges --> ProposeMigration
-    SRU --> DoSRUS
+  UnderstandDep8 --> AddAUTOPKGTESTS
+  ComplexPackageMerges --> ProposeMigration
+  SRU --> DoSRUS
 
-    style IntermediateStudies fill: #FFDAB9, stroke:#F4A460;
-    style IntermediateTasks fill:#FFDAB9, stroke:#F4A460;
-    style BlockA fill:transparent,stroke:transparent;
-```
+  style IntermediateStudies fill: #FFDAB9, stroke:#F4A460;
+  style IntermediateTasks fill:#FFDAB9, stroke:#F4A460;
+  style BlockA fill:transparent,stroke:transparent;
+:::
 
 Once you have done enough of these tasks that your team/mentor says you are
 ready to continue your journey, you can move onto the Advanced topics.
@@ -211,42 +210,41 @@ you are particularly focused on.
 (upload-path-advanced)=
 ## Advanced
 
-```{mermaid}
+:::{mermaid}
 block-beta
-    columns 2
+  columns 2
 
-    block
-        AdvancedStudies("Advanced studies")
-        columns 1
+  block
+    AdvancedStudies("Advanced studies")
+    columns 1
 
-        BlockA(" ")
-        BlockB(" ")
-        BlockC(" ")
+    BlockA(" ")
+    BlockB(" ")
+    BlockC(" ")
 
-        StudyFFE{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/staging/release-team/freeze-exceptions/>Study FFE</a>"}}
-        PlusOne{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/advanced/plus-one-maintenance/>Study +1</a>"}}
-    end
+    StudyFFE{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/staging/release-team/freeze-exceptions/>Study FFE</a>"}}
+    PlusOne{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/advanced/plus-one-maintenance/>Study +1</a>"}}
+  end
 
-    block
-        AdvancedTasks("Advanced tasks")
-        columns 1
-        UpstreamSubmissionFixes["Upstream submission fixes/features"]
-        UpstreamSubmissionDelta["Upstream submission of delta"]
-        MilestonesAndExceptions["Milestones and exceptions"]
-        DoAnFFE["Do An FFE"]
-        PlusOneShadowing["+1 Shadowing"]
-    end
+  block
+    AdvancedTasks("Advanced tasks")
+    columns 1
+    UpstreamSubmissionFixes["Upstream submission fixes/features"]
+    UpstreamSubmissionDelta["Upstream submission of delta"]
+    MilestonesAndExceptions["Milestones and exceptions"]
+    DoAnFFE["Do An FFE"]
+    PlusOneShadowing["+1 Shadowing"]
+  end
 
-    StudyFFE-->DoAnFFE
-    PlusOne-->PlusOneShadowing
+  StudyFFE --> DoAnFFE
+  PlusOne --> PlusOneShadowing
 
-    style AdvancedStudies fill: #FFDAB9, stroke:#F4A460;
-    style AdvancedTasks fill:#FFDAB9, stroke:#F4A460;
-    style BlockA fill:transparent,stroke:transparent;
-    style BlockB fill:transparent,stroke:transparent;
-    style BlockC fill:transparent,stroke:transparent;
-
-```
+  style AdvancedStudies fill: #FFDAB9, stroke:#F4A460;
+  style AdvancedTasks fill:#FFDAB9, stroke:#F4A460;
+  style BlockA fill:transparent,stroke:transparent;
+  style BlockB fill:transparent,stroke:transparent;
+  style BlockC fill:transparent,stroke:transparent;
+:::
 
 With enough of these tasks under your belt to demonstrate your skills and
 experience, you can move onto the Expert topics.
@@ -261,38 +259,38 @@ As a member of MOTU, the following tasks and topics will guide you towards
 becoming a Core Developer. Keep doing enough of these tasks until you have the
 experience you need to apply for Core Dev.
 
-```{mermaid}
+:::{mermaid}
 block-beta
-    columns 2
+  columns 2
     
-    block 
-        columns 1
-        ExpertStudies("Expert studies")
+  block 
+    columns 1
+    ExpertStudies("Expert studies")
 
-        StudyLibaryTransitions{{"<a href=https://wiki.debian.org/Teams/ReleaseTeam/Transitions>Study Libary Transitions</a>"}}
-        StudyPackageTransitions{{"<a href=https://wiki.debian.org/PackageTransition>Study Package Transitions</a>"}}
-        BlockA(" ")
-        StudyMIR{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/MIR/main-inclusion-review/>Study MIR</a>"}}
-    end
+    StudyLibaryTransitions{{"<a href=https://wiki.debian.org/Teams/ReleaseTeam/Transitions>Study libary transitions</a>"}}
+    StudyPackageTransitions{{"<a href=https://wiki.debian.org/PackageTransition>Study package transitions</a>"}}
+    BlockA(" ")
+    StudyMIR{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/MIR/main-inclusion-review/>Study MIR</a>"}}
+  end
 
-    block
-        columns 1
-        ExpertTasks("Expert tasks")
+  block
+    columns 1
+    ExpertTasks("Expert tasks")
 
-        DoLibaryTransitions["Do Libary Transitions"]
-        DoPackageTransitions["Do Package Transitions"]
-        DoMIR["Do a MIR"]
-        SeedChange["Seed Change"]
-    end
+    DoLibaryTransitions["Do libary transitions"]
+    DoPackageTransitions["Do package sransitions"]
+    DoMIR["Do an MIR"]
+    SeedChange["Seed change"]
+  end
 
-        StudyLibaryTransitions-->DoLibaryTransitions
-        StudyPackageTransitions-->DoPackageTransitions
-        StudyMIR-->DoMIR
-        StudyMIR-->SeedChange
+  StudyLibaryTransitions-->DoLibaryTransitions
+  StudyPackageTransitions-->DoPackageTransitions
+  StudyMIR-->DoMIR
+  StudyMIR-->SeedChange
 
-    style ExpertStudies fill: #FFDAB9, stroke:#F4A460;
-    style ExpertTasks fill:#FFDAB9, stroke:#F4A460;
-    style BlockA fill:transparent,stroke:transparent;
-```
+  style ExpertStudies fill: #FFDAB9, stroke:#F4A460;
+  style ExpertTasks fill:#FFDAB9, stroke:#F4A460;
+  style BlockA fill:transparent,stroke:transparent;
+:::
 
 

--- a/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
+++ b/docs/who-makes-ubuntu/joining/path-to-upload-rights.md
@@ -1,64 +1,77 @@
 (path-to-upload-rights)=
 # Path to upload rights
 
+```{note}
+The links shown on this page are subject to sudden changes over the next
+few months as more of the documentation it refers to is migrated here. Please
+expect inconsistencies -- and feel welcome to correct any links you believe are
+incorrect.
+```
+
 This interactive chart shows the skills needed to obtain permissions for
 uploading changes to the Ubuntu Package Archive. It can be used as a guide
 to help build your applications for upload rights on:
 
-* Package Sets
-* [MOTU](https://wiki.ubuntu.com/MOTU), 
-* [Core Developer](https://wiki.ubuntu.com/UbuntuDevelopers#Ubuntu_Core_Developers) 
+* {ref}`Package Sets <membership-in-packageset>`
+* {ref}`MOTU <membership-in-motu>`, 
+* {ref}`Core Developer <membership-in-core-dev>`
 
-
+(upload-path-basics)=
 ## Basics
 
 These topics will get you started with a good foundation for your future work.
 
 ```{mermaid}
-%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
-%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
-flowchart TD
-    direction TB
-    subgraph InitialStudies["Topics for study"]
-        direction BT
+block-beta
+columns 2
+    block
+        InitialStudies("Initial studies")
+        columns 1
         Concepts{{"<a href=https://github.com/canonical/ubuntu-maintainers-handbook>Concepts</a>"}}
-        Git-Ubuntu{{"git-ubuntu"}}
-        Debian-Policy{{"<a href=https://www.debian.org/doc/debian-policy/>Debian Policy</a>"}}
+        GitUbuntu{{"git-ubuntu"}}
+        DebianPolicy{{"<a href=https://www.debian.org/doc/debian-policy/>Debian Policy</a>"}}
     end
 
-    subgraph InitialTasks["Initial tasks"]
-        direction BT
+    block
+        InitialTasks("Initial tasks")
+        columns 1
+        BugTriage["Bug triage"]
         BiteSizedBugs["Bite-sized bugs"]
         TrivialPackgeMerges["Trivial package merges"]
     end
 
     InitialStudies --> InitialTasks
+
+    style InitialStudies fill: #FFDAB9, stroke:#F4A460
+    style InitialTasks fill:#FFDAB9, stroke:#F4A460
 ```
 
 Once your team and/or mentor says you are ready for more, you can move onto the
 intermediate tasks.
 
 
+(upload-path-intermediate)=
 ## Intermediate
 
 This set of topics and tasks will prepare you to apply for single-package or
 package set uploads.
 
 ```{mermaid}
-%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
-%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
-flowchart TD
-    direction TB
-    subgraph IntermediateStudies[" "]
-        direction BT
+block-beta
+    columns 2
+
+    block
+        IntermediateStudies("Intermediate studies")
+        columns 1
         UnderstandDep8{{"<a href=https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>Understand DEP8</a>"}}
         ComplexPackageMerges{{"Complex package merges"}}
         SRU{{"<a href=https://canonical-sru-docs.readthedocs-hosted.com/>Study SRU</a>"}}
-
     end
-    
-    subgraph IntermediateTasks[" "]
-        AddAUTOPKGTESTS["<a href=https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/PackageTests.md>Add Autopkgtest</a>"]
+   
+    block
+        IntermediateTasks("Intermediate tasks")
+        columns 1
+        AddAUTOPKGTESTS["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/bug-fix/package-tests/>Add Autopkgtest</a>"]
         ProposeMigration["<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/how-ubuntu-is-made/processes/proposed-migration/>Proposed Migration</a>"]
         DoSRUS["Do SRUS"]
     end
@@ -67,6 +80,9 @@ flowchart TD
     UnderstandDep8 --> AddAUTOPKGTESTS
     ComplexPackageMerges --> ProposeMigration
     SRU --> DoSRUS
+
+    style IntermediateStudies fill: #FFDAB9, stroke:#F4A460
+    style IntermediateTasks fill:#FFDAB9, stroke:#F4A460
 ```
 
 Once you have done enough of these tasks that your team/mentor says you are
@@ -74,32 +90,44 @@ ready to move onto the Advanced topics, you should be ready to apply for PPU
 or Package Set. 
 
 
+(upload-path-advanced)=
 ## Advanced
 
 ```{mermaid}
-%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
-%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
-flowchart TD
-    subgraph AdvancedStudies[" "]
-        direction TB
-        
+block-beta
+    columns 2
+
+    block
+        AdvancedStudies("Advanced studies")
+        columns 1
+
+        BlockA(" ")
+        BlockB(" ")
+        BlockC(" ")
+
+        StudyFFE{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/staging/release-team/freeze-exceptions/>Study FFE</a>"}}
+        PlusOne{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/advanced/plus-one-maintenance/>Study +1</a>"}}
     end
 
-    subgraph AdvancedTasks[" "]
-        direction TB
-        %% States
-        UpstreamSubmissionFixes(("Upstream submission<br>fixes/features"))
-        UpstreamSubmissionDelta(("Upstream submission<br>of delta"))
-        MilestonesAndExceptions(("Milestones<br>and exceptions"))
-        StudyFFE{{"<a href=https://wiki.ubuntu.com/FreezeExceptionProcess>Study FFE</a>"}}
-        DoAnFFE(("Do An FFE"))
-        PlusOne{{"<a href=https://wiki.ubuntu.com/PlusOneMaintenanceTeam>Study +1</a>"}}
-        PlusOneShadowing(("+1 Shadowing"))
-
-        %% Transitions
-        StudyFFE-->DoAnFFE
-        PlusOne-->PlusOneShadowing
+    block
+        AdvancedTasks("Advanced tasks")
+        columns 1
+        UpstreamSubmissionFixes["Upstream submission fixes/features"]
+        UpstreamSubmissionDelta["Upstream submission of delta"]
+        MilestonesAndExceptions["Milestones and exceptions"]
+        DoAnFFE["Do An FFE"]
+        PlusOneShadowing["+1 Shadowing"]
     end
+
+    StudyFFE-->DoAnFFE
+    PlusOne-->PlusOneShadowing
+
+    style AdvancedStudies fill: #FFDAB9, stroke:#F4A460;
+    style AdvancedTasks fill:#FFDAB9, stroke:#F4A460;
+    style BlockA fill:transparent,stroke:transparent;
+    style BlockB fill:transparent,stroke:transparent;
+    style BlockC fill:transparent,stroke:transparent;
+
 ```
 
 
@@ -109,22 +137,17 @@ At this point, while you are applying for MOTU, you may also want to branch out
 and contribute more to Debian.
 
 ```{mermaid}
-%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
-%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
-flowchart TD
-    subgraph optionalDebian[Optional activites in Debian]
-        %% States
-        Contribute(("<a href=https://www.debian.org/doc/manuals/maint-guide/>Contribute</a>"))
-        DM[["<a href=https://wiki.debian.org/DebianMaintainer>Debian Maintainer</a>"]]
-        DD[["<a href=https://wiki.debian.org/DebianDeveloper>Debian Developer</a>"]]
+flowchart LR
+    Contribute(("<a href=https://www.debian.org/doc/manuals/maint-guide/>Contribute</a>"))
+    DM[["<a href=https://wiki.debian.org/DebianMaintainer>Debian Maintainer</a>"]]
+    DD[["<a href=https://wiki.debian.org/DebianDeveloper>Debian Developer</a>"]]
 
-        %% Transitions
-        Contribute --> DM
-        DM --> DD
-    end
+    Contribute --> DM
+    DM --> DD
 ```
 
 
+(upload-path-expert)=
 ## Expert 
 
 Once you are a member of MOTU, the following tasks and topics will guide you
@@ -132,28 +155,37 @@ towards becoming a Core Developer. Keep doing enough of these tasks until you
 have the experience you need to apply for Core Dev.
 
 ```{mermaid}
-%% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
-%%{ init: { 'flowchart': { 'curve': 'catmullRom' } } }%%
-flowchart TD
-    direction LR
-    subgraph ExpertTasks["Expert tasks"]
-        direction TB
+block-beta
+    columns 2
+    
+    block 
+        columns 1
+        ExpertStudies("Expert studies")
 
-        %% States
         StudyLibaryTransitions{{"<a href=https://wiki.debian.org/Teams/ReleaseTeam/Transitions>Study Libary Transitions</a>"}}
-        DoLibaryTransitions(("Do Libary Transitions"))
         StudyPackageTransitions{{"<a href=https://wiki.debian.org/PackageTransition>Study Package Transitions</a>"}}
-        DoPackageTransitions(("Do Package Transitions"))
-        StudyMIR{{"<a href=https://github.com/canonical/ubuntu-mir/edit/main/README.md>Study MIR</a>"}}
-        DoMIR(("Do a MIR"))
-        SeedChange(("Seed Change"))
+        BlockA(" ")
+        StudyMIR{{"<a href=https://canonical-ubuntu-project.readthedocs-hosted.com/MIR/main-inclusion-review/>Study MIR</a>"}}
+    end
 
-        %% Transitions
+    block
+        columns 1
+        ExpertTasks("Expert tasks")
+
+        DoLibaryTransitions["Do Libary Transitions"]
+        DoPackageTransitions["Do Package Transitions"]
+        DoMIR["Do a MIR"]
+        SeedChange["Seed Change"]
+    end
+
         StudyLibaryTransitions-->DoLibaryTransitions
         StudyPackageTransitions-->DoPackageTransitions
         StudyMIR-->DoMIR
         StudyMIR-->SeedChange
-    end
+
+    style ExpertStudies fill: #FFDAB9, stroke:#F4A460;
+    style ExpertTasks fill:#FFDAB9, stroke:#F4A460;
+    style BlockA fill:transparent,stroke:transparent;
 ```
 
 


### PR DESCRIPTION
### Description

The diagram on the `path-to-upload-rights.md` page was not rendering correctly and many of the labels had disappeared. After trying and failing several methods to fix the rendering, I decided to break up the diagram - which has the advantage that we can now link to the relevant parts of the diagram from other pages.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

I *think* the changes I've made still reflect the [spirit of the original](https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/Reference/PathToUploadRights.md) - please let me know if that's not the case
