### PR TITLE
SRU: target release exception policy for HWE

### DIFF
--- a/docs/SRU/explanation/further-requirements.rst
+++ b/docs/SRU/explanation/further-requirements.rst
@@ -118,56 +118,25 @@ Policy
 
 Any request to use this exception must meet all of the following conditions:
 
-#. While it may skip active interim releases, the enablement must target at
-   least the latest active LTS release that can support it. It is not
-   appropriate to enable hardware only in an older supported LTS while
-   omitting the current LTS.
-#. Users must be protected from upgrading into a release where the
-   selectively enabled functionality is unavailable or unsupported. In
-   practice, the supported upgrade path via ``do-release-upgrade``
-   must detect affected systems and block the upgrade until a supported
-   path exists.
-#. The team requesting the exception must maintain that upgrade
-   protection for as long as it is needed, and remove or update it when
-   the subsequent releases gained that support.
+#. While it may skip active interim releases, the enablement must target at least the latest active LTS release that can support it. It is not appropriate to enable hardware only in an older supported LTS while omitting the current LTS.
+#. Users must be protected from upgrading into a release where the selectively enabled functionality is unavailable or unsupported. In practice, the supported upgrade path via ``do-release-upgrade`` must detect affected systems and block the upgrade until a supported path exists.
+#. The team requesting the exception must maintain that upgrade protection for as long as it is needed, and remove or update it when the subsequent releases gained that support.
 
 Steps
 """""
 
 Here is the process to follow when requesting an SRU using this exception:
 
-#. Prepare the SRU in the usual way, including the normal bug
-   documentation, package builds and testing.
-#. Prepare the upgrade path protection as a PR to the `ubuntu-release-upgrader
-   project <https://git.launchpad.net/ubuntu-release-upgrader>`__. It needs to
-   be reviewable as part of the following steps.
-#. Add an ubuntu-release-upgrader package task to the SRU bug. Once the PR to
-   the upstream project is accepted and merged, the Ubuntu package will also
-   need to be updated.
-#. Add an ubuntu-release-upgrader package task to the SRU bug. This change needs
-   to be prepared, tested and ready to be released alongside the actual
-   hardware enablement that you are driving.
-#. Submit a pull request against this documentation adding a standing exception
-   under :ref:`Package-specific notes <reference-package-specific-notes>`. This
-   is normally required once per class of enablement and rationale, rather than
-   once per upload.
-   #. If you can't target the latest active LTS release, because using the
-      feature there is generally not possible, please ensure that it is
-      explained in this exception why that is the case. It might be acceptable
-      if the whole infrastructure for that feature was dropped (we want to
-      tolerate that), but not if it is only a lack of enablement (which we want
-      to foster) in that release.
-#. Request reviews from the SRU team (will be added automatically by creating a
-   PR that changes SRU pages). At the same time notify the Ubuntu Technical Board
-   via their mailing list at https://lists.ubuntu.com/archives/technical-board/.
-#. Once discussed and approved by the Technical Board, the PR should provide a
-   link to this approval.
-#. With the approval properly documented, the SRU team will merge the PR into
-   this documentation, and the exception will be formally approved and
-   documented here.
-#. From now on, this formally approved exception can be used for SRUs that refer
-   to it in the description - allowing the SRU team to process it under the
-   documented terms.
+#. Prepare the SRU in the usual way, including the normal bug documentation, package builds and testing.
+#. Prepare the upgrade path protection as a PR to the `ubuntu-release-upgrader project <https://git.launchpad.net/ubuntu-release-upgrader>`__. It needs to be reviewable as part of the following steps.
+#. Add an ubuntu-release-upgrader package task to the SRU bug. Once the PR to the upstream project is accepted and merged, the Ubuntu package will also need to be updated.
+#. Add an ubuntu-release-upgrader package task to the SRU bug. This change needs to be prepared, tested and ready to be released alongside the actual hardware enablement that you are driving.
+#. Submit a pull request against this documentation adding a standing exception under :ref:`Package-specific notes <reference-package-specific-notes>`. This is normally required once per class of enablement and rationale, rather than once per upload.
+   #. If you can't target the latest active LTS release, because using the feature there is generally not possible, please ensure that it is explained in this exception why that is the case. It might be acceptable if the whole infrastructure for that feature was dropped (we want to tolerate that), but not if it is only a lack of enablement (which we want to foster) in that release.
+#. Request reviews from the SRU team (will be added automatically by creating a PR that changes SRU pages). At the same time notify the Ubuntu Technical Board via their mailing list at https://lists.ubuntu.com/archives/technical-board/.
+#. Once discussed and approved by the Technical Board, the PR should provide a link to this approval.
+#. With the approval properly documented, the SRU team will merge the PR into this documentation, and the exception will be formally approved and documented here.
+#. From now on, this formally approved exception can be used for SRUs that refer to it in the description - allowing the SRU team to process it under the documented terms.
 
 .. _explanation-documentation:
 

--- a/docs/SRU/explanation/further-requirements.rst
+++ b/docs/SRU/explanation/further-requirements.rst
@@ -119,8 +119,9 @@ Policy
 Any request to use this exception must meet all of the following conditions:
 
 #. While it may skip active interim releases, the enablement must target at
-   least the latest active LTS release. It is not appropriate to enable hardware
-   only in an older supported LTS while omitting the current LTS.
+   least the latest active LTS release that can support it. It is not
+   appropriate to enable hardware only in an older supported LTS while
+   omitting the current LTS.
 #. Users must be protected from upgrading into a release where the
    selectively enabled functionality is unavailable or unsupported. In
    practice, the supported upgrade path via ``do-release-upgrade``
@@ -150,6 +151,12 @@ Here is the process to follow when requesting an SRU using this exception:
    under :ref:`Package-specific notes <reference-package-specific-notes>`. This
    is normally required once per class of enablement and rationale, rather than
    once per upload.
+   #. If you can't target the latest active LTS release, because using the
+      feature there is generally not possible, please ensure that it is
+      explained in this exception why that is the case. It might be acceptable
+      if the whole infrastructure for that feature was dropped (we want to
+      tolerate that), but not if it is only a lack of enablement (which we want
+      to foster) in that release.
 #. Request reviews from the SRU team (will be added automatically by creating a
    PR that changes SRU pages). At the same time notify the Ubuntu Technical Board
    via their mailing list at https://lists.ubuntu.com/archives/technical-board/.

--- a/docs/SRU/explanation/further-requirements.rst
+++ b/docs/SRU/explanation/further-requirements.rst
@@ -1,8 +1,8 @@
 Reasons for requirements
 ------------------------
 
-Preconditions
-~~~~~~~~~~~~~
+Targeted releases
+~~~~~~~~~~~~~~~~~
 
 .. _explanation-devel-first:
 
@@ -83,6 +83,84 @@ hardware enablement or new features.
 
 See also: :ref:`Reference → Requirements → General requirements for all
 SRUs <reference-general-requirements>`
+
+
+Exception to targeted release requirements for hardware enablement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Scope
+"""""
+
+This exception applies only to hardware enablement, or to bug fixes for
+hardware that is itself enabled only in a particular supported Ubuntu
+release.
+
+Reasoning
+"""""""""
+
+The general rule remains that fixes and features should be present in
+the development release and all newer supported releases before they are
+backported to an older stable release. However, hardware support does
+change over time as Ubuntu moves to newer kernels, drivers and user
+space components. In some cases, insisting on enablement in every later
+release would prevent useful support from reaching users of a supported
+LTS, while still not eliminating all differences in hardware support
+between releases.
+
+For that reason, we may exceptionally permit selective hardware
+enablement in a stable release without first enabling the same
+functionality in the development release and every newer supported
+release. Because this creates an upgrade risk, such cases require
+explicit safeguards and are not routine.
+
+Policy
+""""""
+
+Any request to use this exception must meet all of the following conditions:
+
+#. While it may skip active interim releases, the enablement must target at
+   least the latest active LTS release. It is not appropriate to enable hardware
+   only in an older supported LTS while omitting the current LTS.
+#. Users must be protected from upgrading into a release where the
+   selectively enabled functionality is unavailable or unsupported. In
+   practice, the supported upgrade path via ``do-release-upgrade``
+   must detect affected systems and block the upgrade until a supported
+   path exists.
+#. The team requesting the exception must maintain that upgrade
+   protection for as long as it is needed, and remove or update it when
+   the subsequent releases gained that support.
+
+Steps
+"""""
+
+Here is the process to follow when requesting an SRU using this exception:
+
+#. Prepare the SRU in the usual way, including the normal bug
+   documentation, package builds and testing.
+#. Prepare the upgrade path protection as a PR to the `ubuntu-release-upgrader
+   project <https://git.launchpad.net/ubuntu-release-upgrader>`__. It needs to
+   be reviewable as part of the following steps.
+#. Add an ubuntu-release-upgrader package task to the SRU bug. Once the PR to
+   the upstream project is accepted and merged, the Ubuntu package will also
+   need to be updated.
+#. Add an ubuntu-release-upgrader package task to the SRU bug. This change needs
+   to be prepared, tested and ready to be released alongside the actual
+   hardware enablement that you are driving.
+#. Submit a pull request against this documentation adding a standing exception
+   under :ref:`Package-specific notes <reference-package-specific-notes>`. This
+   is normally required once per class of enablement and rationale, rather than
+   once per upload.
+#. Request reviews from the SRU team (will be added automatically by creating a
+   PR that changes SRU pages). At the same time notify the Ubuntu Technical Board
+   via their mailing list at https://lists.ubuntu.com/archives/technical-board/.
+#. Once discussed and approved by the Technical Board, the PR should provide a
+   link to this approval.
+#. With the approval properly documented, the SRU team will merge the PR into
+   this documentation, and the exception will be formally approved and
+   documented here.
+#. From now on, this formally approved exception can be used for SRUs that refer
+   to it in the description - allowing the SRU team to process it under the
+   documented terms.
 
 .. _explanation-documentation:
 

--- a/docs/SRU/howto/introduction-to-sru.rst
+++ b/docs/SRU/howto/introduction-to-sru.rst
@@ -33,7 +33,7 @@ Overview
 
 A typical SRU is performed like this:
 
-1. Ensure the bug is fixed in the :term:`current development release <Current Release in Development>` and all subsequent supported releases to ensure consistency across different Ubuntu versions, especially :ref:`preventing regressions when users upgrade to newer releases<explanation-devel-first>`.
+1. Ensure the bug is fixed in the :term:`current development release <Current Release in Development>` and all subsequent supported releases to ensure consistency across different Ubuntu versions, especially :ref:`preventing regressions when users upgrade to newer releases<explanation-devel-first>`. Please read the :ref:`details about reasoning, special cases and potential exceptions <explanation-devel-first>` to this requirement.
 #. Update the **existing** bug report detailing the Impact of the Bug, the Test Plan to verify that the bug was fixed and highlight where problems could occur.
 #. Get the package with the SRU patch into the upload queue.
 #. The SRU team then reviews from the unapproved queue. When the upload is ready, the SRU team accepts the upload into the proposed pocket.

--- a/docs/SRU/howto/introduction-to-sru.rst
+++ b/docs/SRU/howto/introduction-to-sru.rst
@@ -33,7 +33,7 @@ Overview
 
 A typical SRU is performed like this:
 
