### PR TITLE
Account for amd64v3 in parsing update_output.txt

### DIFF
--- a/docs/how-ubuntu-is-made/processes/proposed-migration/issues-preventing-migration.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/issues-preventing-migration.md
@@ -190,7 +190,7 @@ Using the {pkg}`exim4` package as an example.
     ```none
     trying: exim4
     skipped: exim4 (4, 0, 137)
-        got: 11+0: a-0:a-0:a-0:i-2:p-1:r-7:s-1
+        got: 11+0: a-0:a-0:a-0:a-0:i-2:p-1:r-7:s-1
         * riscv64: sa-exim
     ```
 
@@ -211,10 +211,11 @@ Using the {pkg}`exim4` package as an example.
 
         * 137 packages remain to be examined after this package before this check of all packages is completed.
 
-    `got: 11+0: a-0:a-0:a-0:i-2:p-1:r-7:s-1`
+    `got: 11+0: a-0:a-0:a-0:a-0:i-2:p-1:r-7:s-1`
     : The `got` line shows the number of problems in the release pocket on the different architectures (until the first architecture where a problem is found). In this case, it's 11 uninstallable packages on all architectures together. The letters stand for (in this order):
 
         * `a`: amd64
+        * `a`: amd64v3
         * `a`: arm64
         * `a`: armhf
         * `i`: i386


### PR DESCRIPTION
### Description

It currently doesn't mention amd64v3, so one reading a recent report would get lost with an extra `a-<N>` field in the `got: ` line. While the exact list of architectures can be retrieved from the top of the report, it's good to have the documentation up-to-date. 


### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected


