### PR TITLE
Remove unnecessary note block

### DIFF
--- a/docs/release-team/release-team.md
+++ b/docs/release-team/release-team.md
@@ -1,13 +1,6 @@
 (release-team)=
 # The Release Team
 
-```{note}
-Contents from [wiki: Release Team](https://wiki.ubuntu.com/ReleaseTeam).
-
-This page will move to:
-* Who makes Ubuntu -> Roles and responsibilities -> About the Release Team
-```
-
 The [Ubuntu Release Team](http://launchpad.net/~ubuntu-release) is responsible
 for the overall {ref}`release-cycle`, which includes monitoring the healthy
 development and stability of the Ubuntu distribution.


### PR DESCRIPTION
### Description

Forgot to remove the "where this page is going" box when I moved it out of staging

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

