### PR TITLE
Remove old PG from intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -405,11 +405,6 @@ if os.path.exists("./reuse/substitutions.yaml"):
 
 intersphinx_mapping = {
     "ubuntu-server": ("https://documentation.ubuntu.com/server/", None),
-    "pkg-guide": (
-        "https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/"
-        "en/2.0-preview/",
-        None,
-    ),
     "starter-pack": (
         "https://canonical-starter-pack.readthedocs-hosted.com/latest/",
         None,


### PR DESCRIPTION
### Description

The inclusion of the old packaging guide in the intersphinx mapping throws errors in the local build, this PR removes it from the mapping

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

