### PR TITLE
Hide toc from page

### DIFF
--- a/docs/release-team/mirrors.md
+++ b/docs/release-team/mirrors.md
@@ -3,6 +3,7 @@
 
 ```{toctree}
 :maxdepth: 1
+:hidden:
 
 mirror-scripts
 push-mirroring


### PR DESCRIPTION
### Description

As title - toc is showing at the top of the page


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

