### PR TITLE
Add SRU Exception for NVIDIA CUDA

### DIFF
--- a/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
+++ b/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
@@ -44,6 +44,15 @@ compatible releases that are supported, starting with 26.04. For example, when
 the currently hypothetical 14.1.0 version is released for 28.04, it will be
 SRU'd to 27.10 and 26.04.
 
+A few binary package have the same name between two minor versions:
+-  cuda
+-  cuda-toolkit and cuda-toolkit-<MAJOR>
+
+Users expect these binary packages to be rolling. They can use
+cuda-<MAJOR>-<MINOR> and cuda-toolkit-<MAJOR>-<MINOR> to be sure to stay on
+the same minor version. NVIDIA recommends the installation of minor-tight
+CUDA versions in their own documentation.
+
 **Patch versions**:
 
 Patch versions do replace the corresponding existing version so e.g. 13.2.1 will

--- a/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
+++ b/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
@@ -129,8 +129,8 @@ Integration tests
 
 - `Certification test suite
   <https://github.com/canonical/checkbox/blob/main/providers/gpgpu/units/cuda.pxu>`__
-  must pass on a range of hardware, with the same result as with NVIDIA's
-  provided packages.
+  must pass on a range of hardware, including at least one workstation and one
+  server GPU, with the same result as with NVIDIA's provided packages.
 
 .. _sru_template:
 

--- a/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
+++ b/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
@@ -1,12 +1,10 @@
-.. _reference-exception-nvidia-cuda:
+.. _reference-exception-Nvidia-Cuda-Updates:
 
-#####################
- Nvidia CUDA updates
-#####################
+Nvidia CUDA updates
+===================
 
-**************
- Introduction
-**************
+Introduction
+-------------
 
 This document describes the policy, process and criteria for updating NVIDIA
 CUDA libraries in a stable supported distro, including LTS.
@@ -29,11 +27,12 @@ install files under /usr/local. The exception is temporary, and we are working o
 plan to remove it with CUDA 14.x. Any SRU request that is patching a CUDA version
 relying on the exception is expected to keep installing files under /usr/local.
 
-*******************
- Released versions
-*******************
+.. _release_versions:
 
-Minor versions:
+Released versions
+------------------
+
+**Minor versions**:
 
 CUDA packages are released in the multiverse pocket.
 CUDA's minor versions are meant to be available and installable in parallel, and
@@ -45,7 +44,7 @@ compatible releases that are supported, starting with 26.04. For example, when
 the currently hypothetical 14.1.0 version is released for 28.04, it will be
 SRU'd to 27.10 and 26.04.
 
-Patch versions:
+**Patch versions**:
 
 Patch versions do replace the corresponding existing version so e.g. 13.2.1 will
 replace 13.2.0.
@@ -56,9 +55,8 @@ compatible releases that are supported. For example, 26.04 was released with
 
 .. _requesting_sru:
 
-********************************
- NVIDIA CUDA Requesting the SRU
-********************************
+NVIDIA CUDA Requesting the SRU
+-------------------------------
 
 The SRU should be done with a single process bug appropriately named
 `cuda-X-Y`, instead of individual bug
@@ -85,22 +83,24 @@ reports for individual bug fixes. The one bug should have the following:
 
 .. _packaging_qa:
 
-**************************
- NVIDIA CUDA Packaging QA
-**************************
+
+NVIDIA CUDA Packaging QA
+-------------------------
 
 The objective of the QA is to test:
 
-- Package installation from scratch
-- Package upgrades
-- Compliance with NVIDIA's own releases
-  - Making sure that we deliver the right binary in the right packages with
-    the right license and dependencies
-  - Making sure the CUDA installation is working as expected (integration
-    tests with cuda samples).
-- Compatibility with NVIDIA's own releases and repos
-  - Making sure that NVIDIA's packages supersede ours, and that users adding
-    the NVIDIA repo don't end up with a mix of our packages and NVIDIA's packages
+-  Package installation from scratch
+-  Package upgrades
+-  Compliance with NVIDIA's own releases
+
+   -  Making sure that we deliver the right binary in the right packages with
+      the right license and dependencies
+   -  Making sure the CUDA installation is working as expected (integration
+      tests with cuda samples).
+-  Compatibility with NVIDIA's own releases and repos
+
+   -  Making sure that NVIDIA's packages supersede ours, and that users adding
+      the NVIDIA repo don't end up with a mix of our packages and NVIDIA's packages
 
 This QA is implemented as an autopkgtest within each source package. The result
 of the tests will be attached to the SRU bug. The package upgrade must be
@@ -108,9 +108,9 @@ attempted manually, from a fresh installation.
 
 .. _integration_tests:
 
-*******************
- Integration tests
-*******************
+
+Integration tests
+------------------
 
 - `Certification test suite
   <https://github.com/canonical/checkbox/blob/main/providers/gpgpu/units/cuda.pxu>`__
@@ -119,9 +119,9 @@ attempted manually, from a fresh installation.
 
 .. _sru_template:
 
-**************************
- NVIDIA CUDA SRU Template
-**************************
+
+NVIDIA CUDA SRU Template
+-------------------------
 
 ::
 
@@ -135,7 +135,7 @@ attempted manually, from a fresh installation.
 
     [Test Plan]
     The following development and SRU process was followed:
-    https://documentation.ubuntu.com/sru/en/latest/reference/exception-nvidia-cuda/
+    https://documentation.ubuntu.com/sru/en/latest/reference/exception-Nvidia-Cuda-Updates/
 
     <TODO Document any QA done, automated and manual>
 

--- a/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
+++ b/docs/SRU/reference/exception-Nvidia-Cuda-Updates.rst
@@ -62,6 +62,12 @@ CUDA's patch version package sets are also meant to be broadly SRU'd to
 compatible releases that are supported. For example, 26.04 was released with
 13.1.1 and when 13.1.2 is available in devel it will be SRU'd up until 26.04.
 
+In the past, a patch version of nsight-compute could change the name of a
+binary package. For example, 13.2.0 had `nsight-compute-2026.1.0` while
+13.2.1 had `nsight-compute-2026.1.1`. In such cases, the new package, this
+SRU exception allows the patch version to be SRU'd only if there is a
+transitional package from the old name to the new name.
+
 .. _requesting_sru:
 
 NVIDIA CUDA Requesting the SRU

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -14,8 +14,7 @@ CUDA libraries in a stable supported distro, including LTS.
 NVIDIA CUDA is broadly used by developers for GPU compute activities, for
 example for AI/ML. Canonical has a redistribution agreement with NVIDIA to
 redistribute the CUDA libraries in the Ubuntu archive. Per the agreement, Canonical
-must deliver the prebuilt binaries from NVIDIA without modifications, and follow
-the same schedule than NVIDIA.
+must deliver the prebuilt binaries from NVIDIA without modifications.
 
 CUDA consists of ~37 new source packages for every minor version. Minor versions
 are released on average every 3 months. Each minor version usually receives one or
@@ -34,6 +33,7 @@ relying on the exception is expected to keep installing files under /usr/local.
  Released versions
 *******************
 
+CUDA packages are released in the multiverse pocket.
 CUDA's minor versions are meant to be available and installable in parallel, and
 therefore e.g. 13.2 does not replace 13.1 in Ubuntu. Patch versions do replace the
 corresponding existing version so e.g. 13.2.1 will replace 13.2.0.
