### PR TITLE
Add warning about autopkgtest-build-lxd and old Ubuntu images

### DIFF
--- a/docs/contributors/bug-fix/run-package-tests.md
+++ b/docs/contributors/bug-fix/run-package-tests.md
@@ -119,6 +119,10 @@ First, we will build the image we prepared in the previous section.
 
   You should see an `autopkgtest` image now when you run `lxc image list`.
 
+  ```{warning}
+  The `autopkgtest-build-lxd` command only works with Ubuntu 18.04 (Bionic Beaver) images and later; when applied to older releases, it fails with a timeout or network errors. In this case you can use the `autopkgtest-buildvm-ubuntu-cloud` command to build a VM image instead.
+  ```
+
 
 #### Constructing the command
 


### PR DESCRIPTION
I ran into an issue with building old Ubuntu images using `autopkgtest-build-lxd` (reported in [LP#2146949: autopkgtest-build-lxd times out for xenial image](https://bugs.launchpad.net/ubuntu/+source/autopkgtest/+bug/2146949)). Based on the response in the bug report, this is expected behavior, not a bug in the `autopkgtest-build-lxd` package. It seemed worth warning about this in the docs, since the error message wouldn't make it obvious what the problem is.