### PR TITLE
Update dput to dput-ng references

### DIFF
--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -144,11 +144,18 @@ conform to standard Debian practices.
 
 
 (dput)=
-### DPut
+### dput-ng
 
-[DPut](https://packages.debian.org/sid/dput) is the Debian Package Upload Tool.
-It's used to upload a software package to the Ubuntu repository, or to a
-personal package archive (PPA).
+[dput-ng](https://packages.ubuntu.com/resolute/dput) (the Debian Package Upload Tool,
+next generation) is the modern replacement for `dput`. It's used to upload a
+software package to the Ubuntu repository, or to a personal package archive (PPA).
+
+On recent Ubuntu releases, `dput-ng` is provided by the `dput` package, so
+installing `dput` gives you `dput-ng` automatically:
+
+```none
+$ sudo apt install dput
+```
 
 A working `.dput.cf`:
 


### PR DESCRIPTION
### Description

- Update `dput` references to `dput-ng`, fix heading capitalization, add explicit install command, link to Ubuntu package page

---

### Related issue

- Fixes: #639

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected