### PR TITLE
rota: switch Andreas and Timo

### DIFF
--- a/docs/SRU/reference/rota.rst
+++ b/docs/SRU/reference/rota.rst
@@ -19,9 +19,9 @@ following schedule:
 +-----------+-----------------------------------------------------------------+
 | Wednesday | Nick Rosbrook (enr0n)                                           |
 +-----------+-----------------------------------------------------------------+
-| Thursday  | Andreas Hasenack (ahasenack)                                    |
+| Thursday  | Timo Aaltonen (tjaalton)                                        |
 +-----------+-----------------------------------------------------------------+
-| Friday    | Timo Aaltonen (tjaalton)                                        |
+| Friday    | Andreas Hasenack (ahasenack)                                    |
 +-----------+-----------------------------------------------------------------+
 
 See also: :ref:`How-to → Contact the SRU team <howto-contact>`


### PR DESCRIPTION
### Description

Andreas (me) requested to switch his SRU shift to another day, due to too many meetings on Thursdays, which reduce the time available for SRU processing. Timo agreed to swap his day, and this PR updates the ROTA.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
