### PR TITLE
Add desc. of ACL & LP -> GH team sync

### DIFF
--- a/docs/contributors/contribute-docs.md
+++ b/docs/contributors/contribute-docs.md
@@ -466,6 +466,18 @@ Test your changes before submitting a pull request. Run the following commands f
 | `make pa11y` | Check for accessibility issues |
 
 
+## Access control
+
+Pull requests require review from the team responsible for the relevant section of the documentation, enforced by `.github/CODEOWNERS`. The technical authors are default reviewers for all content; for sections owned by a specific team, the tech. authors are replaced as required reviewers by that team. Some sections are identified by directory (e.g. `SRU/`, `MIR/`), others by file-name prefix (e.g. `aa-*.md`, `dmb-*.md`). Changes to `CODEOWNERS` itself require sign-off from representatives of all teams.
+
+
+### Launchpad team synchronization
+
+Because Launchpad and GitHub maintain separate accounts, the mapping between LP and GitHub usernames in `CODEOWNERS` must be kept manually. A nightly GitHub Actions workflow (`.github/workflows/lp-teams-check.yaml`) queries the Launchpad API for each team tracked in `.github/lpteams/` —- one `<lp-team-name>.team` file per team, containing one LP username per line —- and opens an automated PR if the membership has changed. Merging that PR only updates the `.team` file; a follow-up PR must update the relevant `CODEOWNERS` entries manually.
+
+To start tracking a new team, add a `<lp-team-name>.team` file to `.github/lpteams/` with the current LP usernames and update `CODEOWNERS` accordingly.
+
+
 ## Open Documentation Academy
 
 If you've never contributed to an open source project before, the [Open Documentation Academy](https://documentation.academy) (ODA) is a great way to begin.


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

Adds desc.'s to the Contribution guide:

- `CODEOWNERS`-based ACL
- LP -> GH team sync logic

---

### Related issue

- Fixes: #33 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected
