### PR TITLE
Add LP outage handling to lpteams script

### DIFF
--- a/.github/lpteams/lp-teams-check.sh
+++ b/.github/lpteams/lp-teams-check.sh
@@ -10,8 +10,31 @@ fi
 
 for LP_TEAM in "${TEAMS[@]}"; do
     EXISTING_TEAM=$(cat "$LP_TEAM.team")
-    READ_TEAM=$(curl --silent https://api.launchpad.net/devel/~"${LP_TEAM}"/members |
-        jq -r '.entries[] | .name' | sort)
+
+    # Fetch team members from Launchpad API
+    # Use --fail to detect HTTP errors, and capture the response
+    LP_RESPONSE=$(curl --silent --fail --show-error \
+        https://api.launchpad.net/devel/~"${LP_TEAM}"/members 2>&1)
+
+    CURL_EXIT_CODE=$?
+
+    if [ $CURL_EXIT_CODE -ne 0 ]; then
+        echo "ERROR: Failed to fetch team data for '$LP_TEAM' from Launchpad (curl exit code: $CURL_EXIT_CODE)."
+        echo "This may indicate a Launchpad outage or network issue."
+        echo "Skipping '$LP_TEAM' to avoid creating an incorrect PR."
+        echo "Error details: $LP_RESPONSE"
+        continue
+    fi
+
+    READ_TEAM=$(echo "$LP_RESPONSE" | jq -r '.entries[] | .name' 2>/dev/null | sort)
+
+    # Verify that we got a non-empty result
+    if [ -z "$READ_TEAM" ]; then
+        echo "WARNING: Launchpad returned empty or invalid data for team '$LP_TEAM'."
+        echo "This may indicate a Launchpad outage or API issue."
+        echo "Skipping '$LP_TEAM' to avoid creating an incorrect PR."
+        continue
+    fi
 
     if [ "$READ_TEAM" != "$EXISTING_TEAM" ]; then
         git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
### Description

- Add LP outage detection to `lp-teams-check.sh`: check curl exit code, validate non-empty response, skip team on failure instead of creating a PR that wipes all members

---

### Related issue

- Fixes: #600

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected