### PR TITLE
Reword the rules about symbol files

### DIFF
--- a/docs/MIR/mir-reviewers-template.md
+++ b/docs/MIR/mir-reviewers-template.md
@@ -326,9 +326,10 @@ TODO-B: Problems: None
 
 [Packaging red flags]
 RULE: - Does Ubuntu carry a non necessary delta?
-RULE: - If it's a library, does it either have a symbols file or use an empty
-RULE:   argument to dh_makeshlibs -V? (pass such a patch on to Debian, but
-RULE:   don't block on it).
+RULE: - If it's a library, does it have a symbols file? In the absence
+RULE:   of a symbols file, dh_makeshlibs imposes a tighter constraint
+RULE:   by default, using 'Upstream-Version'; dh_makeshlibs -V with an
+RULE:   empty argument has the same effect.
 RULE:   Note that for C++, see https://wiki.ubuntu.com/DailyRelease/FAQ
 RULE:   for a method to demangle C++ symbols files.
 RULE: - There are shared object only meant for internal use, examples


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

The rules in the context of the absence of a symbol files need to be reworded because for debhelper_compat >= 12, dh_makeshlibs and dh_makeshlibs -V (with an empty argument) impose the same constraint using 'Upstream-Version'.

---

### Related issue

- Fixes: #491

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected


