### PR TITLE
SRU: linux-firmware: add more instructions to avoid archive disruption

### DIFF
--- a/docs/SRU/reference/package-specific.rst
+++ b/docs/SRU/reference/package-specific.rst
@@ -709,9 +709,10 @@ be taken to not leave the kernel with a mismatched firmware package.
 
 However, it is a very large package (over 500MiB in size), and making it
 instantly available in the -security pocket to all Ubuntu users in the world
-via unattended-upgrades causes a lot of strain on the archive network
-and servers. The kernel team is working on that, but until then we need to
-mitigate the impact to all users.
+via unattended-upgrades causes a lot of strain on the archive network and
+servers. Ubuntu 26.04 LTS has split the linux-firmware package into multiple
+smaller packages, but for older releases we need to mitigate the impact to all
+users.
 
 Therefore, for now, once the verification is done and linux-firmware is ready
 to be (SRU) released we have to stagger the release to spread the load.
@@ -719,11 +720,15 @@ to be (SRU) released we have to stagger the release to spread the load.
 * First it should be released to the updates pocket - allowing mirrors to sync
   it and anyone running explicit updates to pick it up.
 
-* Then after phasing has completed, it must be copied to the -security pocket
-  by either an archive admin, or a security team member. That copy should also
-  be spread out over releases. The suggested delay in-between is 4 days,
-  which combined with the "avoid Friday" rule suggests Mon,Thu,Mon,... until
-  all are fully released.
+* After the phasing has completed and we are ready to copy it to the security
+  pocket, first we need to notify Canonical IS, so that they can put mitigation
+  measures in place and prepare for the increased load on the archive.
+
+* After Canonical IS has given the go-ahead, the linux-firmware packages must
+  be copied to the security pocket by either an archive admin, or a security
+  team member. That copy should also be spread out over Ubuntu releases, one at
+  a time. The suggested delay in-between is 4 days, which combined with the
+  "avoid Friday" rule suggests Mon,Thu,Mon,... until all are fully released.
 
 Note that this release process described above only applies to SRUs. Actual
 security updates to this package are not handled through the SRU process


### PR DESCRIPTION
### Description
SRUs of `linux-firmware` continue to bring down the Ubuntu archive, even with the existing process in place. This PR adds another step to the SRU process of `linux-firmware` to try to mitigate further archive disruption.

The Real Fix is something else, and is being discussed, but this is what we can do right now.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
