### PR TITLE
Fix RUST_BOOTSTRAP_DIR path when invoking debian/rules

### DIFF
--- a/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
@@ -275,7 +275,7 @@ Vendor tarball rule
 After that, call the `vendor-tarball` rule in `debian/rules`. This uses `cargo-vendor-filterer` to generate a vendor directory that _only_ contains the dependencies required by supported Ubuntu targets. It then repacks this directory into the `vendor` tarball component. Make sure you point it to your installed Rust toolchain via `RUST_BOOTSTRAP_DIR`:
 
 ```none
-$ RUST_BOOTSTRAP_DIR=~/.rustup/toolchains/<X.Y.Z>-x86_64-unknown-linux-gnu/bin/rustc \
+$ RUST_BOOTSTRAP_DIR=~/.rustup/toolchains/<X.Y.Z>-x86_64-unknown-linux-gnu \
     debian/rules vendor-tarball
 ```
 
@@ -523,7 +523,7 @@ Certain {term}`control files <control file>`, such as `debian/control` and `debi
 `update-version`, in `debian/rules`, updates all relevant control files automatically. In order to run it, it must be given an up-to-date Rust toolchain via `RUST_BOOTSTRAP_DIR`:
 
 ```none
-$ RUST_BOOTSTRAP_DIR=~/.rustup/toolchains/<X.Y.Z>-x86_64-unknown-linux-gnu/bin/rustc \
+$ RUST_BOOTSTRAP_DIR=~/.rustup/toolchains/<X.Y.Z>-x86_64-unknown-linux-gnu \
     debian/rules update-version
 ```
 


### PR DESCRIPTION
### Description

We needed to change the format of the `RUST_BOOTSTRAP_DIR` in `d/rules` recently. I've updated the docs to reflect that.

I have personally verified that the new instructions work properly for both instances in which they appear in the docs.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] I have tested my changes, and they work as expected

---
