### PR TITLE
Simplify getting started setup

### DIFF
--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -22,7 +22,6 @@ $ sudo apt update && \
     git-buildpackage \
     libvirt-daemon-system \
     pastebinit \
-    pkg-config \
     sbuild-launchpad-chroot \
     ubuntu-dev-tools && \
   sudo snap install lxd && \

--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -32,8 +32,7 @@ $ sudo apt update && \
     ubuntu-dev-tools && \
   sudo snap install lxd && \
   sudo snap install --classic snapcraft && \
-  sudo snap install --classic git-ubuntu && \
-  sudo snap install --classic --beta multipass
+  sudo snap install --classic git-ubuntu
 ```
 
 ## Configure software

--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -18,8 +18,6 @@ $ sudo apt update && \
   sudo apt dist-upgrade -y && \
   sudo apt install -y \
     autopkgtest \
-    debconf-utils \
-    debmake \
     dh-make \
     git-buildpackage \
     libvirt-daemon-system \

--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -32,7 +32,6 @@ $ sudo apt update && \
     ubuntu-dev-tools && \
   sudo snap install lxd && \
   sudo snap install --classic snapcraft && \
-  sudo snap install --classic ustriage && \
   sudo snap install --classic git-ubuntu && \
   sudo snap install --classic --beta multipass
 ```

--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -19,7 +19,6 @@ $ sudo apt update && \
   sudo apt install -y \
     apt-cacher-ng \
     autopkgtest \
-    build-essential \
     debconf-utils \
     debmake \
     dh-make \
@@ -27,7 +26,6 @@ $ sudo apt update && \
     libvirt-daemon-system \
     pastebinit \
     pkg-config \
-    quilt \
     sbuild-launchpad-chroot \
     ubuntu-dev-tools && \
   sudo snap install lxd && \

--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -17,7 +17,6 @@ You must have a Launchpad ID. To get an ID:
 $ sudo apt update && \
   sudo apt dist-upgrade -y && \
   sudo apt install -y \
-    apt-cacher-ng \
     autopkgtest \
     debconf-utils \
     debmake \
@@ -290,8 +289,8 @@ preserve-environment=true"
 # updates after each release of Ubuntu
 SKIP_UPDATES="1"
 SKIP_PROPOSED="1"
-# if you have e.g. apt-cacher-ng around
-DEBOOTSTRAP_PROXY=http://127.0.0.1:3142/
+# if you have a local prox like apt-cacher-ng around enable the following
+# DEBOOTSTRAP_PROXY=http://127.0.0.1:3142/
 ```
 
 ```{note}

--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -33,7 +33,7 @@ $ sudo apt update && \
   sudo snap install lxd && \
   sudo snap install --classic snapcraft && \
   sudo snap install --classic ustriage && \
-  sudo snap install --classic --edge git-ubuntu && \
+  sudo snap install --classic git-ubuntu && \
   sudo snap install --classic --beta multipass
 ```
 

--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -20,7 +20,6 @@ $ sudo apt update && \
     autopkgtest \
     dh-make \
     git-buildpackage \
-    libvirt-daemon-system \
     pastebinit \
     sbuild-launchpad-chroot \
     ubuntu-dev-tools && \


### PR DESCRIPTION
I have been in various mentoring sessions and realized that this is totally over the limit.
The list outlined here is full of outdated artifacts, things that are dependencies of one another, some is only needed in the server team but came in when copying from us and more.
I cleared it up to help but also to not have someone starting feeling as much "WTH why so much".

Please note that I know @jugmac00 and others work on unifying https://documentation.ubuntu.com/project/contributors/bug-fix/build-packages-locally/#installing-the-necessary-tools into https://documentation.ubuntu.com/project/contributors/setup/set-up-for-ubuntu-development/
The new list I hereby propose for the latter does directly or indirectly depend on everything that is mentioned here. Therefore https://documentation.ubuntu.com/project/contributors/bug-fix/build-packages-locally/#installing-the-necessary-tools can point to https://documentation.ubuntu.com/project/contributors/setup/set-up-for-ubuntu-development/ without adding any entries.