### PR TITLE
Update how to enable Apport to reflect availability in the Control Center

### DIFF
--- a/docs/contributors/debugging/apport.md
+++ b/docs/contributors/debugging/apport.md
@@ -65,21 +65,11 @@ Apport does not trap SIGABRT signals. If you are getting such a signal, then ple
 (how-to-enable-apport)=
 ## How to enable Apport
 
-<!-- TODO: Error Tracker wiki page may need to be migrated -->
-Apport itself is running at all times because it collects crash data for `whoopsie` (see page on the [Error Tracker](https://wiki.ubuntu.com/ErrorTracker)). However, the crash interception component is still disabled. To enable it permanently, do:
+On Ubuntu Desktop, you can manage error reporting from the Control Center. Open {guilabel}`Settings`, go to {guilabel}`Privacy & Security` > {guilabel}`Diagnostics`, and use {guilabel}`Send error reports to Canonical` to choose how error reports are handled.
 
-```bash
-sudo nano /etc/apport/crashdb.conf
-```
+The default setting is {guilabel}`Manual`, which means Ubuntu asks before sending an error report. You can also choose to send reports automatically or disable error reporting from the same settings page.
 
-and **add a hash symbol #** at the beginning of the following line:
-
-```diff
--'problem_types': ['Bug', 'Package'],
-+#'problem_types': ['Bug', 'Package'],
-```
-
-To disable crash reporting just remove the hash symbol.
+If you are working on a server or another system without a graphical settings interface, you can still inspect crash reports from the command line. Apport stores crash reports in {file}`/var/crash/`, and tools such as {command}`apport-cli` can process pending reports from a terminal.
 
 (im-a-developer-how-do-i-use-these-crash-reports)=
 ## I'm a developer. How do I use these crash reports?

--- a/docs/contributors/debugging/apport.md
+++ b/docs/contributors/debugging/apport.md
@@ -69,7 +69,7 @@ On Ubuntu Desktop, you can manage error reporting from the Control Center. Open 
 
 The default setting is {guilabel}`Manual`, which means Ubuntu asks before sending an error report. You can also choose to send reports automatically or disable error reporting from the same settings page.
 
-If you are working on a server or another system without a graphical settings interface, you can still inspect crash reports from the command line. Apport stores crash reports in {file}`/var/crash/`, and tools such as {command}`apport-cli` can process pending reports from a terminal.
+To inspect crash reports from the command line, use the {command}`apport-cli` tool. Apport stores crash reports in the {file}`/var/crash/` directory.
 
 (im-a-developer-how-do-i-use-these-crash-reports)=
 ## I'm a developer. How do I use these crash reports?


### PR DESCRIPTION
### Description

This pull request updates the “How to enable Apport” section on the Apport page.

The previous section only described editing `/etc/apport/crashdb.conf`. Issue #540 notes that this section should reflect that Apport error reporting is now available from the Control Center, so this update adds the current Settings / Privacy & Security / Diagnostics flow and keeps a short note for command-line users.

---

### Related issue

Related to #540

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [ ] I have tested my changes, and they work as expected

---

### Additional notes (optional)

This PR intentionally addresses only the Control Center guidance part of #540. The larger cleanup of old wiki links, Bazaar links, and the possible DeveloperHowTo migration can be handled separately.