### PR TITLE
Consistently abbreviate feature freeze exception as `FFe`

### DIFF
--- a/docs/contributors/bug-fix/bug-fixing-checklist.md
+++ b/docs/contributors/bug-fix/bug-fixing-checklist.md
@@ -139,7 +139,7 @@ to the version you need before getting the tarball.
 - [ ] {ref}`FFe <feature-freeze-exceptions>`:
 
   ```
-  [[ Feature Freeze Exception ]]
+  [[ Feature Freeze exception ]]
   [Description]
      * A description of the proposed changes, with sufficient detail to estimate their potential impact on the distribution
   [Rationale]

--- a/docs/contributors/bug-triage/bug-types.md
+++ b/docs/contributors/bug-triage/bug-types.md
@@ -163,7 +163,7 @@ Bugs in this category can have subjects like:
 * Please promote \<package\> to \<component\>  
 * Please demote \<package\> to \<component\>  
 * Main inclusion report (MIR)
-* [FFE] bug summary  
+* FFe bug summary
 
 Bugs in this category will have **any** of the following teams subscribed:  
 

--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -650,8 +650,8 @@ FTI
 Failed to install
     *Work in Progress*
 
-FFE
-Feature Freeze Exception
+FFe
+Feature Freeze exception
     *Work in Progress*
 
     See also:

--- a/docs/release-team/request-a-freeze-exception.md
+++ b/docs/release-team/request-a-freeze-exception.md
@@ -75,9 +75,9 @@ there is already a bug related to the exception, you can reuse the bug), e.g.
 
 Your bug contents need to include the following:
 
-* Add `[FFE]` to the bug summary (large title).
+* Add `FFe:` to the bug summary (large title).
 
-* Add an FFE stanza to the description starting with `## FFE ##`.
+* Add an FFe stanza to the description starting with `## FFe ##`.
 
 * **State the reason why you feel it is necessary** (e.g. other bugs it fixes).
 

--- a/docs/who-makes-ubuntu/developers/diagrams/advanced.txt
+++ b/docs/who-makes-ubuntu/developers/diagrams/advanced.txt
@@ -6,7 +6,7 @@ block-beta
     AdvancedStudies("Advanced studies")
     columns 1
     space:3
-    StudyFFE{{"<a href=https://documentation.ubuntu.com/project/release-team/freeze-exceptions/>Study FFE</a>"}}
+    StudyFFe{{"<a href=https://documentation.ubuntu.com/project/release-team/freeze-exceptions/>Study FFe</a>"}}
     PlusOne{{"<a href=https://documentation.ubuntu.com/project/contributors/advanced/plus-one-maintenance/>Study +1</a>"}}
   end
 
@@ -16,7 +16,7 @@ block-beta
     UpstreamSubmissionFixes["Upstream submission fixes/features"]
     UpstreamSubmissionDelta["Upstream submission of delta"]
     MilestonesAndExceptions["Milestones and exceptions"]
-    DoAnFFE["Do An FFE"]
+    DoAnFFe["Do An FFe"]
     PlusOneShadowing["+1 Shadowing"]
   end
 
@@ -31,7 +31,7 @@ block-beta
 
   AdvancedTasks --> PPU
   AdvancedTasks --> PackageSet
-  StudyFFE --> DoAnFFE
+  StudyFFe --> DoAnFFe
   PlusOne --> PlusOneShadowing
 
   classDef Studies fill: #FFDAB9, stroke:#F4A460;


### PR DESCRIPTION
### Description

Consistently abbreviate feature freeze exception as `FFe`

Release team members have been updating bug reports to use this spelling, so let's save their time and instruction people to use it to begin with.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
