### PR TITLE
aa-priority-mismatches: use the correct URL for the txt variant

### DIFF
--- a/docs/maintainers/AA/aa-priority-mismatches.md
+++ b/docs/maintainers/AA/aa-priority-mismatches.md
@@ -26,7 +26,7 @@ but **too-low** priorities don't really impact users.
 ## Priority mismatch report
 
 The `priority-mismatches` file (
-[txt](https://ubuntu-archive-team.ubuntu.com/priority-mismatches.html) or
+[txt](https://ubuntu-archive-team.ubuntu.com/priority-mismatches.txt) or
 [html](https://ubuntu-archive-team.ubuntu.com/priority-mismatches.html))
 tracks and reports priority mismatches in the Archive.
 


### PR DESCRIPTION
The priority mismatches "txt" variant refers to the .html instead of the .txt