### PR TITLE
Improve sphinx-llm config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,9 +177,9 @@ sitemap_show_lastmod = True
 # Exclude generated pages from the sitemap:
 
 sitemap_excludes = [
-    '404/',
-    'genindex/',
-    'search/',
+    "404/",
+    "genindex/",
+    "search/",
 ]
 
 # Template and asset locations
@@ -391,6 +391,23 @@ extlinks = {
 }
 
 
+# sphinx-llm config
+llms_txt_full_build = False
+llms_txt_suffix_mode = "url-suffix"
+llms_txt_description = (
+    "This documentation provides guidance for contributors to and "
+    "maintainers of the Ubuntu Linux distribution. It covers processes "
+    "and concepts, as well as project governance and team workflows. "
+    "There are instructions for packaging, merging, proposed migrations, "
+    "autopkgtests, and many other procedures for maintaining the Ubuntu "
+    "Archive and releasing the distribution."
+)
+
+# sphinx-markdown-builder config
+# set markdown_http_base without `/` at the end
+markdown_http_base = "https://documentation.ubuntu.com/project"
+
+
 # Workaround for https://github.com/canonical/canonical-sphinx/issues/34
 
 if "discourse_prefix" not in html_context and "discourse" in html_context:
@@ -441,23 +458,22 @@ def unescape_amp_in_links(app, exception):
         return
 
     # Only run for html builders
-    if app.builder.format != 'html':
+    if app.builder.format != "html":
         return
 
     def unescape_match(match):
-        return match.group(0).replace('&amp;amp;', '&amp;')
+        return match.group(0).replace("&amp;amp;", "&amp;")
 
     for root, dirs, files in os.walk(app.outdir):
         for file in files:
             if file.endswith(".html"):
                 path = os.path.join(root, file)
                 try:
-                    with open(path, 'r', encoding='utf-8') as f:
+                    with open(path, "r", encoding="utf-8") as f:
                         content = f.read()
-                    new_content = re.sub(r'href=".*\?([^"]*)"',
-                                         unescape_match, content)
+                    new_content = re.sub(r'href=".*\?([^"]*)"', unescape_match, content)
                     if new_content != content:
-                        with open(path, 'w', encoding='utf-8') as f:
+                        with open(path, "w", encoding="utf-8") as f:
                             f.write(new_content)
                 except Exception as e:
                     print(f"Failed to process {path}: {e}")
@@ -465,7 +481,7 @@ def unescape_amp_in_links(app, exception):
 
 def setup(app):
     roles.register_local_role("command", CommandRole())
-    app.connect('build-finished', unescape_amp_in_links)
+    app.connect("build-finished", unescape_amp_in_links)
 
 
 # Define a custom role for package-name formatting

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -34,7 +34,9 @@ vale
 # Custom dependencies (needed by Ubuntu Project docs)
 distro_info
 sphinx-hoverxref
-sphinx-llm
+# Temporary: as soon as upstream merges fix, switch back to 'sphinx-llm' only
+# reference: https://github.com/NVIDIA/sphinx-llm/pull/95
+sphinx-llm @ git+https://github.com/rkratky/sphinx-llm@httpbase
 sphinx-prompt
 sphinx-togglebutton
 sphinxcontrib-mermaid


### PR DESCRIPTION
### Description

sphinx-llm config update:

* Do *not* generate llms-full.txt
* Use 'page.md' instead of 'page/index.html.md'
* Define site summary text
* Use absolute URLs for local links (temp. use of ext. fork)

----

* Tacked on: a few quote fixes in `conf.py` to make a Python linter happy.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [n/a] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Upstream has a bug (https://github.com/NVIDIA/sphinx-llm/pull/95) that causes the extension to not generate (recommended) absolute URLs in `llms.txt`. Until a fix (already submitted) is merged, we're pointing to a temp. fork of the extension.