### PR TITLE
fix: capitalize HPC and correct Legion team formatting

### DIFF
--- a/docs/community/teams/hpc-team.md
+++ b/docs/community/teams/hpc-team.md
@@ -1,5 +1,5 @@
 (hpc-team)=
-# High-performance computing team
+# High-Performance Computing team
 
 The Ubuntu High-Performance Computing (HPC) team aims to provide the highest quality HPC infrastructure, applications, and user experience for the Ubuntu ecosystem. HPC is the bedrock that underpins several major industries and critical research areas such as AI/ML, energy, bioinformatics, pharmacology, engineering, and meteorology. The HPC team works to provide the best free and open-source HPC stack from packaging all the way to cloud applications for Ubuntu.
 
@@ -45,7 +45,6 @@ Interested in joining? Send a message to the General room in the {matrix}`HPC <h
 **Maintainers**
 : The Maintainers team works on the projects owned by the Ubuntu HPC community. Their work includes maintaining HPC-specific packages, developing Charmed HPC, writing documentation, and more.
 
-**The Legion**
 **The Legion**
 : The Legion tests the latest and greatest releases of the Maintainers team's work and report/triage bugs and issues.
 


### PR DESCRIPTION
### Description

This PR fixes some issues I found in the HPC community team page after viewing it on documentation.ubuntu.com. The fixed issues are:

1. The `The Legion` section was rendering incorrectly due to `**The Legion**` being duplicated in the markdown file.
2. I changed the page title from "High-performance computing" to "High-Performance Computing". We - the HPC community team - typically capitalize the expanded HPC acronym when referring to our group name.

Let me know if you have any questions or need additional context :smiley: 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---
