### PR TITLE
contributors/setup: Added note about newer unshare backend for sbuild

### DIFF
--- a/docs/contributors/setup/setup.md
+++ b/docs/contributors/setup/setup.md
@@ -192,6 +192,13 @@ specify a destination, it'll default to doing nothing.
 
 [sbuild](https://wiki.debian.org/sbuild) is a wrapper script around `schroot`.
 
+```{note}
+A newer backend, `unshare`, can be used in place of `schroot`.
+For that, you will need `mmdebstrap` and `uidmap` installed as well.
+Setting `$chroot_mode = "unshare"; $unshare_mmdebstrap_keep_tarball = 1;` in sbuild configuration should be enough.
+However, `unshare` is not used by Launchpad builders, and can fail to build some packages.
+```
+
 In these examples, replace `my_user` with your own username.
 
 Make mount points:


### PR DESCRIPTION
<!-- You can delete any parts of this template not applicable to your Pull Request. -->

### Description

This pull requests adds a mention of the newer 'unshare' backend for sbuild in setup instructions. 
Debian is moving to unshare, and even though Launchpad still uses schroot, it seems nice to be able to show users their options.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---