### PR TITLE
Add project slug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,10 +151,10 @@ html_theme_options = {
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #
-# TODO: If your documentation is hosted on https://docs.ubuntu.com/,
+# If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = "project"
 
 
 #######################


### PR DESCRIPTION
### Description

Adds the `slug` config parameter needed for docs on docs.ubuntu.com.

---

### Related issue

- Fixes: #246 

---

### Checklist

- [ ] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [ ] I have tested my changes, and they work as expected