@@ -56,6 +56,7 @@ reports for individual bug fixes. The one bug should have the following:
   <howto-perform-standard-sru>` documented process
 - The template at the end of this document should be used and all ‘TODO’ filled
   out
+- This SRU exception applies to only the multiverse archive component.
 - The changelog will contain a reference to the single SRU process bug, not all
   bugs fixed by the SRU. However, if there are very important bugs that are
   deemed worthy of reference they too should be included in the changelog.

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -103,7 +103,7 @@ attempted manually, from a fresh installation.
 ::
 
     [Impact]
-    This patch provides both bug fixes and we would like to
+    This patch provides both bug fixes and improvements and we would like to
     make sure all of our users have access to these improvements.
 
     The patched packages are:

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -12,20 +12,23 @@ This document describes the policy, process and criteria for updating NVIDIA
 CUDA libraries in a stable supported distro, including LTS.
 
 NVIDIA CUDA is broadly used by developers for GPU compute activities, for
-example for AI/ML. Ubuntu has a redistribution agreement with NVIDIA to
-redistribute the CUDA libraries in the Ubuntu archive. Per the agreement, Ubuntu
+example for AI/ML. Canonical has a redistribution agreement with NVIDIA to
+redistribute the CUDA libraries in the Ubuntu archive. Per the agreement, Canonical
 must deliver the prebuilt binaries from NVIDIA without modifications, and follow
 the same schedule than NVIDIA.
 
-CUDA represents ~37 new source packages for every minor version. Minor versions
-are released on average every 3 months. Each minor version usually get one or
-two patch versions, which will be candidates for SRUs. Given the nature of CUDA,
-these SRUs are not compliant with the usual SRU policy.
+CUDA consists of ~37 new source packages for every minor version. Minor versions
+are released on average every 3 months. Each minor version usually receives one or
+two patch versions, which will be candidates for SRUs. Since our redistribution 
+agreement requires us to match NVIDIA's changes exactly within a given CUDA release,
+and since CUDA consists primarily of precompiled binaries, our CUDA packages must all
+roll forward in tandem on each upstream update. As a result, CUDA SRUs are not 
+compliant with the standard SRU policy.
 
-As of the time of writing, CUDA packages are under an allowed exception to
-install files under /usr/local. The exception is temporary. Any SRU request that
-is patching a CUDA version relying on the exception is expected to keep
-installing files under /usr/local.
+As of the time of writing, CUDA 13.x packages are under an allowed exception to
+install files under /usr/local. The exception is temporary, and we are working on a
+plan to remove it with CUDA 14.x. Any SRU request that is patching a CUDA version
+relying on the exception is expected to keep installing files under /usr/local.
 
 *******************
  Released versions
@@ -78,6 +81,10 @@ The objective of the QA is to test:
 - Package installation from scratch
 - Package upgrades
 - Compliancy with NVIDIA's own releases
+  - Making sure that we deliver the right binary in the right packages with the right license and dependencies
+  - Making sure the CUDA installation is working as expected (integration tests with cuda samples).
+- Compatibility with NVIDIA's own releases and repos
+  - Making  sure that NVIDIA's packages superseed us, and that users adding the NVIDIA repo don't end up with a mix of our packages and NVIDIA's packages
 
 This QA is implemented as an autopkgtest within each source package. The result
 of the tests will be attached to the SRU bug. The package upgrade must be

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -19,8 +19,12 @@ the same schedule than NVIDIA.
 
 CUDA represents ~37 new source packages for every minor version. Minor versions
 are released on average every 3 months. Each minor version usually get one or
-two patch versions, which will be candidate for an SRU. Given the nature of
+two patch versions, which will be candidates for SRUs. Given the nature of
 CUDA, these SRUs are not compliant with the usual SRU policy.
+
+As of the time of writing, CUDA packages are under an allowed exception to install
+files under /usr/local. The exception is temporary. Any SRU request that is patching 
+a CUDA version relying on the exception is expected to keep installing files under /usr/local.
 
 .. _requesting_sru:
 
@@ -85,13 +89,12 @@ attempted manually, from a fresh installation.
 ::
 
     [Impact]
-    This release provides both bug fixes and new features and we would like to
+    This patch provides both bug fixes and we would like to
     make sure all of our users have access to these improvements.
-    The notable ones are:
 
-    *** <TODO: Create list with LP: # included >
+    The patched packages are:
 
-    See the changelog entry below for a full list of changes and bugs.
+    *** <TODO: Provide a list of updated packages, by comparing https://developer.download.nvidia.com/compute/cuda/redist/redistrib_${MAJOR}.${MINOR}.${PATCH}.json for the current and target versions  >
 
     [Test Plan]
     The following development and SRU process was followed:

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -45,7 +45,8 @@ backported to 27.10 and 26.04.
  NVIDIA CUDA Requesting the SRU
 ********************************
 
-The SRU should be done with a single process bug, instead of individual bug
+The SRU should be done with a single process bug appropriately named
+`cuda-X-Y`, instead of individual bug
 reports for individual bug fixes. The one bug should have the following:
 
 - The SRU should be requested per the :ref:`StableReleaseUpdates

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -1,0 +1,111 @@
+.. _reference-exception-nvidia-cuda:
+
+#####################
+ Nvidia CUDA updates
+#####################
+
+**************
+ Introduction
+**************
+
+This document describes the policy, process and criteria for updating NVIDIA
+CUDA libraries in a stable supported distro, including LTS.
+
+NVIDIA CUDA is broadly used by developers for GPU compute activities, for
+example for AI/ML. Ubuntu has a redistribution agreement with NVIDIA to
+redistribute the CUDA libraries in the Ubuntu archive. Per the agreement, Ubuntu
+must deliver the prebuilt binaries from NVIDIA without modifications, and follow
+the same schedule than NVIDIA.
+
+CUDA represents ~37 new source packages for every minor version. Minor versions
+are released on average every 3 months. Each minor version usually get one or
+two patch versions, which will be candidate for an SRU. Given the nature of
+CUDA, these SRUs are not compliant with the usual SRU policy.
+
+.. _requesting_sru:
+
+********************************
+ NVIDIA CUDA Requesting the SRU
+********************************
+
+The SRU should be done with a single process bug, instead of individual bug
+reports for individual bug fixes. The one bug should have the following:
+
+- The SRU should be requested per the :ref:`StableReleaseUpdates
+  <howto-perform-standard-sru>` documented process
+- The template at the end of this document should be used and all ‘TODO’ filled
+  out
+- The changelog will contain a reference to the single SRU process bug, not all
+  bugs fixed by the SRU. However, if there are very important bugs that are
+  deemed worthy of reference they too should be included in the changelog.
+- Major changes should be called out in the SRU template, especially where
+  changed behavior is not backward compatible.
+- For each release that is proposed to be updated by the SRU a link to the
+  results of the automated tests so that anyone can verify that they have been
+  executed successfully.
+- Additionally, the SRU bug should be verbose in documenting any manual testing
+  that occurred.
+- Any architecture specific fixes need to be noted and architecture specific
+  test results included.
+- Any packaging changes (e.g. a dependency change) need to be stated
+
+.. _packaging_qa:
+
+**************************
+ NVIDIA CUDA Packaging QA
+**************************
+
+The objective of the QA is to test:
+
+- Package installation from scratch
+- Package upgrades
+- Compliancy with NVIDIA's own releases
+
+This QA is implemented as an autopkgtest within each source package. The result
+of the tests will be attached to the SRU bug. The package upgrade must be
+attempted manually, from a fresh installation.
+
+.. _integration_tests:
+
+*******************
+ Integration tests
+*******************
+
+- `Certification test suite
+  <https://github.com/canonical/checkbox/blob/main/providers/gpgpu/units/cuda.pxu>`__
+  must pass on a range of hardware, with the same result as with NVIDIA's
+  provided packages.
+
+.. _sru_template:
+
+**************************
+ NVIDIA CUDA SRU Template
+**************************
+
+::
+
+    [Impact]
+    This release provides both bug fixes and new features and we would like to
+    make sure all of our users have access to these improvements.
+    The notable ones are:
+
+    *** <TODO: Create list with LP: # included >
+
+    See the changelog entry below for a full list of changes and bugs.
+
+    [Test Plan]
+    The following development and SRU process was followed:
+    https://documentation.ubuntu.com/sru/en/latest/reference/exception-nvidia-cuda/
+
+    <TODO Document any QA done, automated and manual>
+
+    The QA team that executed the tests will be in charge of attaching the artifacts and
+    console output of the appropriate run to the bug. NVIDIACUDA maintainers team members
+    will not mark ‘verification-done’ until this has happened.
+
+    [Where problems could occur]
+    NVIDIA could be delivering a not-so-minor change that could cause regressions. The pre-built nature of CUDA
+    prevent us to detect that. It could not install anymore due to a missing newly added package, for example.
+    The installation test, the autopkgtests and the integration tests should be able to detect that.
+
+    <TODO: attach test artifacts for every SRU release, not a link as links expire>

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -19,12 +19,24 @@ the same schedule than NVIDIA.
 
 CUDA represents ~37 new source packages for every minor version. Minor versions
 are released on average every 3 months. Each minor version usually get one or
