### PR TITLE
fix: update ubuntu-helpers clone URL

### DIFF
--- a/docs/contributors/new-package/upload-packages-to-a-ppa.md
+++ b/docs/contributors/new-package/upload-packages-to-a-ppa.md
@@ -75,7 +75,7 @@ The Ubuntu Server Team has its own checks usable through the `ubuntu-helpers` re
 To set up the Server Team's check suite, use the following commands (`python3-termcolor` is a Python module required to run the check scripts):
 ```
 $ sudo apt install python3-termcolor
-$ git clone https://git.launchpad.net/~ubuntu-server/ubuntu-helpers 
+$ git clone https://git.launchpad.net/~ubuntu-server/+git/ubuntu-helpers
 $ ln -s ~/.dput.d ./ubuntu-helpers/cpaelzer/.dput.d/
 ```
 You can also copy instead of symlinking if you want to make your own changes to the checking scripts.


### PR DESCRIPTION
<!-- Delete any parts of this template not applicable to your Pull Request -->

### Description

This PR updates the Ubuntu Server Team check-suite instructions to use the current canonical Launchpad Git endpoint for [ubuntu-helpers](https://ubuntu.com/project/docs/contributors/new-package/upload-packages-to-a-ppa/#extra-pre-upload-checks-with-dput-ng). The repository now advertises that it has moved, so the documentation should point readers to the new location and avoid sending them to the old path.

See the following picture where it says the repo has been moved:
<img width="1001" height="444" alt="image" src="https://github.com/user-attachments/assets/61c58e28-d457-4819-ad7e-593a836ca8bc" />

---

### Related issue

None.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

I verified the docs build environment with make install after the change.

---

