### PR TITLE
[chore] Update redirecting links in MIR pages

### DIFF
--- a/docs/MIR/mir-exceptions-oem.md
+++ b/docs/MIR/mir-exceptions-oem.md
@@ -34,7 +34,7 @@ handling. Which means it can either only be processed by members being in the
 intersection of [SRU members](https://launchpad.net/~ubuntu-sru/+members) and
 [Archive Admin members](https://launchpad.net/~ubuntu-archive/+members).
 Or, following the joint processing as mentioned in
-[SRU uploads hitting the new queue](https://documentation.ubuntu.com/sru/en/latest/howto/special/#sru-uploads-hitting-the-new-queue).
+{ref}`SRU uploads hitting the new queue <howto-new-queue>`.
 
 When uploaded to `-unapproved` the SRU team will see it, but only those that
 also are Archive Admins can process it. For awareness, the uploader is

--- a/docs/MIR/mir-team-meeting.md
+++ b/docs/MIR/mir-team-meeting.md
@@ -16,7 +16,7 @@ You should attend these meetings if you submit an {ref}`MIR request <mir-submit-
 until it is approved or rejected.
 
 Due to the nature of the
-[Ubuntu Development Process](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/2.0-preview/explanation/development-process/),
+{ref}`Ubuntu Development Process <release-cycle>`,
 there are times (e.g. close to Feature Freeze) when this meeting is busy and
 others (e.g. right after a new release) when it is quieter. Consequently,
 response times along the {ref}`MIR process <mir-process-overview>` are


### PR DESCRIPTION
### Description

The linkchecker is reporting a lot of broken and redirecting links across the Project docs. Here I'm updating the redirecting links to point to the new target locations.

Broken links take a bit longer to reconcile and will be part of a separate PR.

I'm handling each team separately so codeowners can focus on their own changes.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