-two patch versions, which will be candidates for SRUs. Given the nature of
-CUDA, these SRUs are not compliant with the usual SRU policy.
+two patch versions, which will be candidates for SRUs. Given the nature of CUDA,
+these SRUs are not compliant with the usual SRU policy.
 
-As of the time of writing, CUDA packages are under an allowed exception to install
-files under /usr/local. The exception is temporary. Any SRU request that is patching 
-a CUDA version relying on the exception is expected to keep installing files under /usr/local.
+As of the time of writing, CUDA packages are under an allowed exception to
+install files under /usr/local. The exception is temporary. Any SRU request that
+is patching a CUDA version relying on the exception is expected to keep
+installing files under /usr/local.
+
+*******************
+ Released versions
+*******************
+
+CUDA's minor versions are meant to be available and installable in parallel, and
+therefore 13.2 does not replace 13.1 in Ubuntu, but 13.2.1 will replace 13.2.0.
+CUDA's minor version package sets are meant to be broadly backported to
+compatible releases that are supported, starting with 26.04. For example, when
+the currently hypothetical 14.1.0 version is released for 28.04, it will be
+backported to 27.10 and 26.04.
 
 .. _requesting_sru:
 
@@ -94,7 +106,7 @@ attempted manually, from a fresh installation.
 
     The patched packages are:
 
