### PR TITLE
[chore] Update redirecting links in SRU pages

### DIFF
--- a/docs/SRU/explanation/requirements.rst
+++ b/docs/SRU/explanation/requirements.rst
@@ -59,20 +59,19 @@ far as to overrule our own release policies.
 Even the simplest of changes can cause unexpected regressions due to
 lurking problems:
 
--  In bug `81125 <https://bugs.launchpad.net/bugs/81125>`__, the upgrade
+-  In :lpbug:`81125`, the upgrade
    regression had nothing to do with the content of the change that
    triggered it: any user who had installed the ``libpthread20`` package
    would encounter a problem the next time ``libc6`` was upgraded.
--  In bug `309674 <https://bugs.launchpad.net/bugs/309674>`__, the
+-  In :lpbug:`309674`, the
    failure was a misbuild due to timestamp skew in the build process.
    The underlying problem existed in the source package in the original
    release, but would only manifest in a small percentage of builds.
--  In bug `559822 <https://bugs.launchpad.net/bugs/559822>`__, a C++
+-  In :lpbug:`559822`, a C++
    library (``wxwidgets2.8``) was uploaded with no code changes. Due to an
    underlying toolchain change/bug, this caused an ABI change, causing a
-   lot of unrelated packages to break (see bug
-   `610975 <https://bugs.launchpad.net/bugs/610975>`__)
--  In bug `2055718 <https://bugs.launchpad.net/bugs/2055718>`__,
+   lot of unrelated packages to break (see :lpbug:`610975`)
+-  In :lpbug:`2055718`,
    updating the package is the trigger for the bug, because the package
    update reconfigures ``tzdata``.
 

--- a/docs/SRU/explanation/standard-processes.rst
+++ b/docs/SRU/explanation/standard-processes.rst
@@ -90,7 +90,7 @@ for this situation are as follows:
 
 -  An SRU must not be released if outstanding autopkgtest regressions
    are reported on the `Pending SRU
-   Report <https://people.canonical.com/~ubuntu-archive/pending-sru.html>`__.
+   Report <https://ubuntu-archive-team.ubuntu.com/pending-sru.html>`__.
 -  Ideally regressions can be fixed with new uploads to the proposed
    pockets as required. Fixes for autopkgtests are generally always
    acceptable. However uploads providing only test fixes will generally
@@ -125,7 +125,7 @@ thereby causing supported package managers (update-manager) not to
 install the update.
 
 The progress of phased updates is visible in a
-`report <http://people.canonical.com/~ubuntu-archive/phased-updates.html>`__
+`report <https://ubuntu-archive-team.ubuntu.com/phased-updates.html>`__
 which is updated by the same job that does the phasing.
 
 See also:

--- a/docs/SRU/howto/common-issues.rst
+++ b/docs/SRU/howto/common-issues.rst
@@ -60,7 +60,7 @@ Where problems could occur
    specific bug being fixed in the upload, here is a place to give any
    additional test cases to help to ensure that there are no regressions
    in the update. Think "what if this change is wrong? How would that
-   show up?" `1590321 <https://bugs.launchpad.net/bugs/1590321>`__ is an
+   show up?" :lpbug:`1590321` is an
    example of a simple fix with a legitimate regression analysis.
 
 Upload

--- a/docs/SRU/internal.rst
+++ b/docs/SRU/internal.rst
@@ -73,7 +73,7 @@ The following review procedure is recommended:
    -  If something is wrong: send the feedback to the bug and set the
       task to "Incomplete"
 
-The `pending SRUs <http://people.canonical.com/~ubuntu-archive/pending-sru>`__ should
+The `pending SRUs <https://ubuntu-archive-team.ubuntu.com/pending-sru>`__ should
 also be reviewed to see whether or not there are any to be released or
 removed from the archive. The process for dealing with these follows:
 
@@ -92,7 +92,7 @@ package to -security ping a member of the
 `ubuntu-security <https://launchpad.net/~ubuntu-security/+members>`__
 team.
 
--  `Currently pending SRUs <http://people.canonical.com/~ubuntu-archive/pending-sru.html>`__
+-  `Currently pending SRUs <https://ubuntu-archive-team.ubuntu.com/pending-sru.html>`__
 
 If a package should be removed from -proposed, use the ``remove-package``
 tool (from ``ubuntu-archive-tools``). e.g., to remove source and binaries

--- a/docs/SRU/reference/exception-Bind9-Updates.rst
+++ b/docs/SRU/reference/exception-Bind9-Updates.rst
@@ -69,7 +69,7 @@ Bind9 contains a set of build and code tests which are executed for each
 commit and release via `GitHub
 Actions <https://github.com/isc-projects/bind9/actions>`__.
 `CodeQL <https://codeql.github.com/>`__ and
