### PR TITLE
Add note that cross-building requires schroot

### DIFF
--- a/docs/contributors/building/build-packages-locally.rst
+++ b/docs/contributors/building/build-packages-locally.rst
@@ -168,6 +168,13 @@ In some cases, builds may be more complex and require additional configuration. 
 Building for a different architecture (cross-building)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+   Cross-building requires the ``schroot`` backend. The ``unshare`` backend
+   does not currently support cross-building. See the
+   `Debian sbuild wiki <https://wiki.debian.org/sbuild#Use_schroot_instead_of_unshare>`_
+   for details.
+
 .. dropdown:: Without ``unshare`` (additional setup required)
 
    Building for a different architecture without ``unshare`` requires using an emulated ``schroot``.


### PR DESCRIPTION
### Description

- Add note that cross-building requires the `schroot` backend, with link to Debian sbuild wiki

---

### Related issue

- Fixes: #622

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected