### PR TITLE
DMB consider logs in one place

### DIFF
--- a/docs/who-makes-ubuntu/councils/dmb-meetings.md
+++ b/docs/who-makes-ubuntu/councils/dmb-meetings.md
@@ -24,11 +24,9 @@ The meeting starts on Matrix in the {matrix}`meeting` channel, and we then offer
 We share the responsibility of chairing the meetings.
 At the end of every meeting, we pre-select the next meeting's chair.
 
-
-## Quorum
-
-[Quorum was originally publicly discussed](https://discourse.ubuntu.com/t/open-discussion-meetings-quorum/5966) on the community forum.
-The specific meaning of **quorum** for voting [was later clarified](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001763.html) and is explained in the {ref}`dmb-voting-and-quorum` section.
+The chair drives the meeting according the agenda, ensures we are following
+the rules of the {ref}`dmb-voting-and-quorum` section, assigns follow up tasks
+like {ref}`dmb-application-communication`.
 
 
 ## General progress during meetings

--- a/docs/who-makes-ubuntu/councils/dmb-meetings.md
+++ b/docs/who-makes-ubuntu/councils/dmb-meetings.md
@@ -29,6 +29,29 @@ like {ref}`dmb-application-communication`.
 
 At the end of every meeting, we try to pre-select the next meeting's chair.
 
+The chair is furthermore repsonsible to ensure that {ref}`meeting-logs` are made
+publicly available.
+
+(meeting-logs)=
+## Meeting Logs
+
+Over the years there have been many forms of meeiting logs, sites logging IRC,
+[meetingology](https://wiki.ubuntu.com/meetingology) based logs,
+missed logs :-/, mail summaries and more. When experimenting to offer video
+calls for more efficient evaluation of the candidate more types like textfiles,
+auto generated logs, google docs or video recording got used.
+
+The goals of these logs is to:
+- allow to retrace how people have been evaluated
+- allow to refer to when a decision was done
+- allow someone to prepare for an application based on former ones
+
+To be able to do that a public accessible folder for the
+[DMB Meeting logs](https://drive.google.com/drive/u/1/folders/18n6c0AjNnMwYg17DYQZcP3ge_1Kx5W0d).
+was established. Old logs, from the different sources of the past, got added
+and now allow searching across all of them as well as an easy way to download
+all for any other kind of processing.
+
 ## General progress during meetings
 
 In January 2023 the DMB agreed to the following.

--- a/docs/who-makes-ubuntu/councils/dmb-meetings.md
+++ b/docs/who-makes-ubuntu/councils/dmb-meetings.md
@@ -22,12 +22,12 @@ The meeting starts on Matrix in the {matrix}`meeting` channel, and we then offer
 ## Chair
 
 We share the responsibility of chairing the meetings.
-At the end of every meeting, we pre-select the next meeting's chair.
 
 The chair drives the meeting according the agenda, ensures we are following
 the rules of the {ref}`dmb-voting-and-quorum` section, assigns follow up tasks
 like {ref}`dmb-application-communication`.
 
+At the end of every meeting, we try to pre-select the next meeting's chair.
 
 ## General progress during meetings
 

--- a/docs/who-makes-ubuntu/councils/dmb-rules.md
+++ b/docs/who-makes-ubuntu/councils/dmb-rules.md
@@ -22,53 +22,29 @@ This rule [was proposed](https://lists.ubuntu.com/archives/devel-permissions/202
 (dmb-voting-and-quorum)=
 ## Voting and quorum
 
-Applications must reach +1 in order to pass.
-If the meeting is quorate and all members present vote in the same way (+1 or -1), then the application will have passed or failed -- the remaining members cannot overturn the vote.
-If the vote is in doubt then it is *hung* and the remaining members will be asked to vote by email or at the next meeting.
-In this case those members are entitled to ask the applicant further questions if they still have any upon reviewing the meeting log.
+* The total number of active board members should be 7, with a quorum of 4.
 
-> Quorum votes are required to make any decision., however if quorum is not reached at first meeting, at the next meeting majority present votes are required.
+* We don't require quorum to hold meetings, we only require 'quorum' during voting
 
-The details for this rule, and **quorum** voting in particular, are not always clear, so the TL:DR for this rule is, any proposal or application that is voted on at a regular meeting must use the process shown in the Python function below;
-if the function does not result in pass or fail, then at the next scheduled meeting, the vote will pass with only a majority of present members (meaning the sum of votes from present members must be greater than 0).
+* Members vote on applications or proposals by giving -1 (reject), 0 (abstain), or +1 (approve)
+
+* The sum of all votes given must reach >0 (a majority) to pass a vote.
+
+* The vote must be quorate for it to be valid.
+
+  * However if quorum is not reached at first meeting, then at the next meeting a "majority of present votes" is sufficient to pass.
+
+* If the meeting is quorate and all members present vote in the same way (+1 or -1), then the application will have passed or failed -- the remaining members cannot overturn the vote. However if the verdict was not unanimous, then the remaining members will be asked to vote by email or at the next meeting.
+
+* If the vote is in doubt (for example, if 4 members are present and the vote is tied) then it is *hung* and the remaining members will be asked to vote by email or at the next meeting.
+
+* In the case of a deferred email or next-meeting vote, those members are entitled to ask the applicant further questions if they still have any upon reviewing the meeting log (or recording).
+
 
 ```{note}
-This rule was proposed and approved in a [mailing list thread](https://lists.ubuntu.com/archives/devel-permissions/2021-August/001728.html), that was discussed and then [extended to a poll](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001756.html) for which [the results](https://lists.ubuntu.com/archives/devel-permissions/2021-November/001782.html) are explained below.
+These rules are complex, a different approach to make it less misunderstandable
+is by expressing it as a {ref}`dmb-vote-function`.
 ```
-
-As *quorum* can be difficult to parse under all circumstances, an explanation from a [mailing list post](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001763.html) (and [follow up post](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001764.html) for a tie vote) is summarized in this Python function, where `total_members` is the total number of **active** board members (which is typically 7):
-
-```none
-def do_vote(*votes, total_members=7):
-
-  absent = total_members - len(votes)
-
-  net_vote = sum(votes)
-
-  min = net_vote - absent
-
-  max = net_vote + absent
-
-  if min > 0:
-
-    print(f'Vote minimum {min} > 0, vote passes')
-
-  elif max < 0:
-
-    print(f'Vote maximum {max} < 0, vote fails')
-
-  elif min == max == net_vote == 0:
-
-    print(f'Vote is tied, vote fails')
-
-  else:
-
-    print(f'Vote is between {min} and {max}, outcome unknown as quorum was not reached')
-```
-
-This function represents the meaning of **quorum** votes.
-Note that if **`total_members`** is 7, if the number of voters is less than 4, it is impossible to pass or fail.
-
 
 (dmb-application-communication)=
 ## Application-related communication

--- a/docs/who-makes-ubuntu/councils/dmb-vote-code.md
+++ b/docs/who-makes-ubuntu/councils/dmb-vote-code.md
@@ -14,39 +14,34 @@ These rules were proposed in
 * with the [results](https://lists.ubuntu.com/archives/devel-permissions/2021-November/001782.html)
 * then [clarified again](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001763.html)
 * and [finalized](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001764.html)
+* Also earlier [Quorum was publicly discussed](https://discourse.ubuntu.com/t/open-discussion-meetings-quorum/5966) on the community forum.
 
-Summarized in this Python-like function:
+All that is summarized in this Python-like function:
 
 ```python
-
 def do_vote(votes, total_members=7):
-   """
-   Print the outcome of the vote
+    """
+    This function prints exactly one of: "passed", "failed", "hung", "require follow up".
 
-   :param votes - a list of votes given being -1,0 or +1
-   :param total_members - active members of the DMB
-  """
-  absent = total_members - len(votes)
-
-  net_vote = sum(votes)
-
-  min = net_vote - absent
-
-  max = net_vote + absent
-
-  if min > 0:
-
-    print(f'Vote minimum {min} > 0, vote passes')
-
-  elif max < 0:
-
-    print(f'Vote maximum {max} < 0, vote fails')
-
-  elif min == max == net_vote == 0:
-
-    print(f'Vote is tied, vote fails')
-
-  else:
-
-    print(f'Vote is between {min} and {max}, outcome unknown as quorum was not reached')
+    :param votes: list of integers (-1, 0, +1) representing votes cast by members present
+    :param total_members: int, number of active board members (default 7)
+    """
+    quorum = 4
+    dmb_members_present = len(votes)
+    sum_of_votes = sum(votes)
+    non_abstain_votes = [v for v in votes if v != 0]
+    if dmb_members_present >= quorum:
+        # unanimous among dmb_members_present non-abstain voters
+        if non_abstain_votes and all(v == 1 for v in non_abstain):
+            print("passed and final")
+        if non_abstain_votes and all(v == -1 for v in non_abstain):
+            print("failed and final")
+        if sum_of_votes > 0:
+            print("passed, but can be overturn by absent members voting by mail until or at next meeting")
+        if sum_of_votes < 0:
+            print("failed, but can be overturn by absent members voting by mail until or at next meeting")
+        # tie or zero sum
+        print("hung, absent members are asked to vote by mail until or at next meeting")
+    else:
+        print("Not quorate - require follow up, next time majority of present members votes will suffice")
 ```

--- a/docs/who-makes-ubuntu/councils/dmb-vote-code.md
+++ b/docs/who-makes-ubuntu/councils/dmb-vote-code.md
@@ -1,0 +1,52 @@
+---
+orphan: true
+---
+
+(dmb-vote-function)=
+# DMB vote funtion
+
+The text on {ref}`dmb-rules` should be easier to consume, but if in doubt
+here a different way to express it.
+
+These rules were proposed in
+* this [mailing list thread](https://lists.ubuntu.com/archives/devel-permissions/2021-August/001728.html)
+* then [extended to a poll](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001756.html)
+* with the [results](https://lists.ubuntu.com/archives/devel-permissions/2021-November/001782.html)
+* then [clarified again](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001763.html)
+* and [finalized](https://lists.ubuntu.com/archives/devel-permissions/2021-October/001764.html)
+
+Summarized in this Python-like function:
+
+```python
+
+def do_vote(votes, total_members=7):
+   """
+   Print the outcome of the vote
+
+   :param votes - a list of votes given being -1,0 or +1
+   :param total_members - active members of the DMB
+  """
+  absent = total_members - len(votes)
+
+  net_vote = sum(votes)
+
+  min = net_vote - absent
+
+  max = net_vote + absent
+
+  if min > 0:
+
+    print(f'Vote minimum {min} > 0, vote passes')
+
+  elif max < 0:
+
+    print(f'Vote maximum {max} < 0, vote fails')
+
+  elif min == max == net_vote == 0:
+
+    print(f'Vote is tied, vote fails')
+
+  else:
+
+    print(f'Vote is between {min} and {max}, outcome unknown as quorum was not reached')
+```


### PR DESCRIPTION
We have struggled to keep logs well,.
Some are in IRC logs sometimes with an index from our pages - but not all of them
Some are in meetingology logs, again some with indexes but with variying success over the years
Others are indexed from the agenda page and now getting old.
And so on.

I've gone through all of the existing links we had in the wiki and elsewhere.
Furthermore downloaded all meeting logs ever created and searched through them to identify DMB meetings that were forgotten to be mentioned/linked. Therefore I think this is the best single collection of all of them in one place.

If anyone wants to track how that list was compiled (nothing to be proud of but pretty effective) you can see that in https://github.com/cpaelzer/dmb-meeting-history

The search function over them is also amazing.

Is it perfect - no I'm not pretending that. To be able to search well you need to be logged in, but it has a simple download-all to search whatever way you like.
I mostly like that it is just file storage on an infra (while not in sole ubuntu project control) that is not undergoing major changes anytime soon - as you know mailing lists, irc, matrix, logs retention - a lot is in flight.

With all of that not perfect but IMHO much better than what we have so far it is time to propose them to the DMB team to evaluate and vote on changing to that (or not).

Please be aware that this depends on #207 to land before.