### PR TITLE
Update Bug Squad contact info

### DIFF
--- a/docs/staging/dmb/ubuntu-development.md
+++ b/docs/staging/dmb/ubuntu-development.md
@@ -102,9 +102,7 @@ policy you have on how you want your bugs to be handled (e.g. assignment, tags,
 etc.). When adding significant chunks of new information to Debugging Procedures,
 please send a note to `ubuntu-bugsquad@lists.ubuntu.com` about it.
 
-Members of the Bug Squad can be found on the `#ubuntu-devel` channel on Matrix.
-There is also the [`ubuntu-bugsquad` mailing list](https://lists.ubuntu.com/mailman/listinfo/ubuntu-bugsquad)
-for general discussion regarding bugs and bug triaging.
+Members of the Bug Squad can be found on the {matrix}`ubuntu-devel` channel on Matrix.
 
 
 ### Release-critical bugs


### PR DESCRIPTION
### Description

This is in one of the staging pages so it might go away anyway, but updated the Bug Squad contact info to point only to the Matrix channel.


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

