### PR TITLE
Improve glossary links - proposed migration / pockets

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -1044,7 +1044,7 @@ Pocket
     * `-backports`
 
     See also:
-    * {ref}Pockets (explanation) <archive-pockets>`
+    * {ref}`Pockets (explanation) <archive-pockets>`
 
 POSIX
     Abbreviation for **Portable Operating System Interface**: A family of


### PR DESCRIPTION
While explaining proposed migration in a meeting I wanted to make sure it is explained in the docs.
It is, but hard to find as the glossary is the first hit and it lacks a good connection to the more detailed content.

Along that I found that the ref for pockets was just wrong and fixed it as well.