### PR TITLE
Add issue template and make it the default

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,43 @@
+name: Feedback
+description: Provide feedback on the Ubuntu Project documentation.
+title: "[Feedback]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to fill out this feedback!**
+        We really appreciate your input, and it will help us improve the documentation.
+        
+        Please provide an appropriate title at the top of this page.
+        
+        ---
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: Please enter the URL of the page you are referring to.
+      placeholder: https://documentation.ubuntu.com/project/
+    validations:
+      required: true
+  - type: checkboxes
+    id: content
+    attributes:
+      label: Select an option
+      description: Please let us know what issue you encountered with the documentation.
+      options:
+        - label: I found what I was looking for
+        - label: I couldn't find what I was looking for
+        - label: I found the information, but it was incorrect/incomplete/confusing
+        - label: I encountered a technical issue (e.g., broken link, image not loading)
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: |
+        Please provide a detailed description of the issue:
+        - What part of the documentation were you trying to use?
+        - What did you expect to happen, and what actually happened?
+        - Any error messages or screenshots you can provide would be very helpful.
+    validations:
+      required: true
+


### PR DESCRIPTION
### Description

Phase 1 of issue automation: This PR adds an issue template, and makes it the default option when opening a new issue.


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

