### PR TITLE
Bug Responses - EOL - add 25.04 to list

### DIFF
--- a/docs/contributors/bug-triage/bug-responses.md
+++ b/docs/contributors/bug-triage/bug-responses.md
@@ -658,6 +658,7 @@ If the specific release has reached End of Life (as per {ref}`list-of-releases` 
 
 Thank you for reporting this bug to Ubuntu.
 
+Ubuntu 25.04 (plucky) reached end-of-life on January 15, 2026
 Ubuntu 24.10 (oracular) reached end-of-life on July 10, 2025
 Ubuntu 23.04 (lunar) reached end-of-life on January 25, 2024
 Ubuntu 23.10 (mantic) reached end-of-life on July 11, 2024


### PR DESCRIPTION
add 25.04 to EOL list

15-Jan-2026 matching https://lists.ubuntu.com/archives/ubuntu-announce/2026-January/000320.html

Reason:  I just tried to use that section; but plucky wasn't there... historically that's a WIKI EDIT & bingo... this instead.

### Checklist

- [ X ] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [ ] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

