### PR TITLE
Remove `~bpo` components from Rust version strings in the Rust backporting tutorial

### DIFF
--- a/docs/maintainers/niche-package-maintenance/rustc/backport-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/backport-rust.md
@@ -518,15 +518,13 @@ We also need to re-include the LLVM copyright stanza in `debian/copyright`:
 
 #### Re-including the LLVM source
 
-Update the {ref}`changelog version number <rust-version-strings>` accordingly. Your version number should now contain either `~bpo0` or `~bpo2` depending on the status of `libgit2`.
-
 You can now {ref}`regenerate the orig tarball <rust-version-strings>`, which should now include the upstream LLVM source in `src/llvm-project`.
 
 After regenerating the orig tarball, get all the new LLVM files and overlay them on your working directory:
 
 ```none
 $ cd ..
-$ tar -xf rustc-<X.Y>_<X.Y.Z>+dfsg0ubuntu1\~bpo<N>.orig.tar.xz
+$ tar -xf rustc-<X.Y>_<X.Y.Z>+dfsg~<series>.orig.tar.xz
 $ cp -ra rustc-<X.Y.Z>-src/src/llvm-project rustc/src
 $ cd -
 ```
@@ -736,15 +734,13 @@ When you refresh the patch and pop everything off again, the patch diff should l
 
 #### Re-including the `libgit2` source
 
-Update the {ref}`changelog version number <rust-version-strings>` accordingly. Your version number should now contain either `~bpo0` or `~bpo10`, depending on the status of LLVM.
-
 You can now {ref}`regenerate the orig tarball <rust-generating-the-orig-tarball>`, which should now include the upstream `libgit2` source in `vendor/libgit2-sys-<version>/libgit2`.
 
 After regenerating the orig tarball, get all the new `libgit2` files and overlay them on your working directory:
 
 ```none
 $ cd ..
-$ tar -xf rustc-<X.Y>_<X.Y.Z>+dfsg0ubuntu1\~bpo<N>.orig.tar.xz
+$ tar -xf rustc-<X.Y>_<X.Y.Z>+dfsg~<series>.orig.tar.xz
 $ cp -ra rustc-<X.Y.Z>-src/vendor/libgit2-sys-<version>/libgit2 rustc/vendor/libgit2-sys-<version>/
 $ cd -
 ```


### PR DESCRIPTION
### Description

The `~bpo` components should not be present in the Rust version strings anymore - they are part of what we are calling the ["legacy format"](https://canonical-ubuntu-documentation-library--432.com.readthedocs.build/project/maintainers/niche-package-maintenance/rustc/rust-version-strings/#legacy-version-string-format).

This PR updates the backporting docs to reflect this, removing an unnecessary update to the changelog version number and updating the respective orig tarball name.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

