### PR TITLE
Add 'bootloader' to spelling exception list

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -19,6 +19,7 @@ bioinformatics
 blocklisted
 boolean
 bootable
+bootloader
 bootloaders
 bugfix
 bugtracker


### PR DESCRIPTION
### Description

Add "bootloader" to spelling exception list, it's currently triggering the spellchecker on unrelated PRs.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

