### PR TITLE
DMB fix meeting max

### DIFF
--- a/docs/who-makes-ubuntu/developers/dmb-application.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application.md
@@ -21,7 +21,7 @@ To understand how the Ubuntu development skills map to the various uploader leve
 
 Reserve your spot
 : Check the Developer Membership Board (DMB) [agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634) to see when the DMB next meeting is, and to check the queue of applications.
-: Only few applications are considered each meeting so if there's a queue, make sure to reserve a spot for when you think you'll be ready for consideration.
+: Only a few applications are considered each meeting so if there's a queue, make sure to reserve a spot for when you think you'll be ready for consideration.
 
 Create your space
 : If it's your first time applying for upload rights, {ref}`dmb-create-a-discourse-post`. If you already have a page, you can


### PR DESCRIPTION
I want us to process more folks than one, but the do-ability of that is up for debate.
But when checking I found that the docs say 2 while 1 as defined in the DMB agenda is correct.
Let us fix this and make the content on the agenda page (on discourse) to be the single truth for this.