### PR TITLE
sru-docs: Add Python as a named toolchain

### DIFF
--- a/docs/SRU/reference/package-specific.rst
+++ b/docs/SRU/reference/package-specific.rst
@@ -760,3 +760,4 @@ Toolchains:
 
 * Java: `Java updates PPA <https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa>`__
 * Go: `Go updates PPA <https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/golang>`__
+* Python: `Python updates PPA <https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/python>`__


### PR DESCRIPTION
### Description

Python needs to be built in a ppa with -security enabled, and we decided to place it in ubuntu-toolchain-r/python.


### Checklist

- [X] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [X] I have tested my changes, and they work as expected

