### PR TITLE
MIR: include a mention that d/copyright needs to cover vendored content

### DIFF
--- a/docs/MIR/mir-reporters-template.md
+++ b/docs/MIR/mir-reporters-template.md
@@ -473,6 +473,10 @@ TODO-C:   compressed), refreshing that code is outlined in debian/README.source
 TODO-D: - This package uses vendored code, refreshing that code is outlined
 TODO-D:   in debian/README.source
 
+TODO-A: - This does not use vendored code
+TODO-B: - This package uses vendored code, the debian/copyright has been
+TODO-B:   updated to cover the vendored content
+
 TODO-A: - This package is not rust based
 TODO-B: - This package is rust based and vendors all non language-runtime
 TODO-B:   dependencies


### PR DESCRIPTION
The topic came as part of the archive admin rejection on https://bugs.launchpad.net/ubuntu/+bug/2133149 where a package vendored didn't have its debian/copyright updated to cover the vendored crates. It has been observed that a part of the packages that did vendor their dependencies in recent cycles as part of the MIR process didn't update the debian/copyright. Adding an item to the vendoring checklist well help communicating the expectation.