### PR TITLE
fix: update autopkgtest tutorial

### DIFF
--- a/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
+++ b/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest.rst
@@ -34,8 +34,8 @@ For the test in ``debian/tests/build`` this would ensure that the packages
         question.
 
 
-The actual tests
-----------------
+An actual test
+--------------
 
 The accompanying test for the example above might be:
 
@@ -80,8 +80,8 @@ pkg-config files, headers and libraries are put into the right place, or that
 the compiler and linker work. This helps to uncover critical issues early on.
 
 
-Executing the test
-------------------
+Executing your tests
+--------------------
 
 While the test script can be easily executed on its own, it is strongly
 recommended to actually use ``autopkgtest`` from the ``autopkgtest`` package for
@@ -90,38 +90,50 @@ Integration (CI) system, it will not land in Ubuntu.  This also avoids clutterin
 your workstation with test packages or test configuration if the test does
 something more intrusive than the simple example above.
 
+For the purposes of this tutorial, we download ``libxml2`` from the Noble series::
+
+        sudo apt install ubuntu-dev-tools
+        pull-lp-source libxml2 noble
+
+Among other things, you should see a new ``libxml2-2.9.14+dfsg`` directory with the
+extracted source code.
+
 The `README.running-tests <running_tests_>`_ documentation explains all
 available testbeds (schroot, LXD, QEMU, etc.) and the most common scenarios how
-to run your tests with ``autopkgtest``, e. g. with locally built binaries, locally
+to run your tests with ``autopkgtest``, e.g., with locally built binaries, locally
 modified tests, etc.
 
 The Ubuntu CI system uses the QEMU runner and runs the tests from the packages
 in the archive, with ``-proposed`` enabled. To reproduce the exact same
-environment, first install the necessary packages::
+environment, first install the necessary packages and add your user to the ``kvm``
+group (so that you can run the test commands without ``sudo``)::
 
         sudo apt install autopkgtest qemu-system qemu-utils autodep8
+        sudo usermod -aG kvm $USER
+
+You may need to log in again for the group changes to take effect.
 
 Now build a testbed with::
 
-        autopkgtest-buildvm-ubuntu-cloud -v
+        autopkgtest-buildvm-ubuntu-cloud -v -r noble
 
 (Please see its manpage and ``--help`` output for selecting different releases,
-architectures, output directory, or using proxies). This will build e. g.
+architectures, output directory, or using proxies). This will build e.g.,
 ``autopkgtest-noble-amd64.img``.
 
-Then run the tests of a source package like ``libpng`` in that QEMU image::
+Then run the tests for the downloaded ``libxml2`` source package using the created QEMU image::
 
-        autopkgtest libpng -- qemu autopkgtest-noble-amd64.img
+        autopkgtest ./libxml2-2.9.14+dfsg -- qemu autopkgtest-noble-amd64.img
 
-The Ubuntu CI system runs packages with only selected packages from
+The Ubuntu CI system runs tests with only selected packages from
 ``-proposed`` available (the package which caused the test to be run); to
 enable that, run::
 
-        autopkgtest libpng -U --apt-pocket=proposed=src:foo -- qemu autopkgtest-release-amd64.img
+        autopkgtest somepkg -U --apt-pocket=proposed=src:foo -- qemu autopkgtest-release-amd64.img
 
 or to run with all packages from ``-proposed``::
 
-        autopkgtest libpng -U --apt-pocket=proposed -- qemu autopkgtest-release-amd64.img
+        autopkgtest somepkg -U --apt-pocket=proposed -- qemu autopkgtest-release-amd64.img
 
 The ``autopkgtest`` manpage has a lot more valuable information on other
 testing options.


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

I am new to `autopkgtest`, and I was trying to play with it based on [this tutorial](https://ubuntu.com/project/docs/how-ubuntu-is-made/processes/automatic-package-testing-autopkgtest/), but the examples were a bit outdated. I also added a few improvements that can benefit other newcomers.

**The main changes are as follows:**
- Switch `libpng` to `libxml2` (`libpng` was last available in Xenial, and `libpng1.6` didn't seem to have any tests).
- Use `noble` explicitly to make the expected outcome more predictable for the learner. 
- Run the tests on a downloaded source.
    - Offers more freedom to play, and make the tests fail.
    - Avoids the need to explicitly enable source packages in the VM (maybe it is a bug in the tool?).
- Add the user to the `kvm` group to avoid the need for `sudo`. 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

