### PR TITLE
Fix the wrong link to Ubuntu Kylin

### DIFF
--- a/docs/community/teams/ubuntu-teams.md
+++ b/docs/community/teams/ubuntu-teams.md
@@ -71,7 +71,7 @@ Below is a list of key teams that operate within the Ubuntu project and their re
 | [Kubuntu Team](https://wiki.ubuntu.com/Kubuntu) | Provide the KDE desktop and software to integrate KDE with Ubuntu |
 | [Lubuntu Team](https://wiki.ubuntu.com/Lubuntu) | Provide a lightweight and easy-to-use distribution, based on Ubuntu and {spellexception}`LXQt` |
 | [Ubuntu Budgie Team](https://ubuntubudgie.org/team/) | Provide an Ubuntu-powered desktop integrating the Budgie Desktop Environment |
-| [Ubuntu Kylin Team](https://wiki.ubuntu.com/Ubuntu%20kylin) | Provide exquisite user experience and make an operating system catering to the specific needs of Chinese users |
+| [Ubuntu Kylin Team](https://wiki.ubuntu.com/Ubuntu%20Kylin) | Provide exquisite user experience and make an operating system catering to the specific needs of Chinese users |
 | [Ubuntu MATE Team](https://ubuntu-mate.community/) | Provide an Ubuntu-based operating system that beautifully integrates the MATE desktop |
 | [Ubuntu Studio Team](https://wiki.ubuntu.com/UbuntuStudio) | Provide an installable disk for multimedia production machines and better maintain those apps in Ubuntu |
 | [Ubuntu Unity Team](https://launchpad.net/~unity7maintainers) | Provide the Unity desktop environment for the modern Ubuntu desktop |

--- a/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
@@ -28,7 +28,7 @@ Delegated teams admitting their own members:
 
 
 Delegated teams whose prospective members apply to the {ref}`Developer Membership Board <dmb>`:
-: * [Ubuntu Kylin](https://wiki.ubuntu.com/UbuntuKylin) Developers (Launchpad: [`~ubuntukylin-dev`](https://launchpad.net/~ubuntukylin-dev))
+: * [Ubuntu Kylin](https://wiki.ubuntu.com/Ubuntu%20Kylin) Developers (Launchpad: [`~ubuntukylin-dev`](https://launchpad.net/~ubuntukylin-dev))
 : * Ubuntu GNOME Developers (Launchpad: [`~ubuntu-gnome-dev`](https://launchpad.net/~ubuntu-gnome-dev))
 : * Ubuntu Bazaar Uploaders (Launchpad: [`~ubuntu-bzr-dev`](https://launchpad.net/~ubuntu-bzr-dev))
 : * Ubuntu CLI/Mono Uploaders (Launchpad: [`~ubuntu-cli-mono-dev`](https://launchpad.net/~ubuntu-cli-mono-dev))


### PR DESCRIPTION
Fix the wrong link to Ubuntu Kylin wiki page.