### PR TITLE
SRU: Add crash and makedumpfile SRU exception policy

### DIFF
--- a/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
+++ b/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
@@ -1,0 +1,199 @@
+.. _crash_and_makedumpfile_sru_exception:
+
+Crash and Makedumpfile SRU Exception
+====================================
+
+This document describes the policy for introducing new upstream- and
+micro- releases of the crash and makedumpfile packages into Ubuntu
+releases. Crash typically has two releases per calendar year, around
+April and November. This can include minor (8.0.4 -> 8.0.5) and major
+version updates (7.3.0 -> 8.0.0), and both scenarios should be covered
+under the testing plan detailed in this page. Makedumpfile also follows
+similar release cadence.
+
+.. _about_makedumpfile:
+
+About makedumpfile
+------------------
+
+Makedumpfile is a user space tool which is run by kdump-tools inside the
+kdump kernel to compress the kernel dump. This compressed dump can be
+read by tools such as crash.
+
+Upstream resources:
+
+- `Porject page <https://github.com/makedumpfile/makedumpfile>`_
+- `Mailing List Archive <https://lists.infradead.org/pipermail/kexec/>`_
+
+.. _about_crash:
+
+About crash
+-----------
+
+Crash is a self-contained tool that can be used to analyze kernel memory
+dumps (e.g. created by makedumpfile). It's also able to investigate live
+systems through e.g. /proc/kcore.
+
+Upstream resources:
+
+- `Project page <https://crash-utility.github.io/>`_
+- `Upstream changelog <https://crash-utility.github.io/crash.changelog.html>`_
+- `Extensions modules <https://crash-utility.github.io/extensions.html>`_
+- `Contribution Guidelines <https://github.com/crash-utility/crash/wiki>`_
+
+.. _rationale_for_the_exception:
+
+Rationale for the exception
+---------------------------
+
+Crash is extremely helpful for analysis and RCA of kernel issues.
+Particularly for HWE kernels, new features could be introduced that
+change the memory structures being parsed by crash. Keeping crash
+updated to latest stable versions keeps compatibility for older kernels,
+while allowing LTS releases to work with kernel dumps from newer Ubuntu
+versions.
+
+Makedumpfile is responsible for generating the compressed memory dump
+from /proc/vmcore which can be consumed by tools such as crash[1]. The
+kdump-tools package uses makedumpfile by default[2]. Since the structure
+and layout of /proc/vmcore is dependent on the kernel, updates to
+makedumpfile are necessary to ensure proper functionality.
+
+Furthermore, the release of both of these projects are disconnected from
+upstream and the Ubuntu release cycles. It is possible the the upstream
+projects have the right support for a new kernel release, but there may
+not be a release for some time. In such situations, SRU of specific
+patches from the upstream crash and makedumpfile projects may be
+required.
+
+.. _upstream_policy_enforces_backwards_compatibility:
+
+Upstream policy enforces backwards compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Although crash and makedumpfile do not seem to have a formal release
+policy documented, upstream maintainers take extensive care so that
+these tools always remain backwards-compatible. This ensures minimal
+breakage and greater stability of these tools. Updates include bug fixes
+and patches to ensure the tool can continue analyzing memory structures
+of newer kernels. For crash, is documented in the `Contribution
+Guidelines <https://github.com/crash-utility/crash/wiki>`_.
+Makedumpfile maintains a support matrix of the package against previous
+kernel versions as documented in the `upstream
+repository <https://github.com/makedumpfile/makedumpfile>`_.
+
+.. _microreleases_are_not_restricted_to_bug_fixes:
+
+Microreleases are not restricted to bug fixes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As there doesn't seem to be a formal release policy documented, there's
+no criteria of what can be included in upstream releases. Historically,
+this has involved compatibility patches to new kernels and
+architectures, regression fixes, cleanup commits, as well as minor
+quality-of-life features. Considering a new release is not necessarily
+restricted to bug fixes only, we can't always push an upstream release
+to Ubuntu as per the `New upstream
+microreleases <https://canonical-sru-docs.readthedocs-hosted.com/en/latest/reference/requirements/#new-upstream-microreleases>`_
+section of the SRU docs. The upstream project also doesn't seem to have
+a formal testing procedure documented, which we hope to cover for Ubuntu
+more extensively through the test plans below.
+
+.. _sru_process:
+
+SRU Process
+-----------
+
+For new releases of the crash utility, the following criteria need to be
+validated and documented in a public Launchpad bug:
+
+1. Crash must be able to correctly open a makedumpfile compressed image of the system
+2. Crash must be able to correctly execute against the generic and HWE kernels
+
+Kernel crash dumps should be captured with default parameters for a
+given Ubuntu release, as this will cover the more general scenario for
+the tool. Alternatively and with appropriate justification from the SRU
+requester, crash can be validated against a live system image as well.
+
+The SRU should ensure all the supported architectures are working
+correctly with a new crash version. Likewise, we're only concerned that
+crash is able to open and parse kernel dumps correctly, extensions or
+specific crash commands **are not going to be covered** with this test.
+
+.. _regression_testing:
+
+Regression Testing
+~~~~~~~~~~~~~~~~~~
+
+The targets above should cover most of the crash users, but it does
+leave out specific flavors and other derivative kernels like
+*linux-aws*, *linux-azure*, etc. Kernel team has integrated kdump
+testing within their SRU Regression Testing suite and hence would be
+running this test against all of the prepared kernel once per kernel SRU
+cycle. This testing is comprehensive and includes all the supported
+architectures.
+
+.. _requesting_the_sru:
+
+Requesting the SRU
+------------------
+
+The SRU should be requested following the regular SRU process, with
+additional notes about the validation steps described above. A suggested
+template for new releases covered under the SRU exception can be found
+below.
+
+Template
+~~~~~~~~
+
+New Upstream release for *crash* and/or *makedumpfile*
+
+[Impact]
+
+This new release contains important bug fixes and compatibility patches
+for [...].
+
+[Upstream Changes]
+
+TODO: link to upstream changelog, making note of any significant
+commits like compatibility to new kernel versions or new architectures
+
+[Test Plan]
+
+The test plan from
+`CrashMakedumpfileUpdates <https://github.com/ubuntu/ubuntu-project-docs/blob/main/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst>`_
+was followed. Attached are console logs for each covered kernel version
+and architecture.
+
+[Where problems could occur]
+
+TODO: document any potential issues or risky patches, as per regular
+SRU process
+
+[Other Info]
+
+TODO: fill out any relevant information to the test plan or the new
+release
+
+Checklist
+~~~~~~~~~
+-  Ensure crash can open dumps for the GA kernel on supported architectures
+-  Ensure crash can open dumps for the HWE kernel on supported architectures
+-  Attach or link to logs confirming above tests
+-  Update the list of previous crash updates under this SRU Exception below
+
+.. _previous_crash_updates_bugs:
+
+Previous crash updates bugs
+---------------------------
+
+- 
+
+References
+----------
+
+[1]
+https://manpages.debian.org/unstable/makedumpfile/makedumpfile.8.en.html
+
+[2]
+https://manpages.debian.org/unstable/kdump-tools/kdump-tools.5.en.html

--- a/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
+++ b/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
@@ -107,8 +107,8 @@ SRU Process
 For new releases of the crash utility, the following criteria need to be
 validated and documented in a public Launchpad bug:
 
-1. Crash must be able to correctly open a makedumpfile compressed image of the system
-2. Crash must be able to correctly execute against the generic and HWE kernels
+-  Crash must be able to correctly open a makedumpfile compressed image of the system
+-  Crash must be able to correctly execute against the generic and HWE kernel
 
 Kernel crash dumps should be captured with default parameters for a
 given Ubuntu release, as this will cover the more general scenario for
@@ -119,6 +119,15 @@ The SRU should ensure all the supported architectures are working
 correctly with a new crash version. Likewise, we're only concerned that
 crash is able to open and parse kernel dumps correctly, extensions or
 specific crash commands **are not going to be covered** with this test.
+
+The following steps can be followed to test a new version of crash and/or
+makedumpfile package:
+
+1. Install the kernel's debug symbols packages
+2. Install the updated crash/makedumpfile packages as well as `kdump-tools` and `kexec-tools` packages
+3. Ensure the system is ready to capture the dump using `sudo kdump-config show`. Reboot if necessary.
+4. Trigger kernel crash (i.e `echo c | sudo tee /proc/sysrq-trigger`)
+5. Once the machine reboots, see if crash is able to load the dumpfile against kernel's debug symbols file (i.e `crash <DEBUG_SYM_FILE> <DUMP_FILE>`.
 
 .. _regression_testing:
 

--- a/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
+++ b/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
@@ -22,7 +22,7 @@ read by tools such as crash.
 
 Upstream resources:
 
-- `Porject page <https://github.com/makedumpfile/makedumpfile>`_
+- `Makedumpfile project page <https://github.com/makedumpfile/makedumpfile>`_
 - `Mailing List Archive <https://lists.infradead.org/pipermail/kexec/>`_
 
 .. _about_crash:
@@ -36,7 +36,7 @@ systems through e.g. /proc/kcore.
 
 Upstream resources:
 
-- `Project page <https://crash-utility.github.io/>`_
+- `Crash project page <https://crash-utility.github.io/>`_
 - `Upstream changelog <https://crash-utility.github.io/crash.changelog.html>`_
 - `Extensions modules <https://crash-utility.github.io/extensions.html>`_
 - `Contribution Guidelines <https://github.com/crash-utility/crash/wiki>`_
@@ -46,25 +46,26 @@ Upstream resources:
 Rationale for the exception
 ---------------------------
 
-Crash is extremely helpful for analysis and RCA of kernel issues.
-Particularly for HWE kernels, new features could be introduced that
+Crash is extremely helpful for analysis and root cause analysis of kernel 
+issues. Particularly for HWE kernels, new features could be introduced that
 change the memory structures being parsed by crash. Keeping crash
 updated to latest stable versions keeps compatibility for older kernels,
 while allowing LTS releases to work with kernel dumps from newer Ubuntu
 versions.
 
-Makedumpfile is responsible for generating the compressed memory dump
-from /proc/vmcore which can be consumed by tools such as crash[1]. The
-kdump-tools package uses makedumpfile by default[2]. Since the structure
+Makedumpfile is responsible for `generating the compressed memory dump <https://manpages.debian.org/unstable/makedumpfile/makedumpfile.8.en.html>`_
+from /proc/vmcore which can be consumed by tools such as crash. The
+kdump-tools package uses `makedumpfile by default <https://manpages.debian.org/unstable/kdump-tools/kdump-tools.5.en.html>`_. Since the structure
 and layout of /proc/vmcore is dependent on the kernel, updates to
 makedumpfile are necessary to ensure proper functionality.
 
 Furthermore, the release of both of these projects are disconnected from
-upstream and the Ubuntu release cycles. It is possible the the upstream
-projects have the right support for a new kernel release, but there may
-not be a release for some time. In such situations, SRU of specific
-patches from the upstream crash and makedumpfile projects may be
-required.
+upstream and the Ubuntu release cycles. It is possible the upstream projects of 
+crash and makedumpfile have the right support for a new kernel release. When the
+kernel is backported as an HWE kernel to an Ubuntu LTS release, it may break 
+the working of `crash and/or makedumpfile <https://bugs.launchpad.net/ubuntu/+source/makedumpfile/+bug/2125145>`_.
+In such situations, SRU of a newer upstream release or specific patches from the
+upstream crash and makedumpfile projects may be required for the LTS release.
 
 .. _upstream_policy_enforces_backwards_compatibility:
 
@@ -138,7 +139,7 @@ The targets above should cover most of the crash users, but it does
 leave out specific flavors and other derivative kernels like
 *linux-aws*, *linux-azure*, etc. Kernel team has integrated kdump
 testing within their SRU Regression Testing suite and hence would be
-running this test against all of the prepared kernel once per kernel SRU
+running this test against all of the prepared kernels once per kernel SRU
 cycle. This testing is comprehensive and includes all the supported
 architectures.
 
@@ -171,8 +172,14 @@ commits like compatibility to new kernel versions or new architectures
 
 The test plan from
 `CrashMakedumpfileUpdates <https://github.com/ubuntu/ubuntu-project-docs/blob/main/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst>`_
-was followed. Attached are console logs for each covered kernel version
+is followed. Attached are console logs for each covered kernel version
 and architecture.
+
+Checklist:
+
+-  Crash can open dumps for the GA kernel on supported architectures
+-  Crash can open dumps for the HWE kernel on supported architectures
+-  Update the list of previous crash updates under this SRU Exception below
 
 [Where problems could occur]
 
@@ -184,13 +191,6 @@ SRU process
 TODO: fill out any relevant information to the test plan or the new
 release
 
-Checklist
-~~~~~~~~~
--  Ensure crash can open dumps for the GA kernel on supported architectures
--  Ensure crash can open dumps for the HWE kernel on supported architectures
--  Attach or link to logs confirming above tests
--  Update the list of previous crash updates under this SRU Exception below
-
 .. _previous_crash_updates_bugs:
 
 Previous crash updates bugs
@@ -198,11 +198,3 @@ Previous crash updates bugs
 
 - 
 
-References
-----------
-
-[1]
-https://manpages.debian.org/unstable/makedumpfile/makedumpfile.8.en.html
-
-[2]
-https://manpages.debian.org/unstable/kdump-tools/kdump-tools.5.en.html

--- a/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
+++ b/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
@@ -159,44 +159,51 @@ below.
 Template
 ~~~~~~~~
 
-New Upstream release for *crash* and/or *makedumpfile*
+::
 
-[Impact]
+    New Upstream release for *crash* and/or *makedumpfile*
 
-This new release contains important bug fixes and compatibility patches
-for [...].
+    [Impact]
 
-[Upstream Changes]
+    This new release contains important bug fixes and compatibility patches
+    for [...].
 
-TODO: link to upstream changelog, making note of any significant
-commits like compatibility to new kernel versions or new architectures
+    [Upstream Changes]
 
-[Test Plan]
+    TODO: link to upstream changelog, making note of any significant
+    commits like compatibility to new kernel versions or new architectures
 
-The test plan from
-:ref:`reference_crash_and_makedumpfile_updates`
-is followed. Attached are console logs for each covered kernel version
-and architecture.
+    [Test Plan]
 
-Checklist:
+    Checklist:
 
--  Crash can open dumps for the GA kernel on supported architectures
--  Crash can open dumps for the HWE kernel on supported architectures
--  Update the list of previous crash updates under this SRU Exception below
+    -  Crash can open dumps for the GA kernel on supported architectures
+    -  Crash can open dumps for the HWE kernel on supported architectures
+    -  Update the list of previous crash updates under this SRU Exception below
 
-Once the regression testing is completed by kernel team, they would be
-responsible to add a comment to approve the release of package(s) to updates.
-This approval is mandatory for release.
+    The test plan followed for each kernel combination is as follows:
 
-[Where problems could occur]
+    1. Install the kernel’s debug symbols packages
+    2. Install the updated crash/makedumpfile packages as well as kdump-tools and kexec-tools packages
+    3. Ensure the system is ready to capture the dump using sudo kdump-config show. Reboot if necessary.
+    4. Trigger kernel crash (i.e echo c | sudo tee /proc/sysrq-trigger)
+    5. Once the machine reboots, see if crash is able to load the dumpfile against kernel’s debug symbols file (i.e crash <DEBUG_SYM_FILE> <DUMP_FILE>.
 
-TODO: document any potential issues or risky patches, as per regular
-SRU process
+    Attached are the console logs for each combination.
 
-[Other Info]
+    Once the regression testing is completed by kernel team, they are
+    responsible to add a comment to approve the release of package(s) to updates.
+    This approval is mandatory for release.
 
-TODO: fill out any relevant information to the test plan or the new
-release
+    [Where problems could occur]
+
+    TODO: document any potential issues or risky patches, as per regular
+    SRU process
+
+    [Other Info]
+
+    TODO: fill out any relevant information to the test plan or the new
+    release
 
 .. _previous_crash_updates_bugs:
 

--- a/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
+++ b/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
@@ -122,14 +122,14 @@ extensions or specific crash commands **are not going to be covered** with
 this test.
 
 The following steps must be followed to test a new version of crash and/or
-makedumpfile package for the generic and HWE kernels:
+makedumpfile package for both the generic and HWE kernels of the target
+Ubuntu release:
 
 1. Install the kernel's debug symbols packages
 2. Install the updated crash/makedumpfile packages as well as `kdump-tools` and `kexec-tools` packages
 3. Ensure the system is ready to capture the dump using `sudo kdump-config show`. Reboot if necessary.
 4. Trigger kernel crash (i.e `echo c | sudo tee /proc/sysrq-trigger`)
 5. Once the machine reboots, see if crash is able to load the dumpfile against kernel's debug symbols file (i.e `crash <DEBUG_SYM_FILE> <DUMP_FILE>`.
-6. Repeat once 
 
 .. _regression_testing:
 
@@ -142,7 +142,9 @@ leave out specific flavors and other derivative kernels like
 testing within their SRU Regression Testing suite and hence would be
 running this test against all of the prepared kernels once per kernel SRU
 cycle. This testing is comprehensive and includes all the supported
-architectures.
+architectures. Final release of the packages to updates would require
+a sign-off from the kernel team. This can be in form of a comment on the
+SRU bug.
 
 .. _requesting_the_sru:
 
@@ -181,6 +183,10 @@ Checklist:
 -  Crash can open dumps for the GA kernel on supported architectures
 -  Crash can open dumps for the HWE kernel on supported architectures
 -  Update the list of previous crash updates under this SRU Exception below
+
+Once the regression testing is completed by kernel team, they would be
+responsible to add a comment to approve the release of package(s) to updates.
+This approval is mandatory for release.
 
 [Where problems could occur]
 

--- a/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
+++ b/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
@@ -100,7 +100,6 @@ section of the SRU docs. The upstream project also doesn't seem to have
 a formal testing procedure documented, which we hope to cover for Ubuntu
 more extensively through the test plans below.
 
-.. _sru_process:
 
 SRU Process
 -----------

--- a/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
+++ b/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst
@@ -1,7 +1,7 @@
-.. _crash_and_makedumpfile_sru_exception:
+.. _reference_crash_and_makedumpfile_updates:
 
-Crash and Makedumpfile SRU Exception
-====================================
+Crash and Makedumpfile Updates
+==============================
 
 This document describes the policy for introducing new upstream- and
 micro- releases of the crash and makedumpfile packages into Ubuntu
@@ -53,9 +53,9 @@ updated to latest stable versions keeps compatibility for older kernels,
 while allowing LTS releases to work with kernel dumps from newer Ubuntu
 versions.
 
-Makedumpfile is responsible for `generating the compressed memory dump <https://manpages.debian.org/unstable/makedumpfile/makedumpfile.8.en.html>`_
+:manpage:`makedumpfile(8)` is responsible for generating the compressed memory dump
 from /proc/vmcore which can be consumed by tools such as crash. The
-kdump-tools package uses `makedumpfile by default <https://manpages.debian.org/unstable/kdump-tools/kdump-tools.5.en.html>`_. Since the structure
+:manpage:`kdump-tools(5)` package uses makedumpfile by default. Since the structure
 and layout of /proc/vmcore is dependent on the kernel, updates to
 makedumpfile are necessary to ensure proper functionality.
 
@@ -63,9 +63,10 @@ Furthermore, the release of both of these projects are disconnected from
 upstream and the Ubuntu release cycles. It is possible the upstream projects of 
 crash and makedumpfile have the right support for a new kernel release. When the
 kernel is backported as an HWE kernel to an Ubuntu LTS release, it may break 
-the working of `crash and/or makedumpfile <https://bugs.launchpad.net/ubuntu/+source/makedumpfile/+bug/2125145>`_.
-In such situations, SRU of a newer upstream release or specific patches from the
-upstream crash and makedumpfile projects may be required for the LTS release.
+the working of crash and/or makedumpfile (see `LP#2125145 <https://bugs.launchpad.net/ubuntu/+source/makedumpfile/+bug/2125145>`_).
+Backporting specific patches on each HWE kernel release can be error prone and
+and time consuming. In such situations, SRU of a newer upstream release may be
+required for the LTS release.
 
 .. _upstream_policy_enforces_backwards_compatibility:
 
@@ -107,27 +108,28 @@ SRU Process
 For new releases of the crash utility, the following criteria need to be
 validated and documented in a public Launchpad bug:
 
--  Crash must be able to correctly open a makedumpfile compressed image of the system
+-  Crash must be able to correctly open a makedumpfile compressed dump of the system
 -  Crash must be able to correctly execute against the generic and HWE kernel
 
 Kernel crash dumps should be captured with default parameters for a
 given Ubuntu release, as this will cover the more general scenario for
-the tool. Alternatively and with appropriate justification from the SRU
-requester, crash can be validated against a live system image as well.
+the tool.
 
 The SRU should ensure all the supported architectures are working
-correctly with a new crash version. Likewise, we're only concerned that
-crash is able to open and parse kernel dumps correctly, extensions or
-specific crash commands **are not going to be covered** with this test.
+correctly with a new crash version through the test plan. Likewise, we're only
+concerned that crash is able to open and parse kernel dumps correctly,
+extensions or specific crash commands **are not going to be covered** with
+this test.
 
-The following steps can be followed to test a new version of crash and/or
-makedumpfile package:
+The following steps must be followed to test a new version of crash and/or
+makedumpfile package for the generic and HWE kernels:
 
 1. Install the kernel's debug symbols packages
 2. Install the updated crash/makedumpfile packages as well as `kdump-tools` and `kexec-tools` packages
 3. Ensure the system is ready to capture the dump using `sudo kdump-config show`. Reboot if necessary.
 4. Trigger kernel crash (i.e `echo c | sudo tee /proc/sysrq-trigger`)
 5. Once the machine reboots, see if crash is able to load the dumpfile against kernel's debug symbols file (i.e `crash <DEBUG_SYM_FILE> <DUMP_FILE>`.
+6. Repeat once 
 
 .. _regression_testing:
 
@@ -170,7 +172,7 @@ commits like compatibility to new kernel versions or new architectures
 [Test Plan]
 
 The test plan from
-`CrashMakedumpfileUpdates <https://github.com/ubuntu/ubuntu-project-docs/blob/main/docs/SRU/reference/exception-CrashMakedumpfile-Updates.rst>`_
+:ref:`reference_crash_and_makedumpfile_updates`
 is followed. Attached are console logs for each covered kernel version
 and architecture.
 

--- a/docs/SRU/reference/package-specific.rst
+++ b/docs/SRU/reference/package-specific.rst
@@ -762,3 +762,10 @@ Toolchains:
 * Java: `Java updates PPA <https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa>`__
 * Go: `Go updates PPA <https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/golang>`__
 * Python: `Python updates PPA <https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/python>`__
+
+Crash And Makedumpfile
+~~~~~~~~~~~~~~~~~~~~~~
+
+The crash and makedumpfile source packages may be uploaded according to the
+procedure documented in :ref:`CrashMakedumpfile-Updates <reference_crash_and_makedumpfile_updates>`.
+

--- a/docs/SRU/reference/package-specific.rst
+++ b/docs/SRU/reference/package-specific.rst
@@ -39,6 +39,7 @@ the Technical Board.
     exception-Bind9-Updates
     exception-Certbot-Updates
     exception-Cloudinit-Updates
+    exception-CrashMakedumpfile-Updates
     exception-Curtin-Updates
     exception-DPDK-Updates
     exception-Docker-Updates


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

This PR introduces SRU exception policy for Crash and Makedumpfile packages to support proper functionality of these packages against new kernel releases.

---

### Checklist

- [ *] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-

---

Thank you for reviewing this document!

