### PR TITLE
Update the Apport settings section

### DIFF
--- a/docs/contributors/debugging/apport.md
+++ b/docs/contributors/debugging/apport.md
@@ -65,7 +65,7 @@ Apport does not trap SIGABRT signals. If you are getting such a signal, then ple
 (how-to-enable-apport)=
 ## How to enable Apport
 
-On Ubuntu Desktop, you can manage error reporting from the Control Center. Open {guilabel}`Settings`, go to {guilabel}`Privacy & Security` > {guilabel}`Diagnostics`, and use {guilabel}`Send error reports to Canonical` to choose how error reports are handled.
+On Ubuntu Desktop, you can manage error reporting from the Control Center. Open {guilabel}`Settings`, go to {guilabel}`Privacy & Security` > {guilabel}`Telemetry`, and use {guilabel}`Send error reports to Canonical` to choose how error reports are handled.
 
 The default setting is {guilabel}`Manual`, which means Ubuntu asks before sending an error report. You can also choose to send reports automatically or disable error reporting from the same settings page.
 


### PR DESCRIPTION
In Ubuntu 26.04 LTS, this page in Settings is now called Telemetry rather than Diagnostics.

By the way, this guide mentions the `upstart` service manager, which hasn't been used by Ubuntu since 15.04 I believe. It's possible that you can just make a replacement from `upstart` to `systemd` but I'm not familiar with them enough to know if their workflow with Apport is exactly 1:1. Best check with somebody more knowledgeable.
