### PR TITLE
DMB application announcement requirement

### DIFF
--- a/docs/who-makes-ubuntu/developers/dmb-application.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application.md
@@ -42,7 +42,7 @@ Collect endorsements
 
 Once you have enough endorsements
 : If you haven't already, add yourself to the [DMB agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634).
-: Then you can announce your application and meeting date by writing an email to the `devel-permissions@` mailing list. Your email should include:
+: Announce your application and meeting date by writing an email to the `devel-permissions@` mailing list. Your email should include:
 
   * The link to your Discourse application page
 

--- a/docs/who-makes-ubuntu/developers/dmb-application.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application.md
@@ -42,7 +42,7 @@ Collect endorsements
 
 Once you have enough endorsements
 : If you haven't already, add yourself to the [DMB agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634).
-: Announce your application and meeting date by writing an email to the `devel-permissions@` mailing list. Your email should include:
+: Announce your application and meeting date by writing an email to the `devel-permissions@` mailing list at `lists.ubuntu.com`. Your email should include:
 
   * The link to your Discourse application page
 

--- a/docs/who-makes-ubuntu/developers/dmb-application.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application.md
@@ -19,10 +19,6 @@ To understand how the Ubuntu development skills map to the various uploader leve
 
 ## Application process overview
 
-Reserve your spot
-: Check the Developer Membership Board (DMB) [agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634) to see when the DMB next meeting is, and to check the queue of applications.
-: Only 2 applications are considered each meeting so if there's a queue, make sure to reserve a spot for when you think you'll be ready for consideration.
-
 Create your space
 : If it's your first time applying for upload rights, {ref}`dmb-create-a-discourse-post`. If you already have a page, you can
   reuse it.
@@ -41,7 +37,7 @@ Collect endorsements
 : {ref}`dmb-collect-endorsements` from those who have worked with you.
 
 Once you have enough endorsements
-: If you haven't already, add yourself to the [DMB agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634).
+: Add yourself to the [DMB agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634).
 : Announce your application and meeting date by writing an email to the `devel-permissions@` mailing list at `lists.ubuntu.com`. Your email should include:
 
   * The link to your Discourse application page


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

We have a couple of cases of DMB applicants not announcing their applications prior to the application meeting, which causes difficulty in our process since the mailing list archive also currently doubles as our application history archive, and then we cannot easily record the result or find it afterwards.

Examining the documentation, it looks like perhaps it might be being implied that the announcement is optional, so adjust the wording to make it clear that it is part of the process.

The DMB agreed on Monday that while we might want a different process for archiving applications and their outcomes, we don't have a process yet, so until we conclude the specifics of any replacement, we should keep the existing system so that we don't inadvertently end up with three by only half-doing some change now.

### Checklist

- [N/A] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [N/A] My pull request is linked to an existing issue (if applicable)
- [N/A] I have tested my changes, and they work as expected
