### PR TITLE
MIR: Identify who is responsible

### DIFF
--- a/docs/MIR/mir-process-states.md
+++ b/docs/MIR/mir-process-states.md
@@ -55,7 +55,7 @@ flowchart TD
 
 | Index | State               | Assignee / Subscriber                   | State-Explanation |
 |-------|---------------------|-----------------------------------------|-------------|
-| *1.*  | New / Confirmed[^1] | (unassigned)                            | Bug is queued for assignment to an MIR team member |
+| *1.*  | New / Confirmed[^1] | (unassigned, ubuntu-mir subscribed)     | Bug is queued for assignment to an MIR team member |
 | *2.*  | New / Confirmed[^1] | (assigned to MIR team member)           | On the TODO list of the assigned MIR team member |
 | *3.*  | New / Confirmed[^1] | (assigned to Security team member)      | On the TODO list of the Security team member |
 | *4.*  | In Progress         | (unassigned)                            | MIR team ACK (and if needed, Security team ACK) done, but now needs the Dependency / Seed change to happen to pull package(s) into `main`/`restricted` |


### PR DESCRIPTION
We used to have just the flowchart and table and tried to balance this between readable and easy, as well as detailed and complete. But it was neither as it was always a tradeoff.

Now that we have established a simpler explanation in the overview we can tackle issue #130 and go all in to make the flowchart fully complete (all states have bug assignee info, all transitions are indexed, ownership is colorized). Furthermore as we did for the states this establishes a table for the transitions to allow more text than what fits well in the flowchart.

Now the chart has a few crossing lines, but everying is much more correct and clearly states who we expect to handle any given state and transition.

Fixes: #130