### PR TITLE
Do not recommend sbuild-launchpad-chroot for installation

### DIFF
--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -22,7 +22,6 @@ $ sudo apt update && \
     dh-make \
     git-buildpackage \
     pastebinit \
-    sbuild-launchpad-chroot \
     ubuntu-dev-tools && \
   sudo snap install lxd && \
   sudo snap install --classic snapcraft && \


### PR DESCRIPTION
The tool is no longer maintained, and there are better alternatives described since PR #619.

cc @BAMF0