### PR TITLE
docs: Mention exporting of the orig tarball in make-changes-to-a-package

### DIFF
--- a/docs/contributors/patching/make-changes-to-a-package.rst
+++ b/docs/contributors/patching/make-changes-to-a-package.rst
@@ -22,13 +22,13 @@ Once we have :command:`git-ubuntu` installed, use it to fetch the source code fo
     $ git-ubuntu clone hello
     $ cd hello/
 
-To eventually build or upload our changed package, we will also need the tarball containing the original upstream source code:
+To eventually build or upload our changed package, we also need the tarball containing the original upstream source code:
 
 .. prompt:: none $ auto
 
     $ git-ubuntu export-orig
 
-This will put the tarball in the parent directory, at `../hello_2.10.orig.tar.gz`. Most ecosystem tools will expect orig tarballs placed one directory up like this, so don't move it.
+This puts the tarball in the parent directory, at `../hello_2.10.orig.tar.gz`. Most ecosystem tools expect orig tarballs placed one directory up like this, so don't move it.
 
 We are using some tools from the :pkg:`ubuntu-dev-tools` package. Install it with:
 

--- a/docs/contributors/patching/make-changes-to-a-package.rst
+++ b/docs/contributors/patching/make-changes-to-a-package.rst
@@ -22,6 +22,14 @@ Once we have :command:`git-ubuntu` installed, use it to fetch the source code fo
     $ git-ubuntu clone hello
     $ cd hello/
 
+To eventually build or upload our changed package, we will also need the tarball containing the original upstream source code:
+
+.. prompt:: none $ auto
+
+    $ git-ubuntu export-orig
+
+This will put the tarball in the parent directory, at `../hello_2.10.orig.tar.gz`. Most ecosystem tools will expect orig tarballs placed one directory up like this, so don't move it.
+
 We are using some tools from the :pkg:`ubuntu-dev-tools` package. Install it with:
 
 .. prompt:: none $ auto


### PR DESCRIPTION
Right now, you can't build after making the patches because the documentation doesn't mention getting the orig tarball. Added a few lines about this in the initial setup.