### PR TITLE
Promote Building to top-level section in contributors index

### DIFF
--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -65,12 +65,23 @@ debugging/index
 
 ## Bug fixing
 
-Pages on finding fixes upstream, building locally or in a PPA, and running package tests.
+Pages on finding fixes upstream and applying patches.
 
 ```{toctree}
 :maxdepth: 1
 
 bug-fix/index
+```
+
+
+## Building
+
+How to build packages locally or in a PPA, install built packages, and run package tests.
+
+```{toctree}
+:maxdepth: 1
+
+building/index
 ```
 
 
@@ -83,17 +94,6 @@ Specific pages on working with Debian patches.
 
 updating/index
 ```
-
-
-## Building
-
-```{toctree}
-:maxdepth: 1
-
-/contributors/building/index
-```
-
-
 
 
 ## Merging


### PR DESCRIPTION
### Description

- Promote "Building" to its own top-level section in the contributors index, separate from "Bug fixing"

---

### Related issue

- Fixes: #546

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected