### PR TITLE
bug-tags: the need-...-retrace tags are still in use

### DIFF
--- a/docs/contributors/bug-triage/bug-tags.md
+++ b/docs/contributors/bug-triage/bug-tags.md
@@ -118,7 +118,7 @@ These tags were relevant previously for Ubuntu bugs and may still appear in some
 
 | Tag | Use case |
 | :---- | :---- |
-| [`need-$arch-retrace`](https://launchpad.net/ubuntu/+bugs?field.tag=need-amd64-retrace) | The bug contains a crash report that needs retracing with `apport-retrace` on the `$arch` actitecture |
+| [`need-$arch-retrace`](https://launchpad.net/ubuntu/+bugs?field.tag=need-amd64-retrace) | The bug contains a crash report that needs retracing with `apport-retrace` on the `$arch` architecture |
 
 ### Kernel-specific
 


### PR DESCRIPTION
Crash reports can be submitted to the error tracker or to launchpad. If they are submitted to launchpad they use those tags and a service is processing the queue, generating a debug backtrace and cleaning the coredump from the reports before making them accessible to bug triage (default is private because the coredumps can include sensitive information)