### PR TITLE
[chore] Fix broken refs preventing RTD build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -425,7 +425,7 @@ if os.path.exists("./reuse/substitutions.yaml"):
 # Add configuration for intersphinx mapping
 
 intersphinx_mapping = {
-    "ubuntu-server": ("https://ubuntu.com/server/docs/", None),
+#    "ubuntu-server": ("https://ubuntu.com/server/docs/", None),
     "starter-pack": (
         "https://canonical-starter-pack.readthedocs-hosted.com/latest/",
         None,

--- a/docs/contributors/bug-fix/install-built-packages.rst
+++ b/docs/contributors/bug-fix/install-built-packages.rst
@@ -16,7 +16,7 @@ You can use the :manpage:`apt(8)`, :manpage:`apt-get(8)`, or :manpage:`dpkg(1)` 
 
     :manpage:`dpkg(1)` is a package manager for :term:`Debian`-based systems. It can install, remove, and build packages, but unlike the :term:`APT` package management systems, it cannot automatically download and install packages or their dependencies.
 
-    See the :external+ubuntu-server:doc:`how-to/software/package-management` article from the :term:`Ubuntu Server` documentation for more details.
+    See the `package management <https://ubuntu.com/server/docs/how-to/software/package-management/>`_ article from the Ubuntu Server documentation for more details.
 
 .. _install-deb-files:
 

--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -3,7 +3,7 @@
 # Glossary
 
 We are currently compiling and defining terms for this glossary. If you would
-like to help, please visit our {ref}`contributions page <contribute>` for
+like to help, please visit our {ref}`contributions page <how-to-contribute-docs>` for
 details on how to get involved.
 
 

--- a/docs/maintainers/AA/triage-aa-contributions.md
+++ b/docs/maintainers/AA/triage-aa-contributions.md
@@ -2,7 +2,7 @@
 
 # Check contributions to AA process and documentation
 
-Everyone is encouraged in {ref}`contribute` to help with the documentation
+Everyone is encouraged in {ref}`how-to-contribute-docs` to help with the documentation
 and modernizing the processes in this repository.
 
 To keep that maintainable for sub-teams the Ubuntu project documentation uses


### PR DESCRIPTION
### Description

Fixes two separate failures in the RTD build:
* Ubuntu Server intersphinx mapping can't be found (due to the reverse proxy setup). Removed this until it can be investigated and fixed (only affects one link)
* Broken ref to the contribute docs page (affects two pages)

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

