### PR TITLE
DMB: add link meeting logs Launchpad code page

### DIFF
--- a/docs/who-makes-ubuntu/councils/dmb-meetings.md
+++ b/docs/who-makes-ubuntu/councils/dmb-meetings.md
@@ -47,7 +47,8 @@ The goals of these logs is to:
 - allow someone to prepare for an application based on former ones
 
 To be able to achieve that in an easy way they are made publicly available
-in a single repository at [DMB Meeting logs](https://git.launchpad.net/~developer-membership-board/+git/dmb-meeting-history/tree/?h=main).
+in a single repository at [DMB Meeting logs](https://launchpad.net/~developer-membership-board/+git/dmb-meeting-history)
+([browse the logs](https://git.launchpad.net/~developer-membership-board/+git/dmb-meeting-history/tree/?h=main)).
 Old logs, from all the different sources of the past were added and now allow
 an easy way to download for any other kind of processing.
 
@@ -92,5 +93,3 @@ See [the original thread](https://lists.ubuntu.com/archives/devel-permissions/20
 
 * Make sure that the applicant has signed the [Ubuntu Code of Conduct](https://launchpad.net/codeofconduct/2.0).
   It must be signed by every Ubuntu Developer.
-
-


### PR DESCRIPTION
### Description

Point the "DMB Meeting logs" link to the Launchpad code page (that shows how to clone the repository) and add a "browse the logs" link to look at the logs in the repository.


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

