### PR TITLE
Attempts to phrase the debian/watch paragraph more future proof

### DIFF
--- a/docs/MIR/mir-reporters-template.md
+++ b/docs/MIR/mir-reporters-template.md
@@ -268,9 +268,9 @@ TODO: - This package is minimal and will be tested in a more wide reaching
 TODO:   solution context TBD, details about this testing are here TBD
 
 [Quality assurance - packaging]
-RULE: - The package uses a debian/watch or debian/upstream/metadata files
-RULE:   whenever possible. The second options is the current modern alternative
-RULE:   for packages maintained with git-buildpackage. Consider whether that's
+RULE: - The package uses a debian/watch or debian/upstream/metadata file
+RULE:   whenever possible. The second option is the alternative for packages
+RULE:   maintained with git-buildpackage. Consider whether that's
 RULE:   still true at the time of reporting your MIR. In cases where this is
 RULE:   not possible (e.g. native packages), the package should either provide
 RULE:   a debian/README.source file or a debian/watch file (with comments only)
@@ -278,9 +278,11 @@ RULE:   providing clear instructions on how to generate the source tar file.
 RULE:   For clarity the TODOs below refer as "upstream watch file" to any
 RULE:   solution similar to the alternatives above which must be present in the
 RULE:   package so tools can detect and fetch new upstream releases.
-TODO-A: - upstream watch file is present and works
-TODO-B: - upstream watch file is not present, instead it has TBD
-TODO-C: - upstream watch file is not present because it is a native package
+TODO-A: - A mechanism to detect and fetch new upstream versions is present and works
+TODO-B: - A mechanism to detect and fetch new upstream versions is not present,
+TODO-B:   instead it has TBD
+TODO-C: - A mechanism to detect and fetch new upstream versions is not present
+TODO-C:   because it is a native package
 
 RULE: - The package should define the correct "Maintainer:" field in
 RULE:   debian/control. This needs to be updated, using `update-maintainer`


### PR DESCRIPTION
### Description

Here's a humble attempt to tackle #328 by making the MIR reporters template more generic and future proof in regards to the `debian/watch` file being present or not. The motivation is better explained in the motivating issue.

---

### Related issue

- Fixes #328

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [NA] I have tested my changes, and they work as expected

---



