### PR TITLE
Fix Launchpad filebug links in new-packages page

### DIFF
--- a/docs/how-ubuntu-is-made/processes/new-packages.md
+++ b/docs/how-ubuntu-is-made/processes/new-packages.md
@@ -7,10 +7,10 @@ For a piece of software to be included in Ubuntu, it must meet the [Ubuntu Licen
 ## Requesting a new package for Ubuntu
 
 Packages that have recently been added to Debian unstable will be automatically synced into Ubuntu prior to the {ref}`debian-import-freeze` (DIF). Once synced, they will follow the {ref}`proposed-migration flow <proposed-migration>`.
-If instead the release process already reached the Debian Import Freeze, you must [file a bug](https://launchpad.net/ubuntu/+filebug/?no-redirect) with the summary field "Please sync `<packagename>` from debian `<distro>`" where
+If instead the release process already reached the Debian Import Freeze, you must [file a bug](https://launchpad.net/ubuntu/+filebug) with the summary field "Please sync `<packagename>` from debian `<distro>`" where
 `<packagename>` is the package you would like to see.
 
-To get a package into Ubuntu, [file a bug in Launchpad](https://bugs.launchpad.net/ubuntu/+filebug?no-redirect&field.tag=needs-packaging) and make sure it has the tag [`needs-packaging`](https://lists.ubuntu.com/archives/ubuntu-motu/2007-March/001471.html).
+To get a package into Ubuntu, [file a bug in Launchpad](https://bugs.launchpad.net/ubuntu/+filebug) and make sure it has the tag [`needs-packaging`](https://lists.ubuntu.com/archives/ubuntu-motu/2007-March/001471.html).
 
 In the bug, mention where to get the source for it and which license it is under.
 An example request [is shown here](https://wiki.ubuntu.com/UbuntuDevelopment/NewPackages/ExamplePackageRequest).


### PR DESCRIPTION
### Description

- Fix two Launchpad filebug links on the new-packages page by removing `?no-redirect` suffixes
- Note: issue #630 (outdated "going through motu" section) was already resolved in an earlier change; this PR only fixes link issues on the same page

---

### Related issue

- Motivation: #630 :)

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected