### PR TITLE
Update manpage URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,7 +338,7 @@ stable_distro = "questing"
 manpages_url = (
     "https://manpages.ubuntu.com/manpages/"
     + stable_distro
-    + "/en/man{section}/{page}.{section}.html"
+    + "/man{section}/{page}.{section}.html"
 )
 
 myst_substitutions = {


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

Updates manpage URL scheme to reflect manpages.ubuntu.com backwards-compat. break.

---

### Related issue

- Fixes: #556 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Ref.: https://github.com/canonical/ubuntu-manpages-operator/issues/55

