### PR TITLE
Fix duplicate-label warnings

### DIFF
--- a/docs/SRU/reference/exception-MariaDB-Galera-Updates.rst
+++ b/docs/SRU/reference/exception-MariaDB-Galera-Updates.rst
@@ -27,7 +27,7 @@ infrastructure stack, providing database functionality for numerous applications
 and services. For the past decade, Debian releases have shipped MariaDB instead
 of MySQL.
 
-.. _upstream_release_policy:
+.. _mariadb_upstream_release_policy:
 
 Upstream release policy
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,7 +43,7 @@ to the MariaDB releases they support:
 * 25.3, 26.4: Long-term supported new major releases
 * 25.3.34, 25.3.27, 26.4.20: Minor maintenance releases with only critical bug fixes and security fixes
 
-.. _ubuntu_releases_affected:
+.. _mariadb_ubuntu_releases_affected:
 
 Ubuntu releases affected by this exception
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ related to specific edge cases and were quickly addressed in subsequent updates.
 * https://launchpad.net/ubuntu/+source/galera-4/+publishinghistory
 * https://launchpad.net/ubuntu/+source/galera-3/+publishinghistory
 
-.. _quality_assurance:
+.. _mariadb_quality_assurance:
 
 Quality assurance
 -----------------
@@ -142,7 +142,7 @@ However, it was not recorded later when
 https://wiki.ubuntu.com/StableReleaseUpdates#Documentation_for_Special_Cases was
 created.
 
-.. _security_uploads:
+.. _mariadb_security_uploads:
 
 Security uploads
 ^^^^^^^^^^^^^^^^
@@ -166,7 +166,7 @@ stable releases made that do not fix any CVEs and so do not need to go to
 ``-security``. This documentation is to clarify the process for those releases;
 stable releases which fix CVEs will go to ``-security`` as normal.
 
-.. _process:
+.. _mariadb_process:
 
 Process
 -------
@@ -189,7 +189,7 @@ To do this we will:
 
 5. Watch the migration page until it lands in the -updates pocket. Fix any regression that might appear during the process.
 
-.. _sru_template:
+.. _mariadb_sru_template:
 
 SRU template
 ^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

Fixes the following build warnings:

```
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:33: WARNING: duplicate label upstream_release_policy, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:49: WARNING: duplicate label ubuntu_releases_affected, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:86: WARNING: duplicate label quality_assurance, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:148: WARNING: duplicate label security_uploads, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:172: WARNING: duplicate label process, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:195: WARNING: duplicate label sru_template, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:33: WARNING: duplicate label upstream_release_policy, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:49: WARNING: duplicate label ubuntu_releases_affected, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:86: WARNING: duplicate label quality_assurance, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:148: WARNING: duplicate label security_uploads, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:172: WARNING: duplicate label process, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
docs/SRU/reference/exception-MariaDB-Galera-Updates.rst:195: WARNING: duplicate label sru_template, other instance in docs/SRU/reference/exception-Intel-Graphics-Updates.rst
```

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [n/a] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

This wen unnoticed/ignored for quite a long time. We might want to consider re-enabling "fail on warning". WDYT, @s-makin?
