### PR TITLE
Updating Rust: fix venv activation typo

### DIFF
--- a/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
@@ -670,7 +670,7 @@ $ python3 -m venv rustc-lintian-to-copyright
 After that, enter the virtual environment and install `pytoml`:
 
 ```none
-$ source ~/.venvs/rustc-lintian-to-copyright
+$ source ~/.venvs/rustc-lintian-to-copyright/bin/activate
 $ which python3
 $ python3 -m pip install pytoml
 ```


### PR DESCRIPTION
<!-- You can delete any parts of this template not applicable to your Pull Request. -->

### Description

There's a typo in my instructions on activating a virtual environment! The wrong file is `source`d in my given command.

I've changed the command and the instructions now work properly. 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://canonical-ubuntu-project.readthedocs-hosted.com/contributors/contribute-docs/)
- [x] I have tested my changes, and they work as expected

---
