### PR TITLE
Dmb fix delegated self approved team

### DIFF
--- a/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
@@ -69,6 +69,27 @@ When applying for a set, please be prepared to attend a DMB meeting.
 
 The Developer Membership Board will take care of creating the packageset and ensuring that the requested permissions are granted.
 
+## Teams approving their own members
+
+We may grant your team's administrators the ability to grant upload access to
+parts of Ubuntu. In this case, we'll want to make sure that you're acting in
+general accordance with how other teams work. The following are the basic
+requirements:
+
+* Applications should be announced to an appropriate publicly-readable
+  mailing list, to provide an opportunity for feedback. Successful applications,
+  or administrator additions, must be announced to devel-permissions@lists.ubuntu.com
+  and to an appropriate publicly-readable mailing list for the team.
+
+* developer-membership-board must be a co-administrator or the owner of your team.
+
+* ubuntu-core-dev must be a member of your team
+
+* Applicants must meet the general requirements for {ref}`Ubuntu contributing developers <dmb-joining-contributing>`.
+
+* Your team must maintain a page describing your policy for granting upload
+  access, and any special requirements for team membership. Preferably as part
+  of this project documentation set.
 
 ## Requesting changes to delegated teams
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
@@ -73,7 +73,7 @@ The Developer Membership Board will take care of creating the packageset and ens
 ## Requesting changes to delegated teams
 
 Email `devel-permissions@lists.ubuntu.com` with the proposed change(s) and the packageset to which the change applies.
-  
+
 A DMB member will review the request and either make the change or ask for further clarification if it us unclear that the package falls under the delegation granted when the team was created.
 
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
@@ -84,12 +84,17 @@ requirements:
 * developer-membership-board must be a co-administrator or the owner of your team.
 
 * ubuntu-core-dev must be a member of your team
+  That will to allow contributions to projects and code maintained by such a team.
 
 * Applicants must meet the general requirements for {ref}`Ubuntu contributing developers <dmb-joining-contributing>`.
 
 * Your team must maintain a page describing your policy for granting upload
   access, and any special requirements for team membership. Preferably as part
   of this project documentation set.
+
+  * Time has shown that some teams are special,
+    even without delegation - there is nothing preventing a documentation of
+    such requirements for non-delegated teams.
 
 ## Requesting changes to delegated teams
 


### PR DESCRIPTION
This came up in a good question while preparing for the DKMS delegated team.
Let us clean up the old content in the wiki and thereby polish what we have in the new project docs.