### PR TITLE
docs(contributors): link local build prerequisites to setup guide

### DIFF
--- a/docs/contributors/bug-fix/build-packages-locally.rst
+++ b/docs/contributors/bug-fix/build-packages-locally.rst
@@ -37,7 +37,7 @@ Building packages locally requires a few tools to be installed and configured. T
 Installing the necessary tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please refer to :ref:`how-to-set-up-for-ubuntu-development`.
+Refer to :ref:`how-to-set-up-for-ubuntu-development`.
 
 
 Setting up ``sbuild``

--- a/docs/contributors/bug-fix/build-packages-locally.rst
+++ b/docs/contributors/bug-fix/build-packages-locally.rst
@@ -37,9 +37,7 @@ Building packages locally requires a few tools to be installed and configured. T
 Installing the necessary tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: none
-
-    $ sudo apt install devscripts dpkg-dev sbuild mmdebstrap uidmap piuparts
+Please refer to :ref:`how-to-set-up-for-ubuntu-development`.
 
 
 Setting up ``sbuild``


### PR DESCRIPTION
Replace the inline apt install command with a reference to the Ubuntu development setup guide.

This avoids duplication. Also e.g. the previously listed "piuparts" was not available on Noble.
