### PR TITLE
Add 'sysroot' to custom wordlist

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -172,6 +172,7 @@ subiquity
 subkey
 subkeys
 supercomputing
+sysroot
 systemd
 tarball
 Tegra


### PR DESCRIPTION
### Description

"sysroot" managed to sneak past the spellchecker in another PR and is now triggering on subsequent PRs. Adding to custom wordlist.


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

