### PR TITLE
Ubuntu patches DEP-3 header related adjustments

### DIFF
--- a/docs/contributors/patching/make-changes-to-a-package.rst
+++ b/docs/contributors/patching/make-changes-to-a-package.rst
@@ -160,7 +160,7 @@ Not everything here needs to be filled in. In this case, our headers might look 
      $ hello -u
      hello, user123!
     Author: Nick Rosbrook <enr0n@ubuntu.com>
-    Forwarded: no, Ubuntu only
+    Forwarded: not-needed
     Last-Update: 2025-04-23 
     ---
     This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
@@ -174,7 +174,7 @@ Our final patch should look something like:
      $ hello -u
      hello, user123!
     Author: Nick Rosbrook <enr0n@ubuntu.com>
-    Forwarded: no, Ubuntu only
+    Forwarded: not-needed
     Last-Update: 2025-04-23
     ---
     This patch header follows DEP-3: http://dep.debian.net/deps/dep3/

--- a/docs/contributors/patching/work-with-debian-patches.md
+++ b/docs/contributors/patching/work-with-debian-patches.md
@@ -103,8 +103,12 @@ Bug-[Vendor]
   them if they're readily available, but you don't need to go hunting for them.
 
 Forwarded
-: Information about where you sent the patch if it hasn't been upstreamed. Only
-  useful for vendor-specific patches.
+: Information about how the patch was sent to the upstream project in case it
+  was not originated from there.  When present, this should be a URL proving
+  that the patch was forwarded (e.g., a Pull Request or a patch in a bug
+  tracker).  If the patch is specific to Debian or to Ubuntu, i.e., whenever it
+  makes no sense to forward the patch to the upstream project, the value for
+  this field must be "not-needed".
 
 Applied-Upstream
 : If the patch has already been applied upstream, link to it. This is not

--- a/docs/maintainers/niche-package-maintenance/rustc/common/local-build.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/common/local-build.md
@@ -71,7 +71,4 @@ Otherwise, you must create your own patch. A template {term}`DEP-3 <DEP 3>` head
 $ quilt header -e --dep3 <path/to/patch>
 ```
 
-For the most part, you can follow the [Debian DEP-3 patch guidelines](https://dep-team.pages.debian.net/deps/dep3/). However, there are a few extra things you must do:
-
-- Debian developers typically don't use the `This patch header follows DEP-3 [...]` line added by `quilt`. Delete this line.
-- If this patch isn't something needed to get the new Rust version to build, and you're instead updating an existing source package, add a `Bug-Ubuntu:` line linking to the Launchpad bug.
+For the most part, you can follow the [Debian DEP-3 patch guidelines](https://dep-team.pages.debian.net/deps/dep3/). However, if this patch isn't something needed to get the new Rust version to build, and you're instead updating an existing source package, add a `Bug-Ubuntu:` line linking to the Launchpad bug.

--- a/docs/maintainers/niche-package-maintenance/rustc/common/local-build.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/common/local-build.md
@@ -71,4 +71,4 @@ Otherwise, you must create your own patch. A template {term}`DEP-3 <DEP 3>` head
 $ quilt header -e --dep3 <path/to/patch>
 ```
 
-For the most part, you can follow the [Debian DEP-3 patch guidelines](https://dep-team.pages.debian.net/deps/dep3/). However, if this patch isn't something needed to get the new Rust version to build, and you're instead updating an existing source package, add a `Bug-Ubuntu:` line linking to the Launchpad bug.
+Then, follow the [Debian DEP-3 patch guidelines](https://dep-team.pages.debian.net/deps/dep3/).

--- a/docs/maintainers/niche-package-maintenance/rustc/common/local-build.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/common/local-build.md
@@ -63,7 +63,7 @@ $ debian/rules override_dh_auto_test-arch RUSTBUILD_TEST_FLAGS="src/bootstrap/ -
 
 In order to fix certain bugs, it's likely you'll need to create your own patch at some point. It's important that this patch contains enough information for other people to understand _what_ it's doing and _why_ it's doing it.
 
-First, ensure that [Debian](https://salsa.debian.org/rust-team/rust/-/tree/debian/experimental?ref_type=heads) has not already created an equivalent patch. If so, you can simply use their patch directly. If you need to modify the patch in any way, make sure to add `Origin: backport, <Debian VCS patch URL>` to the patch header.
+First, ensure that neither the upstream project nor [Debian](https://salsa.debian.org/rust-team/rust/-/tree/debian/experimental?ref_type=heads) has already created an equivalent patch. If so, you can simply use their patch directly. In such cases, make sure to include [DEP-3](https://dep-team.pages.debian.net/deps/dep3/) headers when appropriate.
 
 Otherwise, you must create your own patch. A template {term}`DEP-3 <DEP 3>` header can be generated using the following command:
 


### PR DESCRIPTION
Improve the dep3 headers to avoid confusion on its usage. In special, see https://lists.ubuntu.com/archives/ubuntu-devel-discuss/2026-June/019806.html
