### PR TITLE
release: add Resolute Raccoon

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@ tech-board/ @basak @mwhudson @seb128 @teward
 
 # Release team PR approvals
 # These files have no prefix, so are collected into the release-team dir(s)
-release-team/ @utkarsh2102 @ginggs @paride
+release-team/ @utkarsh2102 @ginggs @paride @Hyask
 
 # Community team PR approvals
 # These files have no prefix, and are all collected into the `docs/community` dir
@@ -39,7 +39,7 @@ community/ @aaronprisk @ilvipero
 **/dmb-*.md @cpaelzer @lvoytek @rbasak @utkarsh2102 @athos-ribeiro @bdrung @julian-klode
 
 # TAs' & special teams' ack required for changes to the CODEOWNERS file
-/.github/CODEOWNERS @s-makin @rkratky @setharnold @joalif @didrocks @cpaelzer @MylesJP @pushkarnk @panlinux @paride @ginggs @schopin-pro @mwhudson @utkarsh2102 @tjaalton @seb128 @raof @aaronprisk @ilvipero @basak @teward @enr0n @julian-klode @awhitcroft
+/.github/CODEOWNERS @s-makin @rkratky @setharnold @joalif @didrocks @cpaelzer @MylesJP @pushkarnk @panlinux @paride @ginggs @schopin-pro @mwhudson @utkarsh2102 @tjaalton @seb128 @raof @aaronprisk @ilvipero @basak @teward @enr0n @julian-klode @awhitcroft @Hyask
 
 # +1 maintenance PR approvals
 plus-one-*.md @schopin-pro @s-makin @rkratky

--- a/docs/release-team/list-of-releases.md
+++ b/docs/release-team/list-of-releases.md
@@ -11,6 +11,7 @@ feature-based one), approximately every 6 months.
 
 | Version | Code name | Docs | Release | End of Standard Support | End of Life |
 | :---- | :---- | :---- | :---- | :---- | :---- |
+| Ubuntu 26.04 LTS | Resolute Raccoon | [Release Notes](https://documentation.ubuntu.com/release-notes/26.04/) | [April 23, 2026](https://lists.ubuntu.com/archives/ubuntu-announce/2026-April/000323.html) | May 2031 | April 2041 |
 | Ubuntu 25.10 | Questing Quokka | [Release Notes](https://discourse.ubuntu.com/t/questing-quokka-release-notes/59220) | [October 9, 2025](https://lists.ubuntu.com/archives/ubuntu-announce/2025-October/000317.html) | July 2026 | July 2026 |
 | Ubuntu 24.04.4 LTS | Noble Numbat | [Release Notes](https://discourse.ubuntu.com/t/noble-numbat-point-release-changes/47565/5) | [February 12, 2026](https://lists.ubuntu.com/archives/ubuntu-announce/2026-February/000321.html) | June 2029 | April 2039 |
 | Ubuntu 24.04.3 LTS | Noble Numbat | [Release Notes](https://discourse.ubuntu.com/t/noble-numbat-point-release-changes/47565/4) | [August 7, 2025](https://lists.ubuntu.com/archives/ubuntu-announce/2025-August/000315.html) | June 2029 | April 2039 |


### PR DESCRIPTION
Trivial change adding Resolute Raccoon to the list of releases.  
This is done here for now as part of the archive opening, but a broader discussion should probably be started on what we want to do with that page now that we have https://documentation.ubuntu.com/release-notes/

Edit: also add myself to CODEOWNERS along the way.
Edit2: wow, Github instantly pinged an insane amount of people due to this. Sorry for the noise y'all :/