### PR TITLE
Remove `libgit2-dev` downgrading section from Rust backport docs

### DIFF
--- a/docs/maintainers/niche-package-maintenance/rustc/backport-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/backport-rust.md
@@ -605,7 +605,7 @@ $ git add src/llvm-project
 (rust-vendoring-libgit2)=
 ### Vendoring `libgit2`
 
-A common problem when backporting is that the version of the `libgit2-dev` C library in the target Ubuntu release is too old for what the backported version of `rustc` requires. In this case, the {lpsrc}`libgit2 C library <libgit2>`, which is normally included in the vendored `libgit2-sys` crate, must be vendored.
+A common problem when backporting is that the version of the `libgit2-dev` C library in the target Ubuntu release is too old for what the backported version of `rustc` requires. In that case, the {lpsrc}`libgit2 C library <libgit2>` must be vendored. The `libgit2` library is already bundled in the vendored `libgit2-sys` crate but is typically stripped from the tarball during packaging; the following steps restore its source and remove the dependency on `libgit2-dev`.
 
 
 #### Re-including `libgit2` in `Files-Excluded`


### PR DESCRIPTION
### Description

After working for several weeks on trying to sort out `libgit2` issues in our builds, @blkerby realized that downgrading `libgit2-dev` is a problematic method - instead, we should always attempt to vendor `libgit2` if the `libgit2-dev` version in the target release is incompatible with the `rustc` version we're backporting.

This PR removes the section that suggests and describes the process of downgrading `libgit2-dev`.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
