### PR TITLE
replace wiki link which is only a re-direct with final link (URL change only)

### DIFF
--- a/docs/contributors/bug-triage/bug-responses.md
+++ b/docs/contributors/bug-triage/bug-responses.md
@@ -696,7 +696,7 @@ Ubuntu 7.10 (gutsy) reached end-of-life on April 18th, 2009
 Ubuntu 7.04 (feisty) reached end-of-life on October 19, 2008
 Ubuntu 6.10 (edgy) reached end-of-life on April 26, 2008
 
-See this document for currently supported Ubuntu releases: https://wiki.ubuntu.com/Releases
+See this document for currently supported Ubuntu releases: https://documentation.ubuntu.com/project/release-team/list-of-releases/
 
 We appreciate that this bug may be old and you might not be interested in discussing it anymore. But if you are then please upgrade to the latest Ubuntu version and re-test. If you then find the bug is still present in the newer Ubuntu version, please add a comment here telling us which new version it is in.
 ```


### PR DESCRIPTION
the current WIKI link just re-directs to https://documentation.ubuntu.com/project/release-team/list-of-releases/  so we might as well use that link (avoiding traffic/delay)...

<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

Just using one of these (EOL) as a bug response, and on checks noticed the wiki link is set to re-direct; so this will update/change it saving server & traffic

---

### Checklist

- [ Y ] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [ ] I have tested my changes, and they work as expected

( Any issues (it'll just by a typo), I can be found on IRC or Matrix AEST times usually; Ubuntu News channels usually easiest )
