### PR TITLE
Fix dmb misunderstandings

### DIFF
--- a/docs/who-makes-ubuntu/developers/dmb-application-knowledge-requirements.md
+++ b/docs/who-makes-ubuntu/developers/dmb-application-knowledge-requirements.md
@@ -9,7 +9,7 @@
 There are several {ref}`dmb-aspects-of-a-good-application`, but questions are often asked around what knowledge and evidence an applicant should provide.
 
 In the table below we show the topics, descriptions of what the topic includes, and the depth to which the topic should be understood for each role.
-We do not expect rote memorization of answers. 
+We do not expect rote memorization of answers.
 The objective is to determine your understanding of the underlying reasons for those answers.
 This often requires a thorough understanding of the policies, technologies, and processes pertinent to a given topic.
 
@@ -22,7 +22,7 @@ Consider the following not as "questions you must be able to answer," but rather
 
 | Topic | Description => Expected level\*¹ | |  |  |  |  |
 | :---- | :---- | :---- | :---- | :---- | :---- | :---- |
-|  |  | PPU*² | pkg-set | SRU-dev | MOTU | core-dev |
+|  |  | {ref}`PPU*² <dmb-joining-ppu>` | {ref}`pkg-set <dmb-joining-packageset>` | {ref}`SRU-dev <dmb-joining-sru-dev>` | {ref}`MOTU <dmb-joining-motu>` | {ref}`core-dev <dmb-joining-core-dev>` |
 | **Upstream/Downstream** |  |  |  |  |  |  |
 | The Derived Distribution Model | Understanding the derivative model (upstream \-\> Debian \-\> Ubuntu); how deltas are added and managed; basic package versioning in regard to that context; Ubuntu as a derivative. | I | I | B | A | A |
 | To fork or not to fork | When adding a delta is appropriate, the maintenance burden of doing so, and how we track and manage that burden. | I | A | B | A | A |

--- a/docs/who-makes-ubuntu/developers/dmb-joining-packageset.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-packageset.md
@@ -88,6 +88,17 @@ The less experience you have in Debian or other open source communities, the mor
 
 Finally, you'll know you're past ready for applying if anyone ever asks, "How do you not already have upload rights??"
 
+## Scope and definition
+
+It is easy to mix up this and {ref}`dmb-joining-ppu`, here a clarification:
+
+* Packagesets are defined by their description.
+* Applicants prove to be able to handle what the description defines.
+* Adding packages can be done on non-formal request as long as they fit the description.
+* Usually a team managed by the DMB is the uploader of a packageset.
+* On successful packageset application people become member of that team.
+* Existing packagesets, their definition and teams can be [seen per release here](https://static-reports.ubuntu.com/packagesets/).
+* relation: `developer` *-is-member-of->* `team` *-is-uploader-of->* `packageset` *-covers->* `packages`
 
 ## Voting
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-packageset.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-packageset.md
@@ -90,15 +90,15 @@ Finally, you'll know you're past ready for applying if anyone ever asks, "How do
 
 ## Scope and definition
 
-It is easy to mix up this and {ref}`dmb-joining-ppu`, here a clarification:
+It is easy to mix up {ref}`dmb-joining-packageset` and {ref}`dmb-joining-ppu`, here a clarification:
 
 * Packagesets are defined by their description.
 * Applicants prove to be able to handle what the description defines.
 * Adding packages can be done on non-formal request as long as they fit the description.
 * Usually a team managed by the DMB is the uploader of a packageset.
 * On successful packageset application people become member of that team.
-* Existing packagesets, their definition and teams can be [seen per release here](https://static-reports.ubuntu.com/packagesets/).
-* relation: `developer` *-is-member-of->* `team` *-is-uploader-of->* `packageset` *-covers->* `packages`
+* Reports list existing [packagesets](https://static-reports.ubuntu.com/packagesets/) and [teams](https://static-reports.ubuntu.com/archive-permissions/teams)
+* relation: `developer` *-is-member-of->* `team` *-has-upload-rights-for->* `packageset` *-covers->* `packages`
 
 ## Voting
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-ppu.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-ppu.md
@@ -36,6 +36,15 @@ They also need to have documented previous concern for the packages in question 
 
 There is a slightly special procedure for Debian Developers wishing to have upload rights to their packages. See {ref}`application process <dmb-application>`.
 
+## Scope and definition
+
+It is easy to mix up this and {ref}`dmb-joining-packageset`, here a clarification:
+
+* Per-package-upload rights are defined per person.
+* Applicants prove to be able to handle the requested package(s).
+* Adding packages is essentially another Per Package uploader application.
+* Existing individual upload rights can be [seen here](https://static-reports.ubuntu.com/archive-permissions/individuals).
+* relation: `developer` *-is-uploader-of->* `packages`.
 
 ## Voting
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-ppu.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-ppu.md
@@ -38,7 +38,7 @@ There is a slightly special procedure for Debian Developers wishing to have uplo
 
 ## Scope and definition
 
-It is easy to mix up this and {ref}`dmb-joining-packageset`, here a clarification:
+It is easy to mix up {ref}`dmb-joining-ppu` and {ref}`dmb-joining-packageset`, here a clarification:
 
 * Per-package-upload rights are defined per person.
 * Applicants prove to be able to handle the requested package(s).


### PR DESCRIPTION
In mentoring it came up as unclear and when checking the Agenda I found many wrong statements copying from the former entry.

The agenda was fixed and this clarifies the definition and thereby the difference in how they operate in regard to packageset vs PPU.

Someone else mentioned that training their mentees was hard as there was no link back from expectations to their definition. The pages didn't exist in that form when expectations got clarified, adding that makes totally sense now.