### PR TITLE
Improve linkchecker runtime

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -221,6 +221,8 @@ linkcheck_ignore = [
     "https://discourse.canonical.com/",
     "https://git.launchpad.net/ubuntu/+source/*",
     "https://wiki.ubuntu.com/*",
+    "https://en.wikipedia.org/*",
+    "https://github.com/*",
 ]
 
 


### PR DESCRIPTION
### Description

We have quite a lot of broken and redirecting links. To facilitate fixing them, I need to speed up the linkchecker, so adding the optimizations I applied to the Server docs.

Also adding some rate limited domains to the ignore list - they are not actually broken, but when we run the linkchecker every 10th one "fails" it.



### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

