### PR TITLE
Drop 32-bit powerpc from supported arches

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/supported-architectures.rst
+++ b/docs/how-ubuntu-is-made/concepts/supported-architectures.rst
@@ -37,10 +37,6 @@ Each official Ubuntu release and update includes appropriate support for these a
       - PowerPC64 Little-Endian 
       - :term:`Little-Endian`
       - :term:`RISC`
-    * - ``powerpc``
-      - PowerPC (32-bit)
-      - :term:`Big-Endian`
-      - :term:`RISC`
     * - ``s390x``
       - IBM System z, S/390, S390X       
       - :term:`Big-Endian`


### PR DESCRIPTION
We stopped doing `powerpc` builds in 17.04

https://lists.ubuntu.com/archives/ubuntu-devel-announce/2016-December/001199.html

This was noted by an LWN reader.

### Checklist

- [x] I have ~~read~~reviewed and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] ~~My pull request is linked to an existing issue (if applicable)~~
- [ ] I have tested my changes, and they work as expected

