### PR TITLE
remove schopin as +1 coordinator

### DIFF
--- a/docs/contributors/advanced/plus-one-maintenance.md
+++ b/docs/contributors/advanced/plus-one-maintenance.md
@@ -18,7 +18,7 @@ e.g. if it involved in a massive transition.
 Most of the day-to-day communication around +1 should take place on the public
 [Ubuntu Development](https://matrix.to/#/#devel:ubuntu.com) channel on Matrix.
 
-The [Debcrafters](https://launchpad.net/~debcrafters-packages) team, and [Simon Chopin ](https://launchpad.net/~schopin) in particular, is responsible for
+The [Debcrafters](https://launchpad.net/~debcrafters-packages) team is responsible for
 coordinating the effort.
 
 ## Who can participate?


### PR DESCRIPTION
### Description

^As per title, to continue the general trend of naming teams rather than individuals

---

### Related issue

- Fixes: #404 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

