### PR TITLE
Bump releases

### DIFF
--- a/docs/release-team/list-of-releases.md
+++ b/docs/release-team/list-of-releases.md
@@ -57,6 +57,7 @@ feature-based one), approximately every 6 months.
 
 | Version | Code name | Schedule | Docs | Release | End of Standard Support |
 | :---- | :---- | :---- | :---- | :---- | :---- |
+| Ubuntu 26.04 LTS | Resolute Raccoon | [Release Schedule](https://discourse.ubuntu.com/t/resolute-raccoon-release-schedule/47198) | [Release Notes](https://discourse.ubuntu.com/t/resolute-raccoon-release-notes/59221) | April 23, 2026 | July 2031 |
 
 
 ## Expanded Security Maintenance


### PR DESCRIPTION
### Description

Questing is now released, moved it to supported releases table. Removed broken wiki link until an alternative is found. Added 26.04 LTS to upcoming releases.

