### PR TITLE
Fix version string from '3.1.3ubuntu0.1' to '3.1.2ubuntu0.1' for SRU example of native packages

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/version-strings.md
+++ b/docs/how-ubuntu-is-made/concepts/version-strings.md
@@ -346,7 +346,7 @@ Native in Ubuntu:
 | `2ubuntu`                      | `3ubuntu`                      | `2ubuntu0.1`                            |
 | `2ubuntu0` (old format)        | `3ubuntu` (new format)         | `2ubuntu0.1`                            |
 | `3.1.2ubuntu.build10`          | `3.1.3ubuntu`                  | `3.1.2ubuntu0.1`                        |
-| `2ubuntu` in multiple releases | `3ubuntu` or `3ubuntu~26.04.1` | `3ubuntu~25.10.1` and `3ubuntu~25.04.1` |
+| `2ubuntu` in multiple releases | `3ubuntu` or `3ubuntu~26.04.1` | `2ubuntu~25.10.1` and `2ubuntu~25.04.1` |
 
 ```{note}
 


### PR DESCRIPTION
Corrected SRU version string format for Ubuntu native packages for consistency.