### PR TITLE
build fix: pin myst-parser version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx>=0.5.1
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
+myst-parser~=4.0
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
### Description
Pin the myst-parser version according to instructions received from the documentation team, to fix the dependency loop that causes the docs to fail to build.

### Related issue
- Fixes: #383 

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
