### PR TITLE
dmb: switch internal discussions to matrix

### DIFF
--- a/docs/who-makes-ubuntu/councils/dmb.md
+++ b/docs/who-makes-ubuntu/councils/dmb.md
@@ -22,9 +22,11 @@ The DMB currently holds {ref}`meetings <dmb-meetings>` every two weeks.
 
 Most asynchronous conversation happens on the [`devel-permissions` mailing list](https://lists.ubuntu.com/mailman/listinfo/devel-permissions).
 This mailing list is public ([`devel-permissions@archives`](https://lists.ubuntu.com/archives/devel-permissions/)), as are our general process and policy discussions.
-If private communication is required, such as discussing the performance of an individual, then use the [private `developer-membership-board` list](https://lists.ubuntu.com/mailman/listinfo/developer-membership-board).
 
 You can discuss developer application matters on the {matrix}`ubuntu-dmb-public` Matrix channel.
+
+If private communication among DMB members is required, such as discussing the performance of an individual,
+then use the {matrix}`ubuntu-dmb-private` Matrix channel.
 
 
 ## Applying for Developer Membership


### PR DESCRIPTION
We no more use the internal mailing list for a while, proving we can go without.

Instead what worked well is keeping discussions in public as usual and for the few private words use a member only matrix channel. Refer to that in the docs acknowledging this