### PR TITLE
[chore] Update redirecting links in community pages

### DIFF
--- a/docs/community/contribute/patch-pilots.md
+++ b/docs/community/contribute/patch-pilots.md
@@ -17,7 +17,7 @@ You should reach out to a Patch Pilot if:
 * Your package can't go into Debian and you'd like to contribute a {ref}`new Ubuntu-specific package <new-packages>`.
 * You'd like a new package or patch to appear in Ubuntu, but need some guidance on how to make it part of Debian.
 
-Patch Pilots are available in the {matrix}`devel` channel on [Matrix](https://ubuntu.com/community/communications/matrix) and will be monitoring bugs with patches on Launchpad.
+Patch Pilots are available in the {matrix}`devel` channel on [Matrix](https://ubuntu.com/community/docs/communications/matrix) and will be monitoring bugs with patches on Launchpad.
 The current Pilot is noted in the channel topic.
 If you'd like to plan ahead, see the [Ubuntu Patch Pilots](https://calendar.google.com/calendar/embed?showPrint=0&showCalendars=0&mode=WEEK&src=Y184ZWRhZjk2OTllYWFmMWFmMmNjYTY2ZTYyOGZkNDEwODQ2ZTkwMjcwNmQ2YTMzMTU1OTNmODhiOTk0ZTZlOWE2QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20&color=%23F4511E) calendar.
 

--- a/docs/community/governance/index.md
+++ b/docs/community/governance/index.md
@@ -81,8 +81,8 @@ If you have a particular interest in a specific aspect of the project, please jo
 
 ## Local Community Teams
 
-A major part of the fabric of the community is the Local Community (LoCo) team structure. LoCo teams work with local Linux User Groups (LUGs), schools, municipalities and even national governments to open people's eyes to the world of free software.
+A major part of the fabric of the community is the Local Community team structure. Local Community teams work with local Linux User Groups (LUGs), schools, municipalities and even national governments to open people's eyes to the world of free software.
 
-Local Community teams are a great way to gather free software lovers together for beer, open discussion, talks, marketing events and to recognise the achievements of local free software contributors. LoCo teams are provided with spaces for discussion, collaboration and event planning on the [Ubuntu Discourse](https://discourse.ubuntu.com/c/locos/129).
+Local Community teams are a great way to gather free software lovers together for beer, open discussion, talks, marketing events and to recognise the achievements of local free software contributors. Local Community teams are provided with spaces for discussion, collaboration and event planning on the [Ubuntu Discourse](https://discourse.ubuntu.com/c/community/circles/129).
 
 To join a Local Community team or learn how to start one in your area, check out {ref}`Ubuntu Local Communities <local-communities>`.

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -34,12 +34,12 @@ To better understand how our large umbrella of communities operates, take a look
 * Members of the Ubuntu Community follow a simple set of core principles that help ensure our community stays healthy, stable and remains a place for collaboration and prosperity. {ref}`Read the Ubuntu Code of Conduct <code-of-conduct>`.
 * The mission for Ubuntu is both social and economic. We believe that bringing free software to the widest audience will empower individuals and communities to innovate, experiment and grow. {ref}`Learn the guiding tenets of the Ubuntu Mission <mission>`.
 * Ubuntu, like other large communities, requires leadership and direction to help ensure its sustainability and longevity. Learning how all the interconnected bodies work together is important to understanding the Ubuntu way. {ref}`Learn how they all work together to sustain our community <community-council>`.
-* Keep up to date with all the latest news and happenings from around the community with [The Ubuntu Weekly Newsletter](https://discourse.ubuntu.com/c/uwn/124) and the [Ubuntu Blog](https://ubuntu.com/blog).
+* Keep up to date with all the latest news and happenings from around the community with [The Ubuntu Weekly Newsletter](https://discourse.ubuntu.com/c/community/uwn/124) and the [Ubuntu Blog](https://ubuntu.com/blog).
 
 
 ## Get help
 
-Are you instead stuck and need help? [Take a look at how our community can support you.](https://ubuntu.com/community/support)
+Are you instead stuck and need help? [Take a look at how our community can support you.](https://ubuntu.com/community/docs/support)
 
 
 ## Discover

--- a/docs/community/local/index.md
+++ b/docs/community/local/index.md
@@ -12,9 +12,9 @@ lc-faq
 
 ![loco-map|450x228](loco-map.png)
 
-Ubuntu Local Communities, often shortened to LoCos, are regional teams that help advocate, promote, translate, develop and otherwise improve Ubuntu. 
+Ubuntu Local Communities are regional teams that help advocate, promote, translate, develop and otherwise improve Ubuntu. 
 
-With the incredible success of Ubuntu around the world, the Ubuntu Local Communities program was formed to help Ubuntu fans and enthusiasts work together.  Our worldwide network of LoCo teams are an important staple in the Ubuntu ecosystem and provide a strong backbone to our already vast and extensive Ubuntu community.
+With the incredible success of Ubuntu around the world, the Ubuntu Local Communities program was formed to help Ubuntu fans and enthusiasts work together. Our worldwide network of Local Community teams are an important staple in the Ubuntu ecosystem and provide a strong backbone to our already vast and extensive Ubuntu community.
 
 
 ## What are the perks of being in an Ubuntu Local Community?
@@ -28,7 +28,7 @@ With the incredible success of Ubuntu around the world, the Ubuntu Local Communi
 
 ## How to join an Ubuntu Local Community
 
-Becoming part of an Ubuntu Local Community is a great way to meet other passionate Ubuntu enthusiasts in your community. Find a team in your area to join by checking out the [Ubuntu Local Community Teams](https://ubuntu.com/community/local-communities#join-community) Directory.
+Becoming part of an Ubuntu Local Community is a great way to meet other passionate Ubuntu enthusiasts in your community. Find a team in your area to join by checking out the [Ubuntu Local Community Teams](https://ubuntu.com/community/circles) Directory.
 
 
 ## How to create an Ubuntu Local Community
@@ -38,4 +38,4 @@ Can’t find a team in your area? You may want to consider starting one! Learn h
 
 ## Join in the Ubuntu Local Community conversation
 
-Do you have other Ubuntu Local Community related questions or want to help shape the future of the program? Engage with other LoCo leaders and advocates in the [Ubuntu LoCo Discourse](https://discourse.ubuntu.com/c/locos/129).
+Do you have other Ubuntu Local Community related questions or want to help shape the future of the program? Engage with other Local Community leaders and advocates in the [Ubuntu Circles Discourse](https://discourse.ubuntu.com/c/community/circles/129).

--- a/docs/community/local/lc-create.md
+++ b/docs/community/local/lc-create.md
@@ -72,7 +72,7 @@ Once your event is created and listed on the Community Portal, don't forget to s
 ### Share your successes
 
 After you've hosted or taken part in an event, be sure to let the community hear all about it.
-Consider posting a topic on the Ubuntu Discourse, either in the [Events section](https://discourse.ubuntu.com/c/events/11) or under your Local Community, with a recap of everything you did, learned and experienced.
+Consider posting a topic on the Ubuntu Discourse, either in the [Events section](https://discourse.ubuntu.com/c/community/events/11) or under your Local Community, with a recap of everything you did, learned and experienced.
 Don't forget to use the **`#event-report`** tag and add any pictures or videos you may have snapped while you were there!
 
 
@@ -85,7 +85,7 @@ Once you've successfully held a few events and have demonstrated a strong degree
 Gaining verified status will allow you to request Ubuntu swag, funds for traveling and possible invitations to future Ubuntu events.
 Note that the council will look at activity on the Ubuntu Discourse (event reports, general conversations) to determine if your team is eligible, so it's important to be active on that platform.
 
-To request verification for your local community, post a topic with the title "Verification Request - LOCAL COMMUNITY NAME" in the [LoCo Support category](https://discourse.ubuntu.com/c/locos/loco-support/156) on Discourse.
+To request verification for your Local Community, post a topic with the title "Verification Request - LOCAL COMMUNITY NAME" in the [Local Community Support category](https://discourse.ubuntu.com/c/community/circles/circle-support/156) on Discourse.
 
 
 ### UbuCons

--- a/docs/community/matrix/room-ownership/regain-control.md
+++ b/docs/community/matrix/room-ownership/regain-control.md
@@ -13,7 +13,7 @@ This guide applies to official rooms on the Ubuntu homeserver that have the Mode
 
 Access to the Ubuntu Matrix homeserver happens via Single Sign On and is tied to Launchpad groups.
 If you cannot login, make sure you recover access to your Launchpad account.
-This can be done by accessing the [Launchpad help webpage](https://help.launchpad.net/YourAccount).
+This can be done by accessing the [Launchpad help webpage](https://documentation.ubuntu.com/launchpad/user/YourAccount/).
 
 
 ## The administrators of your room are no longer active

--- a/docs/community/membership/ubuntu-email.md
+++ b/docs/community/membership/ubuntu-email.md
@@ -15,7 +15,7 @@ Ubuntu Members are granted special `@Ubuntu.com` aliases they can use to send an
 
 ![4](four.png)
 
-4. If you plan on sending emails via your [`ubuntu.com`](http://ubuntu.com/) address, then under {guilabel}`Quick Links` select {guilabel}`Generate Password` to create a unique password. You will use this when configuring your SMTP services on your mail application of choice.
+4. If you plan on sending emails via your [`ubuntu.com`](https://ubuntu.com/) address, then under {guilabel}`Quick Links` select {guilabel}`Generate Password` to create a unique password. You will use this when configuring your SMTP services on your mail application of choice.
 
 ![5|781x314](five.png)
 


### PR DESCRIPTION
### Description

The linkchecker is reporting a lot of broken and redirecting links across the Project docs. Here I'm updating the redirecting links to point to the new target locations.

Broken links take a bit longer to reconcile and will be part of a separate PR.

I'm handling each team separately so codeowners can focus on their own changes.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

