### PR TITLE
Update mirrors.md

### DIFF
--- a/docs/release-team/mirrors.md
+++ b/docs/release-team/mirrors.md
@@ -72,7 +72,7 @@ To keep your mirror up to date and working, follow these guidelines:
 **Make sure you have enough disk space**
 : The Ubuntu archive, as of September 2025, uses about:
 
-  * **2.6TB** of disk space for the Ubuntu Package Archive
+  * **3.6TB** of disk space for the Ubuntu Package Archive
 
   * **50GB** for Ubuntu release CD images
 


### PR DESCRIPTION
updated from 2.6 to 3.6 TB for archive disk space.

<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

I recently synced the Archive mirror and it used 3.6 TB of disk space. 

---