-`SonarCloud <https://www.sonarsource.com/products/sonarcloud/>`__ are
+`SonarCloud <https://www.sonarsource.com/products/sonarqube/cloud/>`__ are
 used to build bind9 and check for vulnerabilities in the code. Upstream
 tests and additional builds are also run via `GitLab
 pipelines <https://gitlab.isc.org/isc-projects/bind9/-/pipelines>`__.
@@ -183,14 +183,14 @@ Here is a log of known regressions.
    These were reported in both Debian and Ubuntu:
 
    -  segfault: https://lists.debian.org/debian-security-announce/2024/msg00146.html,
-      https://bugs.debian.org/1077281, https://bugs.debian.org/1074378.
+      https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1077281, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074378.
       Ubuntu not affected because we don't link with jemalloc
 
    -  removal of SIG(0) (this removal is the actual CVE fix):
-      https://bugs.debian.org/1077653
+      https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1077653
 
    -  Deprecated options now finally removed:
-      https://bugs.debian.org/1077512. Reporter seems to be using ubuntu
+      https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1077512. Reporter seems to be using ubuntu
       packages, though.
 
    -  `LP: #2075542 Missing binaries, new DNSSEC

--- a/docs/SRU/reference/exception-Certbot-Updates.rst
+++ b/docs/SRU/reference/exception-Certbot-Updates.rst
@@ -32,8 +32,7 @@ Certbot Requesting the SRU
 --------------------------
 
 The SRU should be done with a single process bug, instead of individual
-bug reports for individual bug fixes. See `bug
-1640978 <https://launchpad.net/bugs/1640978>`__ for an example. The one
+bug reports for individual bug fixes. See :lpbug:`1640978` for an example. The one
 bug should have the following:
 
 -  The SRU should be requested per the

--- a/docs/SRU/reference/exception-Cloudinit-Updates.rst
+++ b/docs/SRU/reference/exception-Cloudinit-Updates.rst
@@ -83,8 +83,7 @@ following:
    specific test results included
 -  Any packaging changes (e.g. a dependency change) need to be stated
 -  If any manual testing occurs it should also be documented. See
-   `LP: #1588052 <http://launchpad.net/bugs/1588052>`__ as an
-   example.
+   :lpbug:`1588052` as an example.
 
 
 cloud-init QA Process

--- a/docs/SRU/reference/exception-DPDK-Updates.rst
+++ b/docs/SRU/reference/exception-DPDK-Updates.rst
@@ -42,7 +42,7 @@ Upstream Change and Release Policy
 ----------------------------------
 
 Upstream have a
-`policy <http://dpdk.org/doc/guides/contributing/stable.html>`__ for
+`policy <http://doc.dpdk.org/guides/contributing/stable.html>`__ for
 accepting changes into the LTS release branches which includes:
 
 -  Back-porting of any critical bug fixes (crashes, data loss, etc)
@@ -64,13 +64,13 @@ enable it so nothing changes.
 
 Commits are peer reviewed as part of the normal development process and
 are signed to signify both the developer and review (see
-`contrib <http://dpdk.org/doc/guides/contributing/patches.html>`__ for
+`contrib <http://doc.dpdk.org/guides/contributing/patches.html>`__ for
 the doc on this).
 
 LTS release updates are made after some time has passed (to allow
 testing) and usually follow the new master release which happens more or
 less every 3 months (see the the current
-`road-map <http://dpdk.org/dev/roadmap>`__).
+`road-map <http://core.dpdk.org/roadmap/>`__).
 
 Updates to LTS releases are numbered with a minor point release
 
@@ -104,13 +104,13 @@ time.
 
 Results are published via email to the dpdk-test-report mailing list
 (see an
-`examples <http://dpdk.org/ml/archives/test-report/2017-May/020337.html>`__).
+`examples <http://mails.dpdk.org/archives/test-report/2017-May/020337.html>`__).
 
 In addition there is a smaller set of integration tests that runs
 pre-checks. This is integrated into patchwork to directly augment the
 patch review. Those checks were run by Intel so far but are currently
 extended to be a Hardware vendor opt-in to gain even more coverage - see
-`CI <http://dpdk.org/browse/tools/dpdk-ci/tree/README>`__ efforts for
+`CI <https://git.dpdk.org/tools/dpdk-ci/tree/README>`__ efforts for
 details on this growing part of the project that will provide even more
 coverage.
 
@@ -137,7 +137,7 @@ endurance tests via re-attaching devices or re-starting guests (all
 those based on lessons learned by past issues we identified).
 
 In addition, we set up
-`autopkgtests <http://autopkgtest.ubuntu.com/packages/dpdk>`__ as well
+`autopkgtests <https://autopkgtest.ubuntu.com/packages/dpdk>`__ as well
 for those components that can be tested. Those are mostly the extra
 packaging bits that would not be covered by the upstream testing: -
 testing the init scripts - testing dkms modules work within Ubuntu -
@@ -198,7 +198,7 @@ following:
 -  Major changes should be called out in the SRU template, especially
    where changed behavior is not backwards compatible.
 -  Changelog should contain a link to the stable releases announcement
-   (`example <http://dpdk.org/ml/archives/announce/2017-December/000163.html>`__)
+   (`example <http://mails.dpdk.org/archives/announce/2017-December/000163.html>`__)
 
 
 DPDK SRU Template

--- a/docs/SRU/reference/exception-Docker-Updates.rst
+++ b/docs/SRU/reference/exception-Docker-Updates.rst
@@ -68,7 +68,7 @@ autopkgtests on arm64 at the time).
 
 There is also an autopkgtest that exercises "docker in lxd" as described
 in
-https://insights.ubuntu.com/2016/04/13/stephane-graber-lxd-2-0-docker-in-lxd-712/
+https://ubuntu.com/blog/stephane-graber-lxd-2-0-docker-in-lxd-712
 . on autopkgtests.
 
 This QA should happen both for the -proposed -> -release migration in

--- a/docs/SRU/reference/exception-MariaDB-Galera-Updates.rst
+++ b/docs/SRU/reference/exception-MariaDB-Galera-Updates.rst
@@ -150,7 +150,7 @@ Security uploads
 In past years, all microreleases have been uploaded on the basis of open CVEs,
 sponsored by the security team. MariaDB is a large piece of software and
 typically has at least 2-5 CVEs per year. See
-https://mariadb.com/kb/en/security/ for details. Note that about 10% of the CVEs
+https://mariadb.com/docs/server/security for details. Note that about 10% of the CVEs
 in Oracle MySQL apply for MariaDB too due to the shared historical code base.
 
 In both MariaDB and MySQL the CVEs are always resolved by publishing the entire

--- a/docs/SRU/reference/exception-NVidia-Updates.rst
+++ b/docs/SRU/reference/exception-NVidia-Updates.rst
@@ -171,7 +171,7 @@ QA tests
    suite <https://git.launchpad.net/plainbox-provider-sru/tree/units/sru.pxu>`__
    must pass on a range of hardware.
 -  Call for testing is sent to the community via the `community
-   hub <https://community.ubuntu.com>`__ as soon as the drivers are
+   hub <https://discourse.ubuntu.com/>`__ as soon as the drivers are
    available in the staging PPA.
 
 
@@ -238,13 +238,13 @@ References
 ----------
 
 -  `nVidia Unix Drivers
-   Archive <https://www.nvidia.com/object/unix.html>`__
+   Archive <https://www.nvidia.com/en-us/drivers/unix/>`__
 -  `Full
-   history <https://www.nvidia.com/object/linux-amd64-display-archive.html>`__
+   history <https://download.nvidia.com/XFree86/Linux-x86_64/>`__
    of the drivers
 -  `Support timeframe for legacy
    drivers <https://nvidia.custhelp.com/app/answers/detail/a_id/3142>`__
 -  `What is a legacy
-   GPU <https://www.nvidia.com/object/IO_32667.html>`__
+   GPU <https://www.nvidia.com/en-us/drivers/unix/legacy-gpu/>`__
 -  `nVidia drivers staging
    PPA <https://launchpad.net/~canonical-hwe-team/+archive/ubuntu/intermediate-kernel>`__

--- a/docs/SRU/reference/exception-Netplan-Updates.rst
+++ b/docs/SRU/reference/exception-Netplan-Updates.rst
@@ -66,7 +66,7 @@ Merges
 ------
 
 Updates to `netplan master
-branch <http://github.com/canonical/netplan>`__ go through the following
+branch <https://github.com/canonical/netplan>`__ go through the following
 process:
 
 -  Reviewed and approved by a member of the development team

--- a/docs/SRU/reference/exception-OEMMeta-Updates.rst
+++ b/docs/SRU/reference/exception-OEMMeta-Updates.rst
@@ -57,7 +57,7 @@ OEM SRU Bug template
 OEM Procedure
 -------------
 
-There is `an existing MIR exception <https://canonical-ubuntu-project.readthedocs-hosted.com/MIR/mir-exceptions-oem/#mir-exceptions-oem>`__,
+There is :ref:`an existing MIR exception <mir-exceptions-oem>`,
 allowing these packages to be accepted directly into main. As long as
 the package complies with the template required for the MIR exception to
 apply, it can be similarly accepted into \`-proposed\` without further

--- a/docs/SRU/reference/exception-OpenStack-Updates.rst
+++ b/docs/SRU/reference/exception-OpenStack-Updates.rst
@@ -86,7 +86,7 @@ SRU Expectations
        #.  corresponding UCA release
 
 .. warning::
-    [1] Landing a fix upstream may not always be possible, for example once the upstream branch is in critical-fix or security-fix only mode, or once it has reached EOL.  See the `OpenStack upstream stable branch policy <http://docs.openstack.org/project-team-guide/stable-branches.html>`__, which specifies the various phases of support for stable branches, which are typically supported for 12 to 18 months.  The case where a bug can't be fixed upstream first must be handled with extreme caution, since fixes would be released directly to the corresponding Ubuntu release without having landed upstream first.
+    [1] Landing a fix upstream may not always be possible, for example once the upstream branch is in critical-fix or security-fix only mode, or once it has reached EOL.  See the `OpenStack upstream stable branch policy <https://docs.openstack.org/project-team-guide/stable-branches.html>`__, which specifies the various phases of support for stable branches, which are typically supported for 12 to 18 months.  The case where a bug can't be fixed upstream first must be handled with extreme caution, since fixes would be released directly to the corresponding Ubuntu release without having landed upstream first.
 
 .. warning::
     [2] Landing a fix in a corresponding Ubuntu release may not always be possible, for example once the Ubuntu release has reached EOL and the UCA is still supported.  This case must be handled with extreme caution, since fixes would be released directly to the corresponding UCA without having first landed in the corresponding Ubuntu release, and possibly also without having first landed in the upstream OpenStack release.

--- a/docs/SRU/reference/exception-OpenVMTools-Updates.rst
+++ b/docs/SRU/reference/exception-OpenVMTools-Updates.rst
@@ -115,7 +115,7 @@ Ambiguity
 
 The server team does many MREs and therefore sometimes it happened that
 these uploads were called an MRE, it is not. This is a platform
-enablement SRU upload under the condition of `"other safe cases" sub section 2 <https://documentation.ubuntu.com/sru/en/latest/reference/requirements/#other-safe-cases>`__:
+enablement SRU upload under the condition of :ref:`"other safe cases" sub section 2 <sru-other-safe-cases>`:
 
 .. code-block:: text
 

--- a/docs/SRU/reference/exception-Snapcraft-Updates.rst
+++ b/docs/SRU/reference/exception-Snapcraft-Updates.rst
@@ -9,7 +9,7 @@ a stable supported distro, including LTS.
 snapcraft is the tool to create snaps. This package needs to be kept in
 sync with snapd releases so we can build snaps that will work with the
 latest features added to Ubuntu Core.
-`snapd <https://documentation.ubuntu.com/sru/en/latest/reference/exception-ec2-hibinit-agent-Updates>`__ already has an
+:ref:`snapd <reference-exception-ec2-hibinit-agent-Updates>` already has an
 exception to release new versions into the stable distro; therefore in
 addition to critical bug fixes, new features and small improvements are
 allowed in an snapcraft update **as long as the conditions outlined

--- a/docs/SRU/reference/exception-Sosreport-Updates.rst
+++ b/docs/SRU/reference/exception-Sosreport-Updates.rst
@@ -17,7 +17,7 @@ third party vendors.
 -  Upstream reference:
 
    -  https://sos.readthedocs.io/en/main/
-   -  http://github.com/sosreport/sos
+   -  https://github.com/sosreport/sos
 
 Therefore, in addition to bug fixes, new features are allowed in an
 update **as long as the conditions outlined below are met**.

--- a/docs/SRU/reference/exception-Squid-Updates.rst
+++ b/docs/SRU/reference/exception-Squid-Updates.rst
@@ -24,13 +24,13 @@ Squid Upstream release policy
 As described in
 http://wiki.squid-cache.org/DeveloperResources/ReleaseProcess and
 discussed in the upstream mailing list at
-http://lists.squid-cache.org/pipermail/squid-dev/2015-March/001853.html,
+https://ml-archives.squid-cache.org/squid-dev/2015-March/001853.html,
 starting in Squid 4, Squid follows a Major.Point release policy where
 the Point releases could be considered new upstream microreleases as per
