### PR TITLE
contributors: manual merge: submit MP against `debian/sid`

### DIFF
--- a/docs/contributors/merging/merge-manually.md
+++ b/docs/contributors/merging/merge-manually.md
@@ -207,7 +207,7 @@ Next step: Check the source for errors.
 $ git push kstenerud merge-lp1802914-disco
 ```
 
-Then create a MP manually in Launchpad, and save the URL.
+Then create a MP manually in Launchpad against the `debian/sid` branch (**not** `ubuntu/devel`), and save the URL.
 
 Next step: {ref}`merge-update-the-merge-proposal`.
 


### PR DESCRIPTION
By convention, merges are submitted against Debian, otherwise you get merge conflicts from LP due to the rebase-based workflow.