### PR TITLE
Packaging guide redirects

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -227,8 +227,7 @@ contributors/bug-fix/bug-control/ who-makes-ubuntu/specialist-teams/bug-control-
 # SRU
 # =============================================================================
 
-SRU/explanation/ SRU/
-
+SRU/explanation/ SRU/stable-release-updates/
 SRU/index SRU/stable-release-updates/
 how-ubuntu-is-made/processes/stable-release-updates/ SRU/stable-release-updates/
 


### PR DESCRIPTION
### Description

The redirects file was becoming quite confusing to navigate. I've tidied it up by splitting redirects into sections and grouping page redirects by the *target* path to make it easier to update all relevant target pages when a page moves.

I am also adding page-by-page redirects for all the pages in the packaging guide, so that we can do a simple URL redirection in the packaging guide itself without losing any traffic or showing 404s.

This allows us to finally sunset the packaging guide RTD project

---

### Related issue

- Related to: #134
- Related to: #345 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

