### PR TITLE
DMB: UCB do not need an agenda entry

### DIFF
--- a/docs/who-makes-ubuntu/developers/dmb-application.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application.md
@@ -22,6 +22,7 @@ To understand how the Ubuntu development skills map to the various uploader leve
 Reserve your spot
 : Check the Developer Membership Board (DMB) [agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634) to see when the DMB next meeting is, and to check the queue of applications.
 : Only a few applications are considered each meeting so if there's a queue, make sure to reserve a spot for when you think you'll be ready for consideration.
+: Applications to {ref}`Ubuntu Contributing Developers <dmb-joining-contributing>` are handled only via the mailing list, therefore no agenda entry is needed for those (the DMB will vote as replies to your post to the `devel-permissions@` mailing list).
 
 Create your space
 : If it's your first time applying for upload rights, {ref}`dmb-create-a-discourse-post`. If you already have a page, you can


### PR DESCRIPTION
When discussing the recent influx of Contributing Developers we re-agreed on not needing an Agenda entry for them.
Document that along the application process so people that apply would know.