### PR TITLE
docs: fix lxc launch image in test-the-new-build.md

### DIFF
--- a/docs/contributors/merging/test-the-new-build.md
+++ b/docs/contributors/merging/test-the-new-build.md
@@ -39,7 +39,7 @@ See {ref}`how-to-run-package-tests`.
 1. Create and start a new LXD container to test in:
 
     ```none
-    $ lxc launch ubuntu-daily:ubuntu/<ubuntu-codename> tester && lxc exec tester bash
+    $ lxc launch ubuntu-daily:<ubuntu-codename> tester && lxc exec tester bash
     ```
 
 1. Install the currently available version of the package you've been working on:
@@ -86,7 +86,7 @@ See {ref}`how-to-run-package-tests`.
 1. Create and start a new LXD container to test in:
 
     ```none
-    $ lxc launch ubuntu-daily:ubuntu/<ubuntu-codename> tester && lxc exec tester bash
+    $ lxc launch ubuntu-daily:<ubuntu-codename> tester && lxc exec tester bash
     ```
 
 1. Add your PPA to the virtual system to upgrade the package to the version you want to test:


### PR DESCRIPTION
The "test the new build" part of the merging docs seems to have outdated image paths:
```
$ lxc launch ubuntu-daily:ubuntu/resolute tester && lxc exec tester bash
Launching tester
Error: Failed instance creation: Failed getting remote image info: Failed getting image: The requested image couldn't be found for fingerprint "ubuntu/resolute"
```
with the working version being
```
lxc launch ubuntu-daily:resolute tester && lxc exec tester bash
```
I've adjusted the page accordingly.