### PR TITLE
Fix keyboard shortcut

### DIFF
--- a/docs/contributors/check-accessibility.md
+++ b/docs/contributors/check-accessibility.md
@@ -98,7 +98,7 @@ For a more thorough test, you need these shortcuts:
 | Move to previous interactive item | {kbd}`Shift+Tab` |
 | Interact with an item or group | {kbd}`Enter` |
 | Exit a group | {kbd}`Esc` |
-| Move between windows/main area, top bar and dashboard | {kbd}`Ctrl+Alt+Tab` |
+| Move between windows, top bar, desktop icons, and dock | {kbd}`Ctrl+Alt+Tab` |
 
 
 ### Keyboard navigation checklist


### PR DESCRIPTION
- Fix wrong shortcut for moving between windows, top bar, desktop icons and dock (it's Ctrl+Alt+Tab, not Ctrl+Tab)
- Tweak description for the same shortcut