### PR TITLE
Fix navig structure

### DIFF
--- a/docs/community/contribute/index.md
+++ b/docs/community/contribute/index.md
@@ -22,7 +22,7 @@ Here are just a few ways to you can contribute to our community.
 : As the developers' choice of operating systems, Ubuntu provides numerous avenues for creating new software. Developers can build universal and sandboxed Snap applications, pursue traditional Debian package development, or even create Juju Charms for container orchestration.
 : Do you want to create software that will be used around the world?
 
-{ref}`Ubuntu Development <how-to-contribute>`
+{ref}`Ubuntu Development <guides-for-contributors>`
 : Ubuntu, like other Linux distributions, relies on a vast collection of software packages created and supported by a global community of passionate developers. There are a number of ways that you can help support its ongoing development regardless of your current skill or knowledge level.
 : Are you ready to get help forge the future of Ubuntu?
 

--- a/docs/contributors/bug-fix/build-packages-locally.rst
+++ b/docs/contributors/bug-fix/build-packages-locally.rst
@@ -184,7 +184,7 @@ The flags used have the following meaning:
 
 * ``--build=source`` (``-S``): source-only build
 * ``--no-check-builddeps`` (``-d``): do not check build dependencies
-* ``--no-pre-clean`` (``-nc``): do not pre clean the source tree
+* ``--no-pre-clean`` (``-nc``): do not clean the source tree before build
 
 
 Building both source and binary packages

--- a/docs/contributors/debugging/apport.md
+++ b/docs/contributors/debugging/apport.md
@@ -215,11 +215,8 @@ If a crash or bug report is submitted through Apport, the relevant hooks will be
 (use-the-source-luke)=
 ## Use the source, Luke!
 
-<!-- TODO: bazaar links may need to be migrated -->
-* You can download the upstream tarball from the [Launchpad project page](https://launchpad.net/apport/+download), or the Ubuntu source tarball from the [Ubuntu archive](http://archive.ubuntu.com/ubuntu/pool/main/a/apport/).
-* apport is developed with the [bazaar](http://bazaar-vcs.org) RCS on [Launchpad](https://code.launchpad.net/apport). If you want to contribute to it or develop your own system based on it, you can get your own branch with `bzr branch lp:apport` for trunk, or `debcheckout -a apport` for the Ubuntu packaging branch.
+Apport is developed on Launchpad ([Apport](https://code.launchpad.net/apport)). To contribute to it or develop your own system based on it, see [code.launchpad.net/apport](https://code.launchpad.net/apport) for cloning instructions. To contribute to the Ubuntu package, use {lpsrc}`apport`.
 
-You can also [browse it online](http://bazaar.launchpad.net/~apport-hackers/apport/trunk).
 
 (future-plans)=
 ## Future plans

--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -1,9 +1,15 @@
-(how-to-contribute)=
-# Contributing to Ubuntu Development
+(guides-for-contributors)=
+# Guides for contributors
+
+These guides help you with the specific tasks and processes that build Ubuntu.
+
+
+## Contributing to Ubuntu Development
 
 Contributing to Ubuntu can mean many things, from {ref}`developing new applications <contribute-to-app-development>` to {ref}`reporting <how-to-report-a-bug>`, {ref}`triaging <triaging-bugs>`, and {ref}`fixing bugs <fixing-bugs>`, and many more development tasks. 
 
-## Getting Started with Ubuntu Development
+
+### Getting Started with Ubuntu Development
 
 A great place to start working on Ubuntu is through {ref}`reporting a bug <how-to-report-a-bug>`. Being active on the bug discussion after posting is important as developers and other community members may ask follow up questions or ask for additional log information.
 
@@ -11,9 +17,7 @@ A great place to start working on Ubuntu is through {ref}`reporting a bug <how-t
 
 {ref}`Fixing bugs <fixing-bugs>` is a more advanced task that requires greater knowledge of `git` and {ref}`patching workflows <patching>`. If you're feeling more comfortable in your skills as a software developer then finding upstream fixes, applying them to existing packages, and contributing to upstream projects to fix issues is of great help to Ubuntu.
 
-# Guides for contributors
-
-These guides help you with the specific tasks and processes that build Ubuntu.
+---
 
 
 ## Setting up for distro work

--- a/docs/contributors/uploading/request-an-upload.md
+++ b/docs/contributors/uploading/request-an-upload.md
@@ -20,7 +20,7 @@ For sponsors:
     * {ref}`how-to-sponsor-a-sync`
 :::
 
-Follow the general {ref}`guidance for contributors <how-to-contribute>` to have your changes properly prepared for sponsorship. Remember that someone else needs to understand what you've done.
+Follow the general {ref}`guidance for contributors <guides-for-contributors>` to have your changes properly prepared for sponsorship. Remember that someone else needs to understand what you've done.
 
 For any non-trivial change, it's good practice to discuss your plans with a potential sponsor (ask in {matrix}`devel`) *after* you think you know what needs to be done, but *before* you've actually done it. Often, an experienced developer can offer alternative approaches that may save you time or provide better results.
 

--- a/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
+++ b/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
@@ -183,14 +183,13 @@ For help with resolving problems, join the :matrix:`devel` Matrix channel to get
 Further reading
 ---------------
 
-* `Autopkgtest - Defining tests for Debian packages <https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst>`_
+* `Autopkgtest - Defining tests for Debian packages <autopkgtest_>`_
 
-.. wokeignore:rule=master
 .. _libxml2: https://git.launchpad.net/ubuntu/+source/libxml2/tree/debian/tests
 .. _gvfs: https://git.launchpad.net/ubuntu/+source/gvfs/tree/debian/tests
 .. _gtk3: https://git.launchpad.net/ubuntu/+source/gtk+3.0/tree/debian/tests
 .. _ubiquity: https://git.launchpad.net/ubiquity/tree/debian/tests
 .. _jenkins: https://autopkgtest.ubuntu.com/
-.. wokeignore:rule=master
 .. _running_tests: https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.running-tests.rst
 .. _requiredtests: https://wiki.ubuntu.com/QATeam/RequiredTests
+.. _autopkgtest: https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst

--- a/docs/staging/dmb/ubuntu-development.md
+++ b/docs/staging/dmb/ubuntu-development.md
@@ -284,9 +284,7 @@ so please be considerate.
 
 [Ubuntu Developers' Tools Installation Quick Start](https://wiki.ubuntu.com/BeginnersTeam/FocusGroups/Development/Devbeginnings)
 
-You will find some tools explained in the {ref}`how-to-contribute`, also from
-Gutsy on, you will find `ubuntu-dev-tools` in the Archive, which contains
-[tools for developing Ubuntu](https://wiki.ubuntu.com/UbuntuDevTools).
+Tools for contributors are explained in the {ref}`guides-for-contributors`. There's also the {pkg}`ubuntu-dev-tools` package in the Archive, which contains useful scripts for Ubuntu developers. See [Ubuntu Developer Tools](https://launchpad.net/ubuntu-dev-tools) on Launchpad.
 
 
 ### New packages


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

In 3d8f9d5, @j5awry introduced what I believe was an unintended bug into the docs navig. menu. A new H1 heading was added to `contributors/index.md`, and the presence of two H1 headings in the file caused the navig to look like this:

<img width="357" height="414" alt="image" src="https://github.com/user-attachments/assets/34308a5b-33a9-4012-906b-b0b703d95188" />

But it should be this:

<img width="365" height="329" alt="image" src="https://github.com/user-attachments/assets/7c940864-bf89-4c91-bb6b-bc54dd0abe56" />

I fixed it by moving the orig. H1 to the top of the file and relegating the new heading from John to a lower-level heading. Let me know if the intention was different.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Also fixed (unrelated):

- A couple of spelling problems
- An incl. lang. problem

