### PR TITLE
chore: remove leftover merge conflict marker

### DIFF
--- a/docs/how-ubuntu-is-made/processes/transitions.md
+++ b/docs/how-ubuntu-is-made/processes/transitions.md
@@ -202,5 +202,3 @@ transition project can truly be considered finished:
 
 1. Bug reports filed against packages within the ecosystem relating to upgrade
    failures or other problems caused with the newly-introduced package
-
->>>>>>> 9d833bf (Add process pages)


### PR DESCRIPTION
### Description

Removes leftover merge conflict marker, which was making the page look like:

<img width="898" height="493" alt="image" src="https://github.com/user-attachments/assets/5dcf1ba2-2bb8-44c5-bf00-6dc9959dbc95" />

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

