### PR TITLE
Replace wiki links with new Project docs links

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -330,7 +330,7 @@ Closed Source Software
 
 Code name
     Short identifier used to refer to a specific Ubuntu release (e.g. , Jammy Jellyfish for Ubuntu 22.04).
-    [List of Releases with Code Names](https://wiki.ubuntu.com/Releases)
+    {ref}`List of Releases with Code Names <list-of-releases>`
 
 CoC
 Code of Conduct
@@ -505,7 +505,7 @@ Developer Membership Board
     *Work in Progress*
 
     See also:
-    * [Developer Membership Board (Ubuntu Wiki)](https://wiki.ubuntu.com/DeveloperMembershipBoard)
+    * {ref}`Developer Membership Board <dmb>`
 
 diff
     A text format that shows the difference between files that are compared.
@@ -624,7 +624,7 @@ Feature Freeze Exception
     *Work in Progress*
 
     See also:
-    * [Freeze Exception Process](https://wiki.ubuntu.com/FreezeExceptionProcess)
+    * {ref}`Freeze Exception process <freeze-exceptions>`
 
 FR
 Feature Request

--- a/docs/how-ubuntu-is-made/concepts/version-strings.md
+++ b/docs/how-ubuntu-is-made/concepts/version-strings.md
@@ -112,9 +112,8 @@ If these updates pass Ubuntu's automated testing, they do not require manual
 intervention. However, there are scenarios where the automation cannot handle
 the process.
 
-First, once the development release reaches
-[Debian import freeze](https://wiki.ubuntu.com/DebianImportFreeze), the sync
-automation is disabled.
+First, once the development release reaches {ref}`debian-import-freeze`, the
+sync automation is disabled.
 
 Therefore, if an update from Debian *is* required, it must be
 {ref}`manually synced <how-to-request-a-sync>`. Version numbering in this case is

--- a/docs/staging/dmb/ubuntu-development.md
+++ b/docs/staging/dmb/ubuntu-development.md
@@ -67,7 +67,7 @@ which is moderated (excepting registered Ubuntu developers). The
 [`ubuntu-devel-discuss` mailing list](https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-discuss)
 is available for open discussion about Ubuntu development (not for
 [reporting bugs](https://help.ubuntu.com/community/ReportingBugs#Reporting_non-crash_hardware_and_desktop_application_bugs)
-or [user support](https://www.ubuntu.com/support)). All
+or [user support](https://ubuntu.com/support)). All
 {ref}`ubuntu-developers` should subscribe to the
 [`ubuntu-devel-announce` mailing list](https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-announce),
 where important development events are announced.
@@ -157,11 +157,11 @@ create and modify Debian-format packages.
   **TODO: link is broken**
   
 * All Ubuntu developers should be familiar with the
-  [Debian New Maintainer Guide](https://www.debian.org/doc/maint-guide/); though
+  [Debian New Maintainer Guide](https://www.debian.org/doc/manuals/maint-guide/); though
   be aware that there are many differences (technical, social and procedural)
   between Ubuntu and Debian of which they must also be aware.
 
-* [A packaging tutorial](https://wiki.debian.org/PackagingTutorial) is available
+* [A packaging tutorial](https://wiki.debian.org/Packaging/Intro) is available
   from the Debian Wiki, as is
   [an explanation of maintainer scripts](https://wiki.debian.org/MaintainerScripts)
   and [further help with building packages](https://wiki.debian.org/AdvancedBuildingTips).

--- a/docs/staging/new-packages.md
+++ b/docs/staging/new-packages.md
@@ -22,9 +22,7 @@ synced into Ubuntu prior to the
 After the Debian Import Freeze, you will have to
 [file a bug](https://launchpad.net/ubuntu/+filebug/?no-redirect) with the
 summary field "Please sync `<packagename>` from debian `<distro>`" where
-`<packagename>` is the package you would like to see. Find the date for Debian
-Import Freeze on
-[the release schedule page](https://wiki.ubuntu.com/ReleaseSchedule).
+`<packagename>` is the package you would like to see.
 
 To get a package into Ubuntu, please
 [file a bug in Launchpad](https://bugs.launchpad.net/ubuntu/+filebug?no-redirect&field.tag=needs-packaging)
@@ -62,11 +60,11 @@ given subset of packages. Some of them are:
 * [Debian GNOME Team](https://wiki.debian.org/Teams/DebianGnome)
 * [Debian KDE Team](https://salsa.debian.org/qt-kde-team/)
 * [Debian XFCE Group](https://wiki.debian.org/Teams/DebianXfceGroup)
-* [Debian Games Team](https://wiki.debian.org/Games/Team)
+* [Debian Games Team](https://wiki.debian.org/Teams/Games)
 * [Debian Multimedia](https://wiki.debian.org/DebianMultimedia)
 * [Debian Perl Group](https://wiki.debian.org/Teams/DebianPerlGroup)
-* [Debian Python Modules Team](https://wiki.debian.org/Teams/PythonModulesTeam)
-* [Debian Python Applications Packaging Team](https://wiki.debian.org/Teams/PythonAppsPackagingTeam)
+* [Debian Python Modules Team](https://wiki.debian.org/Teams/PythonTeam)
+* [Debian Python Applications Packaging Team](https://wiki.debian.org/Teams/PythonTeam)
 * [Debian CLI Applications Team](https://wiki.debian.org/Teams/DebianCliAppsTeam)
 * [Debian Mozilla Extension Team](https://wiki.debian.org/Teams/DebianWebextensionTeam)
 * [Debian X Team](https://salsa.debian.org/xorg-team)
@@ -174,7 +172,7 @@ The MOTU team uses the following workflow:
 
 ### Deadline
 
-[Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze) is the latest approval
+{ref}`feature-freeze` is the latest approval
 date, it is recommended to get things done in a couple of weeks earlier, as
 getting approval may take some time.
 

--- a/docs/staging/not-AA.md
+++ b/docs/staging/not-AA.md
@@ -129,9 +129,9 @@ May be a duplicate of what's in the packaging guide
 ### Archive Administration and Freezes
 
 Archive Admins should be familiar with the
-[Freeze Exception Process](https://wiki.ubuntu.com/FreezeExceptionProcess),
-however it is the bug submitter's and sponsor's responsibility to make sure
-that the process is being followed. Some things to keep in mind for common tasks:
+{ref}`Freeze Exception process <freeze-exceptions>`, however it is the bug
+submitter's and sponsor's responsibility to make sure that the process is being
+followed. Some things to keep in mind for common tasks:
 
 * When the Archive is frozen (i.e. the week before a Milestone, or from one
   week before RC until the final release), you need an ACK from `ubuntu-release`
@@ -144,15 +144,13 @@ that the process is being followed. Some things to keep in mind for common tasks
   if filed by a `core-dev`, `ubuntu-dev` or `motu` (`universe`/`multiverse`
   only) or have an ACK by a sponsor or someone from `ubuntu-sponsors`.
 
-* After [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze), all (new or
+* After {ref}`feature-freeze`, all (new or
   otherwise) packages in the Archive (i.e. `main`, `restricted`, `universe` and
   `multiverse`) require an ACK from `ubuntu-release` for any
-  Freeze Exception (e.g. [Feature Freeze](https://wiki.ubuntu.com/FeatureFreeze),
-  [User Interface Freeze](https://wiki.ubuntu.com/UserInterfaceFreeze), and
-  [Milestone](https://wiki.ubuntu.com/MilestoneProcess)). Packages that do not
+  Freeze Exception (e.g. {ref}`user-interface-freeze`). Packages that do not
   require a Freeze Exception can be processed normally.
 
-See [Freeze Exception Process](https://wiki.ubuntu.com/FreezeExceptionProcess) for complete details.
+See {ref}`freeze-exceptions` for complete details.
 
 
 ## MIR team
@@ -163,7 +161,7 @@ Owner: MIR + AA teams
 ### OEM metapackages
 
 The Archive team runs a script, maintained by the
-[Developer Membership Board](https://wiki.ubuntu.com/DeveloperMembershipBoard),
+{ref}`Developer Membership Board <dmb>`,
 to automatically grant upload rights to `oem-*-meta` packages -- including
 packages that aren't yet in Ubuntu (uploaders can upload to NEW for these
 packages) -- to some members of Canonical's OEM delivery team via a packageset called "canonical-oem-metapackages".


### PR DESCRIPTION
### Description

Where a wiki page has been moved to the Project docs, this PR replaces the original wiki link with a new internal ref to the replacement.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

