### PR TITLE
Update contact instructions for SRU team

### DIFF
--- a/docs/SRU/howto/contact.rst
+++ b/docs/SRU/howto/contact.rst
@@ -24,7 +24,7 @@ Contact the SRU team
   - `#ubuntu-devel <https://wiki.ubuntu.com/IRC>`__ on Libera.Chat
   - The `ubuntu-devel-discuss <https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-discuss>`__ mailing list
 
-- If you **do have upload access**, you can contact the SRU team here:
+- If your **patch has been uploaded**, you can contact the SRU team here:
 
   - `#sru:ubuntu.com <https://matrix.to/#/#sru:ubuntu.com>`__ channel on Matrix, dedicated to SRU topics.
   - The `ubuntu-release <https://lists.ubuntu.com/mailman/listinfo/ubuntu-release>`__ mailing list


### PR DESCRIPTION
### Description

The original phrase **if you have upload access** might be interpreted in a few ways. I have personally interpreted this up until now as if I must be an uploader to have the rights to talk in the SRU channel on Matrix to avoid causing noise.

But this might have intended to express that _once a patch has been uploaded_, that's when the SRU team should be contacted and not before, thus that's when the SRU channel is useful.

I'm opening this to provoke the question and come up with clarification.

### Related issue

- Fixes: #377 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [ ] I have tested my changes, and they work as expected



