### PR TITLE
DMB: connect articles with a series header

### DIFF
--- a/docs/who-makes-ubuntu/_dmb-series.md
+++ b/docs/who-makes-ubuntu/_dmb-series.md
@@ -1,0 +1,15 @@
+```{admonition} **Developer Membership Board (DMB)** series
+:class: admonition-highlight-this-page
+
+The article series covers the different Ubuntu developer memberships, their implied upload permissions, and the Developer Membership Board that governs them.
+
+Developer roles:
+- {ref}`ubuntu-developers` - The path to become an Ubuntu developer/uploader
+  - Variations of {ref}`PPU <dmb-joining-ppu>`, {ref}`PkgSet <dmb-joining-packageset>`, {ref}`MOTU <dmb-joining-motu>`, {ref}`SRU <dmb-joining-sru-dev>` and {ref}`Ubuntu Core <dmb-joining-core-dev>` upload rights
+  - Details about {ref}`Prospective <dmb-joining-prospective>`, {ref}`Contributing <dmb-joining-contributing>`, {ref}`Delegated <dmb-joining-delegated>` developers
+- {ref}`Application process <dmb-application>` - With {ref}`knowledge requirements <dmb-application-knowledge-requirements>` and {ref}`tips for a good application <dmb-aspects-of-a-good-application>`
+
+DMB operations:
+- {ref}`dmb-meetings` - Meeting schedule and procedures
+- {ref}`dmb-rules` - Board rules, {ref}`voting logic <dmb-vote-function>` and {ref}`Board member selection and onboarding <dmb-restaffing>`
+- {ref}`dmb-manage-packagesets` - Packageset management and {ref}`seed based packagesets <dmb-seed-packagesets-exceptions>`

--- a/docs/who-makes-ubuntu/councils/dmb-manage-packagesets.md
+++ b/docs/who-makes-ubuntu/councils/dmb-manage-packagesets.md
@@ -1,6 +1,11 @@
 (dmb-manage-packagesets)=
 # DMB Manage packagesets
 
+```{include} ../_dmb-series.md
+```
+
+
+
 ```{note}
 This page is about how to create and modify a packageset.
 

--- a/docs/who-makes-ubuntu/councils/dmb-meetings.md
+++ b/docs/who-makes-ubuntu/councils/dmb-meetings.md
@@ -1,6 +1,11 @@
 (dmb-meetings)=
 # DMB meetings
 
+```{include} ../_dmb-series.md
+```
+
+
+
 The {ref}`dmb` conducts meetings every two weeks.
 
 

--- a/docs/who-makes-ubuntu/councils/dmb-restaffing.md
+++ b/docs/who-makes-ubuntu/councils/dmb-restaffing.md
@@ -1,6 +1,11 @@
 (dmb-restaffing)=
 # DMB restaffing
 
+```{include} ../_dmb-series.md
+```
+
+
+
 See {ref}`Governance docs: DMB selection process <dmb-selection-process>` for details on how new {ref}`dmb` members are appointed.
 
 

--- a/docs/who-makes-ubuntu/councils/dmb-rules.md
+++ b/docs/who-makes-ubuntu/councils/dmb-rules.md
@@ -1,6 +1,11 @@
 (dmb-rules)=
 # DMB rules
 
+```{include} ../_dmb-series.md
+```
+
+
+
 This section contains rules and regulations for the {ref}`dmb` to use when conducting its business.
 Changes to these rules should be proposed by a board member and voted on by the board.
 

--- a/docs/who-makes-ubuntu/councils/dmb-seed-packageset-exceptions.md
+++ b/docs/who-makes-ubuntu/councils/dmb-seed-packageset-exceptions.md
@@ -1,6 +1,11 @@
 (dmb-seed-packagesets-exceptions)=
 # DMB seed packagesets exceptions
 
+```{include} ../_dmb-series.md
+```
+
+
+
 As outlined for {ref}`seeds based packagesets <dmb-types-of-packagesets>`
 there can be cases that cause such a package set to not be absolutely
 equivalent to the seed.

--- a/docs/who-makes-ubuntu/councils/dmb-vote-code.md
+++ b/docs/who-makes-ubuntu/councils/dmb-vote-code.md
@@ -5,6 +5,11 @@ orphan: true
 (dmb-vote-function)=
 # DMB vote funtion
 
+```{include} ../_dmb-series.md
+```
+
+
+
 The text on {ref}`dmb-rules` should be easier to consume, but if in doubt
 here a different way to express it.
 

--- a/docs/who-makes-ubuntu/developers/dmb-application-knowledge-requirements.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application-knowledge-requirements.md
@@ -1,6 +1,11 @@
 (dmb-application-knowledge-requirements)=
 # DMB application knowledge requirements
 
+```{include} ../_dmb-series.md
+```
+
+
+
 There are several {ref}`dmb-aspects-of-a-good-application`, but questions are often asked around what knowledge and evidence an applicant should provide.
 
 In the table below we show the topics, descriptions of what the topic includes, and the depth to which the topic should be understood for each role.

--- a/docs/who-makes-ubuntu/developers/dmb-application.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application.md
@@ -1,6 +1,11 @@
 (dmb-application)=
 # Developer Membership application process
 
