### PR TITLE
de-duplicate update-maintainer entries

### DIFF
--- a/docs/contributors/patching/work-with-debian-patches.md
+++ b/docs/contributors/patching/work-with-debian-patches.md
@@ -219,30 +219,10 @@ At this stage only the patch itself (here `debian/patches/my-changes.patch`)
 is committed.
 ```
 
-The updated changelog (and maybe an updated control file, in case
-`update-maintainer` needs to be run) will be committed later (all separately).
-This simplifies a later rebase.
-
-
-### About update-maintainer
-
-`update-maintainer` is a script that checks the `Maintainer` field of a
-`debian/control` file and (if needed):
-
-* Sets the `Maintainer` field to:
-  `Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>`
-
-* Adds a property `XSBC-Original-Maintainer` with the original value of the
-  `Maintainer` field.
-
-If a Debian package introduces a change that does not work on Ubuntu, we need
-to change the package to fix the bug. Then, when someone has a problem with the
-Ubuntu package they might contact the Debian maintainer and report the bug to
-them, although they have nothing to do with our modification. Therefore we
-change the value of the `Maintainer` field.
-
+The updated {ref}`changelog <debian-directory-changelog>` (and maybe an updated
+control file, in case {ref}`update-maintainer <debian-maintainer>` needs to be
+run) will be committed later (all separately). This simplifies a later rebase.
 
 ## Further reading
 
 * [Debian wiki - Using Quilt](https://wiki.debian.org/UsingQuilt)
-* [Ubuntu wiki - Debian Maintainer Field](https://wiki.ubuntu.com/DebianMaintainerField)

--- a/docs/how-ubuntu-is-made/concepts/debian-directory.rst
+++ b/docs/how-ubuntu-is-made/concepts/debian-directory.rst
@@ -13,6 +13,7 @@ This article explains the different files important to the packaging of Ubuntu p
 These are required for all packages. A number of additional files in the :file:`debian/` directory may be used to customize and configure the behavior of the package. Some of these files are discussed in this article, but this is not meant to be a complete list.
 
 
+.. _debian-directory-changelog:
 The :file:`changelog` file
 --------------------------
 


### PR DESCRIPTION
There is a good and complete page about update maintainer in key-concept and a shorter variant in working with patches. Now this has not strictly much to do with patches so it is the wrong place. Furthermore duplication makes this hard to maintain. It also pointed to the wiki in further reading which isn't needed anymore.

Changes:
- drop the duplicate shorter content
- refer to key concepts for changelog
- refer to key concepts for update-maintainer
- drop the reference to the old wiki entry