### PR TITLE
Add redirect for SRU explanations

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -136,4 +136,5 @@ contributors/setup/setup/ contributors/setup/set-up-for-ubuntu-development/
 contributors/merging/submit-merge-proposal/ contributors/merging/git-ubuntu-merge-proposal/
 
 SRU/index SRU/stable-release-updates/
+SRU/explanation/ SRU/
 how-ubuntu-is-made/processes/stable-release-updates/ SRU/stable-release-updates/


### PR DESCRIPTION
### Description

Adds redirect for SRU `explanation/` landing page.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
