### PR TITLE
add link to FTBFS report, archive test rebuild explanation (fix #237)

### DIFF
--- a/docs/how-ubuntu-is-made/processes/proposed-migration/failure-to-build-from-source-ftbfs.md
+++ b/docs/how-ubuntu-is-made/processes/proposed-migration/failure-to-build-from-source-ftbfs.md
@@ -3,6 +3,10 @@
 
 A package has to be buildable to be able to migrate from the `-proposed` to `-release` {term}`pocket`. This article describes a number of common reasons why a package build may fail.
 
+A community-maintained, automatically generated FTBFS report is available at [UbuntuWire](http://qa.ubuntuwire.com/ftbfs). It lists the packages that are currently FTBFS in the primary Ubuntu archive for the current development release.
+
+At any time, every package must be able to build from source so that changes (such as security fixes) can be applied - this is an Ubuntu policy. To verify that all packages can still build from source, periodic "Archive Test Rebuilds" are organized: a test rebuild archive is created, and all packages are rebuilt there. Then, the `lp-ftbfs-report` tool is used to generate a report that is made accessible to the Ubuntu community. Packages that are FTBFS will need a new upload to fix the issue.
+
 :::{admonition} **Proposed migration** series
 The {ref}`proposed-migration` article series explains the various migration failures and ways of investigating them.
 


### PR DESCRIPTION
### Description

Add a link to the community-maintained FTBFS report for development release, as well as an explanation for periodic FTBFS reports published for archive test rebuilds.

---

### Related issue

- Fixes: #237 

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

I am currently working on modernizing the `lp-ftbfs-report` tool. It is currently a community-only tool that has different forks available in many Launchpad git and bazarr branches. My repo is currently [lp-ftbfs-report](https://github.com/vhaudiquet/lp-ftbfs-report). Once that initiative is advanced enough, the repo will move to Canonical or Ubuntu namespace, and the software will be packaged as snap. The goal is also to expose `ftbfs.ubuntu.com` with a report that is similar to the UbuntuWire one. I will make another pull request when that initiative is done (targetting the end of the Stonking cycle).

---