### PR TITLE
fix: fixed typo `ForwardMail` > `Forward Email`

### DIFF
--- a/docs/community/membership/ubuntu-email.md
+++ b/docs/community/membership/ubuntu-email.md
@@ -1,9 +1,9 @@
 (ubuntu-email)=
 # Ubuntu Member email alias
 
-Ubuntu Members are granted special `@Ubuntu.com` aliases they can use to send and receive emails. Official members looking to enable this perk will need to set up a ForwardMail account by following these steps:
+Ubuntu Members are granted special `@Ubuntu.com` aliases they can use to send and receive emails. Official members looking to enable this perk will need to set up a Forward Email account by following these steps:
 
-1. Log into [ForwardMail](https://forwardemail.net/en/ubuntu) using your UbuntuOne SSO account. Under {guilabel}`Quick Links` beside the [`ubuntu.com`](https://ubuntu.com/) domain, select **Aliases**.
+1. Log into [Forward Email](https://forwardemail.net/en/ubuntu) using your UbuntuOne SSO account. Under {guilabel}`Quick Links` beside the [`ubuntu.com`](https://ubuntu.com/) domain, select **Aliases**.
 
 ![1](one.png)
 


### PR DESCRIPTION
Fixed typo in Forward Email.