### PR TITLE
Update intersphinx mapping for ubuntu-server

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -404,7 +404,7 @@ if os.path.exists("./reuse/substitutions.yaml"):
 # Add configuration for intersphinx mapping
 
 intersphinx_mapping = {
-    "ubuntu-server": ("https://documentation.ubuntu.com/server/", None),
+    "ubuntu-server": ("https://ubuntu.com/server/docs/", None),
     "starter-pack": (
         "https://canonical-starter-pack.readthedocs-hosted.com/latest/",
         None,


### PR DESCRIPTION
### Description

While touching the configuration file earlier I noticed that the intersphinx mapping for the Server docs can be updated to the new URL


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

