### PR TITLE
Add github paths to allowed list for triage bot

### DIFF
--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -29,7 +29,7 @@ jobs:
             const urlsWithProtocol = issueBody.match(urlRegex) || [];
             
             // Also extract URLs without protocol (common domains)
-            const domainRegex = /(?:^|\s)((?:documentation\.)?ubuntu\.com\/server[^\s]*)/gi;
+            const domainRegex = /(?:^|\s)((?:documentation\.)?ubuntu\.com\/project[^\s]*)/gi;
             const urlsWithoutProtocol = issueBody.match(domainRegex) || [];
             
             // Also extract from the "Page URL" template field
@@ -67,7 +67,7 @@ jobs:
             // Valid domain patterns for the docs
             const validDomains = [
               'ubuntu.com',  // Catches all ubuntu.com subdomains (documentation.ubuntu.com, archive.ubuntu.com, etc.)
-              'launchpad.net'
+              'launchpad.net',
             ];
             
             // Check if URLs are valid
@@ -81,9 +81,9 @@ jobs:
             console.log('Valid URLs: ' + validUrls.length);
             console.log('Invalid URLs: ' + invalidUrls.length);
             
-            // Check for "local build" exception: if no URL but contains ubuntu-server-documentation path from local error
-            const hasLocalBuildPath = issueBody.includes('ubuntu-server-documentation');
-            console.log('Contains ubuntu-server-documentation path: ' + hasLocalBuildPath);
+            // Check for "local build" exception: if no URL but contains ubuntu-project-docs path from local error
+            const hasLocalBuildPath = issueBody.includes('ubuntu-project-docs');
+            console.log('Contains ubuntu-project-docs path: ' + hasLocalBuildPath);
             
             // Check for "missing documentation" exception where the reporter is requesting docs on a topic (no docs yet = no valid URL
             const missingDocPatterns = [


### PR DESCRIPTION
### Description

Sorry @rkratky, it looks like when I imported the Server issue triage bot I forgot to change the allowed urls from `server` to `project`, hence why it's working properly in the server docs but not here.

From now on, it should correctly allow issues as valid if there is some sort of path included (even if it's a github URL or a partial path). I'll keep an eye and continue to fix as necessary.

Related: #600 

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