-https://documentation.ubuntu.com/sru/en/latest/reference/requirements/#new-upstream-microreleases
+:ref:`reference-criteria-microreleases`.
 
 This has been recently confirmed through the squid users mailing list in
-http://lists.squid-cache.org/pipermail/squid-users/2023-January/025586.html
+https://ml-archives.squid-cache.org/squid-users/2023-January/025586.html
 
 New releases are cut when one of the following criteria is met:
 

--- a/docs/SRU/reference/exception-UbuntuImage-Updates.rst
+++ b/docs/SRU/reference/exception-UbuntuImage-Updates.rst
@@ -37,7 +37,7 @@ is generally reviewed by at least one other member of the ubuntu-image
 team, although because of the team's size this cannot always be
 guaranteed. Continuous integration is performed on **all** pull
 requests, using DEP-8 style `autopackage
-tests <http://autopkgtest.ubuntu.com/packages/ubuntu-image>`__ on all
+tests <https://autopkgtest.ubuntu.com/packages/ubuntu-image>`__ on all
 supported Ubuntu releases. Branches are never merged if any test fails.
 This includes 100% unit test coverage.
 

--- a/docs/SRU/reference/exception-Virtualbox-Updates.rst
+++ b/docs/SRU/reference/exception-Virtualbox-Updates.rst
@@ -148,7 +148,7 @@ In Debian/Ubuntu:
    leaves virtualbox in stable releases generally vulnerable, e.g. to
    CVE-2015-2594
 
-   -  [1] http://www.oracle.com/us/support/assurance/vulnerability-remediation/disclosure/index.html
+   -  [1] https://www.oracle.com/corporate/security-practices/assurance/vulnerability/disclosure/
 
 -  Usually newer kernels means a bad experience for users, since the
    kernel drivers are rebuilt at each kernel update, and leads to failures

--- a/docs/SRU/reference/historical-removals.rst
+++ b/docs/SRU/reference/historical-removals.rst
@@ -12,9 +12,8 @@ The following packages have previously been (pseudo-)removed via SRU
 following our removals process.
 
 -  `tor <https://lists.ubuntu.com/archives/ubuntu-devel/2007-September/024453.html>`__
-   (was reintroduced later on in
-   `#413657 <https://launchpad.net/bugs/413657>`__)
--  `bitcoin <https://bugs.launchpad.net/ubuntu/+source/bitcoin/+bug/1314616>`__
--  `owncloud <https://launchpad.net/bugs/1384355>`__
--  `jsunit and tinyjsd <https://launchpad.net/bugs/1895643>`__ (more context in
+   (was reintroduced later on in :lpbug:`413657`)
+-  :lpbug:`bitcoin <1314616>`
+-  :lpbug:`owncloud <1384355>`
+-  :lpbug:`jsunit and tinyjsd <1895643>` (more context in
    `this post <https://discourse.ubuntu.com/t/thunderbird-lts-update/20819>`__)

--- a/docs/SRU/reference/requirements.rst
+++ b/docs/SRU/reference/requirements.rst
@@ -40,6 +40,8 @@ Stable release updates will, in general, only be issued in order to fix
    -  A library for a web service needs to be updated for changes to the
       web server API.
 
+.. _sru-other-safe-cases:
+
 Other safe cases
 ^^^^^^^^^^^^^^^^
 
@@ -115,7 +117,7 @@ For upstreams who have
 -  the tests are covering both functionality and API/ABI stability,
 -  the tests run during package build to cover all architectures,
 -  the package has an
-   `autopkgtest <http://packaging.ubuntu.com/html/auto-pkg-test.html>`__
+   :ref:`autopkgtest <automatic-package-testing-autopkgtest>`
    to run the tests in an Ubuntu environment against the actual binary
    packages,
 

--- a/docs/SRU/reference/special.rst
+++ b/docs/SRU/reference/special.rst
@@ -28,7 +28,7 @@ permitted SRU, some of which overlap:
 
 * **Extended Security Maintenance:** there are special procedures for
   uploads to stable releases in their
-  `Extended Security Maintenance (ESM) <https://ubuntu.com/esm>`__ period.
+  `Extended Security Maintenance (ESM) <https://ubuntu.com/security/esm>`__ period.
   Please prepare the SRU bug and subscribe the ESM team to it.
 
 * **Staged upload** [:ref:`explanation <explanation-staged-uploads>`],


### PR DESCRIPTION
### Description

The linkchecker is reporting a lot of broken and redirecting links across the Project docs. Here I'm updating the redirecting links to point to the new target locations.

Broken links take a bit longer to reconcile and will be part of a separate PR.

I'm handling each team separately so codeowners can focus on their own changes.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

