### PR TITLE
bug tags: standardize canonical team usage

### DIFF
--- a/docs/contributors/bug-triage/bug-tags.md
+++ b/docs/contributors/bug-triage/bug-tags.md
@@ -249,7 +249,7 @@ here so everyone can find and understand their meaning.
 Tags are not the only way to get awareness - Teams are structurally subscribed
 when they own (see {ref}`main-inclusion-review`) a package.
 In addition they might also subscribe their team to a specific bug so it can
-be included in future reviews of the acknowledged acklog.
+be included in future reviews of the acknowledged backlog.
 
 | Tag | Use case |
 | :---- | :---- |


### PR DESCRIPTION
This is out of a sprint discussion, we want to standardize our understanding and usage of tags.

Adding the folks that have been at the discussion for review....