### PR TITLE
Fix broken external ref

### DIFF
--- a/docs/how-ubuntu-is-made/processes/git-ubuntu/index.md
+++ b/docs/how-ubuntu-is-made/processes/git-ubuntu/index.md
@@ -135,7 +135,7 @@ it.
 See {ref}`keyring-with-plaintext-storage` for instructions on configuring keyring to use
 plaintext password storage instead, to avoid getting keyring password prompts.
 
-git-ubuntu uses {external:std:ref}`launchpadlib <get-started-with-launchpadlib>` for Launchpad API access. This
+git-ubuntu uses {external:std:ref}`launchpadlib <launchpadlib-tutorial>` for Launchpad API access. This
 library in turn uses the [Python keyring package](https://pypi.org/project/keyring/) for credential storage. If you see a password prompt, it is because the keyring package's defaults in your particular environment require encrypted password-based credential storage. Configure this to your needs by following the [keyring documentation](https://pypi.org/project/keyring/).
 
 


### PR DESCRIPTION
### Description

Intersphinx external ref for launchpadlib is failing because the ref was changed in the target docs. Updating.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

