### PR TITLE
26.04 release notes and schedule have docs URL

### DIFF
--- a/docs/release-team/list-of-releases.md
+++ b/docs/release-team/list-of-releases.md
@@ -58,7 +58,7 @@ feature-based one), approximately every 6 months.
 
 | Version | Code name | Schedule | Docs | Release | End of Standard Support |
 | :---- | :---- | :---- | :---- | :---- | :---- |
-| Ubuntu 26.04 LTS | Resolute Raccoon | [Release Schedule](https://discourse.ubuntu.com/t/resolute-raccoon-release-schedule/47198) | [Release Notes](https://discourse.ubuntu.com/t/resolute-raccoon-release-notes/59221) | April 23, 2026 | July 2031 |
+| Ubuntu 26.04 LTS | Resolute Raccoon | [Release Schedule](https://documentation.ubuntu.com/release-notes/26.04/schedule/) | [Release Notes](https://documentation.ubuntu.com/release-notes/26.04/) | April 23, 2026 | July 2031 |
 
 
 ## Expanded Security Maintenance


### PR DESCRIPTION
s/discourse.ubuntu.com/documentation.ubuntu.com/

### Additional notes (optional)

current URL still lacking the "Contribute to this page" deeplink (different repo, `ubuntu/ubuntu-release-notes` vs `ubuntu/ubuntu-project-docs`)