+```{include} ../_dmb-series.md
+```
+
+
+
 ```{toctree}
 :titlesonly:
 :hidden:

--- a/docs/who-makes-ubuntu/developers/dmb-aspects-of-a-good-application.md
+++ b/docs/who-makes-ubuntu/developers/dmb-aspects-of-a-good-application.md
@@ -1,6 +1,11 @@
 (dmb-aspects-of-a-good-application)=
 # Aspects of a good DMB application
 
+```{include} ../_dmb-series.md
+```
+
+
+
 Since every applicant is unique, what makes a "good" DMB application can be flexible. No two applications are ever exactly the same, and everyone has a different position to some extent.
 
 If you need different considerations for some reason, make sure to explain this in your application and we are happy to consider it.

--- a/docs/who-makes-ubuntu/developers/dmb-index.md
+++ b/docs/who-makes-ubuntu/developers/dmb-index.md
@@ -1,6 +1,11 @@
 (ubuntu-developers)=
 # Ubuntu Developers
 
+```{include} ../_dmb-series.md
+```
+
+
+
 ```{toctree}
 :titlesonly:
 :hidden:

--- a/docs/who-makes-ubuntu/developers/dmb-joining-MOTU.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-MOTU.md
@@ -1,6 +1,11 @@
 (dmb-joining-motu)=
 # MOTU
 
+```{include} ../_dmb-series.md
+```
+
+
+
 MOTU, or "Masters of the Universe", maintain the collection of packages in the `universe` and `multiverse` components (i.e. packages not in `main`).
 They are [members of the MOTU team](https://launchpad.net/~motu) in Launchpad.
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-contributing.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-contributing.md
@@ -1,6 +1,10 @@
 (dmb-joining-contributing)=
 # Ubuntu Contributing Developers
 
+```{include} ../_dmb-series.md
+```
+
+
 
 Ubuntu Contributing Developers are implicitly considered Ubuntu Members.
 They are members of the [`ubuntu-developer-members`](https://launchpad.net/~ubuntu-developer-members) team in Launchpad.

--- a/docs/who-makes-ubuntu/developers/dmb-joining-core-dev.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-core-dev.md
@@ -1,6 +1,11 @@
 (dmb-joining-core-dev)=
 # Core Developers
 
+```{include} ../_dmb-series.md
+```
+
+
+
 Core Developers (Core Devs) are members of the [`ubuntu-core-dev`](https://launchpad.net/~ubuntu-core-dev) team in Launchpad.
 Core Devs collectively maintain all packages in Ubuntu, which notably includes uploading to the `main` component.
 Core Devs also have elevated privileges for re-triggering autopkgtests and performing other administrative actions in Ubuntu.

--- a/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-delegated.md
@@ -1,6 +1,11 @@
 (dmb-joining-delegated)=
 # Delegated Developers
 
+```{include} ../_dmb-series.md
+```
+
+
+
 Delegated Developers are members of a [delegated development group](https://wiki.ubuntu.com/UbuntuDevelopers/TeamDelegation) in Launchpad.
 They are collectively responsible for the maintenance of a subset of packages in Ubuntu.
 This role is similar to the {ref}`dmb-joining-ppu` and {ref}`dmb-joining-packageset` roles, except that the packageset is governed by a delegated team.

--- a/docs/who-makes-ubuntu/developers/dmb-joining-packageset.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-packageset.md
@@ -1,6 +1,11 @@
 (dmb-joining-packageset)=
 # Packageset uploaders
 
+```{include} ../_dmb-series.md
+```
+
+
+
 Upload rights can be given for certain **[packagesets](https://ubuntu-archive-team.ubuntu.com/packagesets/)**, such as '[ubuntu-server](https://ubuntu-archive-team.ubuntu.com/packagesets/questing/ubuntu-server)' or '[ubuntu-desktop](https://ubuntu-archive-team.ubuntu.com/packagesets/questing/ubuntu-desktop)'.
 The original design intent was for the packageset level to be applied to individuals who will only be working on a very small set of packages.
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-ppu.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-ppu.md
@@ -1,6 +1,11 @@
 (dmb-joining-ppu)=
 # Per-Package Uploaders
 
+```{include} ../_dmb-series.md
+```
+
+
+
 Per-Package Uploaders are developers with a specialization in a specific package (or packages) in Ubuntu.
 They are granted direct upload to the Ubuntu Archive for those packages.
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-prospective.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-prospective.md
@@ -1,6 +1,11 @@
 (dmb-joining-prospective)=
 # Ubuntu Prospective Developers
 
+```{include} ../_dmb-series.md
+```
+
+
+
 This is where you should start if you are interested in joining the development team.
 Prospective Developers:
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-sru-dev.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-sru-dev.md
@@ -1,6 +1,11 @@
 (dmb-joining-sru-dev)=
 # SRU Developers
 
+```{include} ../_dmb-series.md
+```
+
+
+
 SRU Developers are developers with a specialisation in working on [Stable Release Updates](https://documentation.ubuntu.com/sru/en/latest/) in Ubuntu.
 They are granted direct upload to the Ubuntu Archive for all packages -- but only to the stable releases.
 


### PR DESCRIPTION
Compared to before in the MIR pages I had to come up with solutions to not leave the header too shallow and covering too much, nor getting so huge it would be a fill page. The solution was linking to other sub-pages in the explanation text.
