### PR TITLE
Fix numbering in Ubuntu email setup instructions

### DIFF
--- a/docs/community/membership/ubuntu-email.md
+++ b/docs/community/membership/ubuntu-email.md
@@ -5,23 +5,23 @@ Ubuntu Members are granted special `@Ubuntu.com` aliases they can use to send an
 
 1. Log into [Forward Email](https://forwardemail.net/en/ubuntu) using your UbuntuOne SSO account. Under {guilabel}`Quick Links` beside the [`ubuntu.com`](https://ubuntu.com/) domain, select **Aliases**.
 
-![1](one.png)
+   ![1](one.png)
 
-![2](two.png)
+   ![2](two.png)
 
 2. Select {guilabel}`Edit` under {guilabel}`Quick links` and enter your personal email under **Forwarding Recipients**.
 
-![3](three.png)
+   ![3](three.png)
 
-![4](four.png)
+   ![4](four.png)
 
 3. If you plan on sending emails via your [`ubuntu.com`](https://ubuntu.com/) address, then under {guilabel}`Quick Links` select {guilabel}`Generate Password` to create a unique password. You will use this when configuring your SMTP services on your mail application of choice.
 
-![5|781x314](five.png)
+   ![5|781x314](five.png)
 
 4. Once you have your SMTP password, you can click on the {guilabel}`Setup Instructions` link to learn how to configure mail sending on various desktop and mobile mail applications.
 
-![6|275x170](six.png)
+   ![6|275x170](six.png)
 
 ## Feedback and support
 


### PR DESCRIPTION
Changed the numbering from 1,1,4,5 to 1,2,3,4.


- Fixes: #390 
- I simply changed the numbers to be in proper order.

