### PR TITLE
docs: clarify local builds are for existing packages

### DIFF
--- a/docs/contributors/bug-fix/build-packages-locally.rst
+++ b/docs/contributors/bug-fix/build-packages-locally.rst
@@ -3,6 +3,12 @@
 How to build packages locally
 =============================
 
+.. note::
+
+        This is about building an existing package locally. If you want to
+        build a new package, please refer to
+        :ref:`how-to-create-a-new-package`.
+
 In Ubuntu, packages can be built in several ways, depending on the intended
 artifacts. The standard and recommended way to build packages for Ubuntu is
 with ``dpkg-buildpackage`` and ``sbuild``. This ensures that the build


### PR DESCRIPTION
Add a note at the top of build-packages-locally.rst to direct users creating a new package to the dedicated how-to guide.

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