-    *** <TODO: Provide a list of updated packages, by comparing https://developer.download.nvidia.com/compute/cuda/redist/redistrib_${MAJOR}.${MINOR}.${PATCH}.json for the current and target versions  >
+    *** <TODO: Provide a list of updated packages, by comparing https://developer.download.nvidia.com/compute/cuda/redist/redistrib_${MAJOR}.${MINOR}.${PATCH}.json for the current and target versions >
 
     [Test Plan]
     The following development and SRU process was followed:

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -32,7 +32,8 @@ installing files under /usr/local.
 *******************
 
 CUDA's minor versions are meant to be available and installable in parallel, and
-therefore 13.2 does not replace 13.1 in Ubuntu, but 13.2.1 will replace 13.2.0.
+therefore e.g. 13.2 does not replace 13.1 in Ubuntu. Patch versions do replace the
+corresponding existing version so e.g. 13.2.1 will replace 13.2.0.
 CUDA's minor version package sets are meant to be broadly backported to
 compatible releases that are supported, starting with 26.04. For example, when
 the currently hypothetical 14.1.0 version is released for 28.04, it will be

--- a/docs/SRU/reference/exception-nvidia-cuda.rst
+++ b/docs/SRU/reference/exception-nvidia-cuda.rst
@@ -16,7 +16,7 @@ example for AI/ML. Canonical has a redistribution agreement with NVIDIA to
 redistribute the CUDA libraries in the Ubuntu archive. Per the agreement, Canonical
 must deliver the prebuilt binaries from NVIDIA without modifications.
 
-CUDA consists of ~37 new source packages for every minor version. Minor versions
+CUDA consists of about 37 new source packages for every minor version. Minor versions
 are released on average every 3 months. Each minor version usually receives one or
 two patch versions, which will be candidates for SRUs. Since our redistribution 
 agreement requires us to match NVIDIA's changes exactly within a given CUDA release,
@@ -33,14 +33,26 @@ relying on the exception is expected to keep installing files under /usr/local.
  Released versions
 *******************
 
+Minor versions:
+
 CUDA packages are released in the multiverse pocket.
 CUDA's minor versions are meant to be available and installable in parallel, and
