### PR TITLE
Center and theme archive Mermaid diagram

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/package-archive.rst
+++ b/docs/how-ubuntu-is-made/concepts/package-archive.rst
@@ -11,8 +11,10 @@ The general flow is that the archive splits into :ref:`Ubuntu series <archive-se
 
 .. mermaid::
    :align: center
-   :config: { "theme": "base", "themeVariables": { "fontFamily": "Ubuntu", "fontSize": "25px", "background": "#ffffff", "primaryColor": "#fff", "primaryBorderColor": "#cfcfcf", "primaryTextColor": "#000", "lineColor": "#cfcfcf" } }
 
+   %%{init: {'themeVariables': {
+                'fontSize': '25px',
+                'fontFamily': 'Ubuntu'}}}%%
     flowchart TD;
       A[Ubuntu package archive] --> B([Splits into Ubuntu **series**]);
 
@@ -35,19 +37,6 @@ The general flow is that the archive splits into :ref:`Ubuntu series <archive-se
       N --> Q[restricted];
       N --> R[multiverse];
 
-      style C fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style D fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style E fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-
-      style I fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style J fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style K fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style L fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style M fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style O fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style P fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style Q fill:#fff,stroke:#cfcfcf,stroke-width:2px;
-      style R fill:#fff,stroke:#cfcfcf,stroke-width:2px;
 
 .. note::
 

--- a/docs/how-ubuntu-is-made/concepts/package-archive.rst
+++ b/docs/how-ubuntu-is-made/concepts/package-archive.rst
@@ -10,6 +10,8 @@ On Ubuntu installations, the Ubuntu package archive is configured as the default
 The general flow is that the archive splits into :ref:`Ubuntu series <archive-series>`. Each series is split up into :ref:`pockets <archive-pockets>`, and then each pocket contains four :ref:`components <archive-components>`. This diagram shows a look through a single path:
 
 .. mermaid::
+   :align: center
+   :config: { "theme": "base", "themeVariables": { "fontFamily": "Ubuntu", "fontSize": "25px", "background": "#ffffff", "primaryColor": "#fff", "primaryBorderColor": "#cfcfcf", "primaryTextColor": "#000", "lineColor": "#cfcfcf" } }
 
     flowchart TD;
       A[Ubuntu package archive] --> B([Splits into Ubuntu **series**]);


### PR DESCRIPTION
### Description

- Center the archive Mermaid diagram and apply a dark-theme-friendly base theme config

---

### Related issue

- Fixes: #627

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected