### PR TITLE
Update location of update-seeds script

### DIFF
--- a/docs/tech-board/3rd-party-software-sources.md
+++ b/docs/tech-board/3rd-party-software-sources.md
@@ -246,7 +246,7 @@ Via deb package as synced from Debian:
 
 * `ember`
 
-Via [seeds](https://bazaar.launchpad.net/\~ubuntu-archive/ubuntu-archive-scripts/trunk/view/head:/update-seeds)
+Via [seeds](https://git.launchpad.net/ubuntu-archive-scripts/tree/update-seeds)
 
 * `snapd` itself (Samuele says: *`snapd` itself is also a snap that we ship in images, it uses latest/stable like `firefox` and the deb has a SRU-exception(?). The `snapd` deb also installs it if not already present when installing snaps*)
 


### PR DESCRIPTION
### Description

The `update-seeds` script location changed following the git conversion of the repo where it lives. This change updates a link pointing to it.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