-therefore e.g. 13.2 does not replace 13.1 in Ubuntu. Patch versions do replace the
-corresponding existing version so e.g. 13.2.1 will replace 13.2.0.
-CUDA's minor version package sets are meant to be broadly backported to
+therefore e.g. 13.2 does not replace 13.1 in Ubuntu. Minor versions are always a
+new set of source packages, suffixed with MAJOR.MINOR, e.g. cuda-13-2.
+
+CUDA's minor version package sets are meant to be broadly SRU'd to
 compatible releases that are supported, starting with 26.04. For example, when
 the currently hypothetical 14.1.0 version is released for 28.04, it will be
-backported to 27.10 and 26.04.
+SRU'd to 27.10 and 26.04.
+
+Patch versions:
+
+Patch versions do replace the corresponding existing version so e.g. 13.2.1 will
+replace 13.2.0.
+
+CUDA's patch version package sets are also meant to be broadly SRU'd to
+compatible releases that are supported. For example, 26.04 was released with
+13.1.1 and when 13.1.2 is available in devel it will be SRU'd up until 26.04.
 
 .. _requesting_sru:
 
@@ -54,8 +66,8 @@ reports for individual bug fixes. The one bug should have the following:
 
 - The SRU should be requested per the :ref:`StableReleaseUpdates
   <howto-perform-standard-sru>` documented process
-- The template at the end of this document should be used and all ‘TODO’ filled
-  out
+- The template at the end of this document should be used and all ‘TODO’ items
+  filled out
 - This SRU exception applies to only the multiverse archive component.
 - The changelog will contain a reference to the single SRU process bug, not all
   bugs fixed by the SRU. However, if there are very important bugs that are
@@ -81,11 +93,14 @@ The objective of the QA is to test:
 
 - Package installation from scratch
 - Package upgrades
-- Compliancy with NVIDIA's own releases
-  - Making sure that we deliver the right binary in the right packages with the right license and dependencies
-  - Making sure the CUDA installation is working as expected (integration tests with cuda samples).
+- Compliance with NVIDIA's own releases
+  - Making sure that we deliver the right binary in the right packages with
+    the right license and dependencies
+  - Making sure the CUDA installation is working as expected (integration
+    tests with cuda samples).
 - Compatibility with NVIDIA's own releases and repos
-  - Making  sure that NVIDIA's packages superseed us, and that users adding the NVIDIA repo don't end up with a mix of our packages and NVIDIA's packages
+  - Making sure that NVIDIA's packages supersede ours, and that users adding
+    the NVIDIA repo don't end up with a mix of our packages and NVIDIA's packages
 
 This QA is implemented as an autopkgtest within each source package. The result
 of the tests will be attached to the SRU bug. The package upgrade must be
@@ -129,8 +144,8 @@ attempted manually, from a fresh installation.
     will not mark ‘verification-done’ until this has happened.
 
     [Where problems could occur]
-    NVIDIA could be delivering a not-so-minor change that could cause regressions. The pre-built nature of CUDA
-    prevent us to detect that. It could not install anymore due to a missing newly added package, for example.
-    The installation test, the autopkgtests and the integration tests should be able to detect that.
+    NVIDIA could deliver a not-so-minor change that could cause regressions. The pre-built nature of CUDA
+    prevents us from detecting that. It might fail to install due to a newly added missing package, for example.
+    The installation test, the autopkgtests and the integration tests will to detect that.
 
     <TODO: attach test artifacts for every SRU release, not a link as links expire>

--- a/docs/SRU/reference/package-specific.rst
+++ b/docs/SRU/reference/package-specific.rst
@@ -50,6 +50,7 @@ the Technical Board.
     exception-MariaDB-Galera-Updates
     exception-multipath-tools-Updates
     exception-NVidia-Updates
+    exception-Nvidia-Cuda-Updates
     exception-Netplan-Updates
     exception-OEMMeta-Updates
     exception-OpenJDK-Updates


### PR DESCRIPTION
**This PR will require approval from an SRU team member**

I will also update the [TBD] sections if an SRU team member approves.

## Description

Add an SRU exception for the CUDA packages that we are newly delivering in 26.04. It's sets of 37+ prebuilt packages whose patches we will want to backport.