### PR TITLE
docs: link to the PPA upload page in the Making Changes to a Package page

### DIFF
--- a/docs/contributors/patching/make-changes-to-a-package.rst
+++ b/docs/contributors/patching/make-changes-to-a-package.rst
@@ -382,7 +382,7 @@ Next steps
 From here, there are many options for testing our patch before proposing the change in a merge proposal:
 
 * Build and test the package locally using :command:`sbuild` and :command:`autopkgtest`.
-* Upload to a PPA and test from there.
+* :ref:`Upload to a PPA <merge-create-a-ppa>` and test from there.
 
 Once you feel confident that the patch is working correctly, open a merge proposal and request :ref:`sponsorship` for your change.
 


### PR DESCRIPTION
Small QOL change, in the "Next Steps" section where it recommends testing on a PPA, I've linked to the page for uploading to PPAs. 

The full page in `Contributing/Upload Packages to a PPA` is unfinished, so for now as a stopgap the link points to [Merging/Upload a PPA](https://documentation.ubuntu.com/project/contributors/merging/upload-a-ppa/) instead.