### PR TITLE
docs: fix broken Jenkins link in Squid SRU exception page

### DIFF
--- a/docs/SRU/reference/exception-Squid-Updates.rst
+++ b/docs/SRU/reference/exception-Squid-Updates.rst
@@ -75,14 +75,6 @@ any benchmarks or coverage data for that.
 Squid Upstream CI
 -----------------
 
-BuildFarm
-^^^^^^^^^
-
-The upstream project performs builds for different OSes and platforms
-from different branches in a continuous manner. This process is
-described in http://wiki.squid-cache.org/BuildFarm and is performed in
-Squid's own Jenkins instance at http://build.squid-cache.org/.
-
 .. _github_actions:
 
 GitHub Actions


### PR DESCRIPTION
### Description

this page documented Squid's upstream BuildFarm CI as running on its own Jenkins instance at build.squid-cache.org but that link is dead. Checking Squid's own upstream wiki it still references the same dead Jenkins URL as of its last update so there iss no official replacement link to substitute in

rather than leave a broken link or invent a replacement, I removed the dead URL and rewrote the paragraph to note that this legacy Jenkins instance is no longer reachable while keeping the (still-live) wiki link for historical context. The page already has a "GitHub Actions" section directly below describing Squids actual current upstream CI so I added a forward-reference to it instead of duplicating that information


---

### Related issue
Fixes: #508

---

### Checklist

- [ ] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [ ] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

