### PR TITLE
DMB: hint at joining the matrix channel

### DIFF
--- a/docs/who-makes-ubuntu/councils/dmb.md
+++ b/docs/who-makes-ubuntu/councils/dmb.md
@@ -26,7 +26,7 @@ Most asynchronous conversation happens on the [`devel-permissions` mailing list]
 This mailing list is public ([`devel-permissions@archives`](https://lists.ubuntu.com/archives/devel-permissions/)), as are our general process and policy discussions.
 
 You can discuss developer application matters on the {matrix}`ubuntu-dmb-public` Matrix channel.
-Applicants should join that channel even if they don't have questions to get passed the Meets link.
+Applicants should join that channel, even if they don't have questions, to receive the Meets link.
 
 If private communication among DMB members is required, such as discussing the performance of an individual,
 then use the {matrix}`ubuntu-dmb-private` Matrix channel.


### PR DESCRIPTION
We had to fall back to a private ping today, encouraging them to join does help and lowers the bar if they have questions later.