-1. Ensure the bug is fixed in the :term:`current development release <Current Release in Development>` and all subsequent supported releases to ensure consistency across different Ubuntu versions, especially preventing regressions when users upgrade to newer releases.
+1. Ensure the bug is fixed in the :term:`current development release <Current Release in Development>` and all subsequent supported releases to ensure consistency across different Ubuntu versions, especially :ref:`preventing regressions when users upgrade to newer releases<explanation-devel-first>`.
 #. Update the **existing** bug report detailing the Impact of the Bug, the Test Plan to verify that the bug was fixed and highlight where problems could occur.
 #. Get the package with the SRU patch into the upload queue.
 #. The SRU team then reviews from the unapproved queue. When the upload is ready, the SRU team accepts the upload into the proposed pocket.

--- a/docs/SRU/reference/requirements.rst
+++ b/docs/SRU/reference/requirements.rst
@@ -62,9 +62,7 @@ Term Support releases:
    of newly introduced drivers must not overlap with previously shipped
    drivers. This also includes updating hardware description data such
    as udev keymaps, media-player-info, mobile broadband vendors, or
-   PCI vendor/product list updates. To avoid regressions on upgrade, any
-   such hardware enablement must first also be added to any newer
-   supported Ubuntu release.
+   PCI vendor/product list updates.
 
 .. _reference-criteria-features:
 
@@ -74,9 +72,7 @@ Term Support releases:
    existing software needs to be modified to make use of the new
    feature, it must be demonstrated that these changes are non-intrusive,
    have a minimal regression potential, and have been tested properly.
-   To avoid regressions on upgrade, any such feature must then also be
-   added to any newer supported Ubuntu release. Once a new
-   feature/package has been introduced, subsequent changes to it are
+   Once a new feature/package has been introduced, subsequent changes to it are
    subject to the usual requirements of SRUs to avoid regressions.
 -  **FTBFS** (Fails To Build From Source) can also be considered. Please
    note that in **main** the release process ensures that there are no
@@ -143,10 +139,14 @@ Out of scope
 General requirements for all SRUs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  The development release must already be fixed and its bug task marked
-   "Fix Released", unless the development release is not yet open, in
-   which case the development release upload must be prepared, ready and
-   documented [:ref:`explanation <explanation-devel-first>`].
+-  To avoid regressions on upgrade, the development release and any newer
+   supported Ubuntu release than the one targted must already be fixed and its
+   bug task marked "Fix Released".
+   Exceptions may apply, but still need to prevent regressions
+   on upgrade.
+   Please read the :ref:`details about reasoning, special cases
+   and potential exceptions <explanation-devel-first>` to this requirement.
+
 -  Changes must be minimal [:ref:`explanation <explanation-minimal>`],
    unless at least one of the following cases apply:
 


### PR DESCRIPTION
### Description

SRU: add target release exception policy for HWE
    
The questions are left open in the mailing list archive of the
TB [1] and I was participating in a related TB call recently. While
I took notes I've seen no policy change based on that call yet.
    
This came up again and demands attention to unblock related cases.
Therefore I hereby turn my notes of the TB meeting to document
the compromise made there into a policy.
   
That will allow to land hardware enablement in selective releases for
the benefit of our users, but at the same time keep the bar high to
not get abused.
    
[1]: https://lists.ubuntu.com/archives/technical-board/2026-May/003131.html