### PR TITLE
Add wrapper Makefile so make cmds can be run from root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Wrapper Makefile to forward all commands to docs/Makefile
+# This allows "make" commands to be run from the root dir
+
+# Get the directory where this Makefile is located (repository root)
+ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Forward all targets to the docs/Makefile
+.DEFAULT_GOAL := help
+
+# Catch-all target: route all unknown targets to docs/Makefile
+%:
+	@$(MAKE) -C $(ROOT_DIR)docs $@
+
+.PHONY: help


### PR DESCRIPTION
### Description

Add a wrapper for the Makefil so commands like `make run` can be run from root

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

