### PR TITLE
Add 'rustls' to custom wordlist

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -149,6 +149,7 @@ Rockcraft
 Rosbrook
 rulebook
 runtimes
+rustls
 Rustup
 sandboxed
 sbuild


### PR DESCRIPTION
Add 'rustls' to custom wordlist.

### Checklist

- [X] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [X] My pull request is linked to an existing issue (if applicable)
- [X] I have tested my changes, and they work as expected


