### PR TITLE
Update container-stack SRU exception policy

### DIFF
--- a/docs/SRU/reference/exception-Docker-Updates.rst
+++ b/docs/SRU/reference/exception-Docker-Updates.rst
@@ -43,6 +43,20 @@ this page for the sake of the SRU team member doing the review!).
 are fixing any CVEs, we should sync with the security team and perform
 the uploads through the security pocket instead.**
 
+Starting with Ubuntu 25.10 (Questing Quokka), two new packages are included in
+this stack and are covered by this exception: `containerd-stable` and
+`runc-stable`. These two packages were created to provide stability for
+user deployments when that is preferred over receiving the latest upstream
+features for the software shipped in those packages.
+
+Although `containerd-stable` and `runc-stable` are part of this exception,
+their upgrade policy differs from the process described above. Once a new
+Ubuntu series is released, these packages in that series must only receive
+**patch-level** upgrades under this policy. For instance, if
+`containerd-stable` `2.2.1` was released in Ubuntu 26.04, this exception only
+covers upgrading it to versions greater than `2.2.1` and lower than `2.3.0~`.
+The remainder of this exception applies normaly to these packages.
+
 QA
 --
 


### PR DESCRIPTION
### Description

Update the container-stack SRU exception policy to include the new containerd-stable and runc-stable packages in the exception

- Fixes: #1234

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [-] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Hello SRU team, I would like to include the new *-stable packages in the container-stack exception. The policy for upgrading those do differ from the other packages, but it would still be nice to have them in the same policy instead of having a new one for them.

You can have more information on these packages and why they were created at https://discourse.ubuntu.com/t/ubuntu-server-gazette-issue-8-containers-steady-paths-for-agile-stacks/68680

