### PR TITLE
DMB: Julian stepped down

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ community/ @aaronprisk @ilvipero
 
 # DMB team PR approvals
 # Like the AA team, these files are prefixed with "dmb-" but not kept in a specific directory
-**/dmb-*.md @cpaelzer @lvoytek @rbasak @utkarsh2102 @athos-ribeiro @bdrung @julian-klode
+**/dmb-*.md @cpaelzer @lvoytek @rbasak @utkarsh2102 @athos-ribeiro @bdrung
 
 # TAs' & special teams' ack required for changes to the CODEOWNERS file
 /.github/CODEOWNERS @s-makin @rkratky @setharnold @joalif @didrocks @cpaelzer @MylesJP @pushkarnk @panlinux @paride @ginggs @schopin-pro @mwhudson @utkarsh2102 @tjaalton @seb128 @raof @aaronprisk @ilvipero @basak @teward @enr0n @julian-klode @awhitcroft @Hyask


### PR DESCRIPTION
Per [1] Julian stepped down from this role. We are in the process of refilling but have no fully conclusive new person yet. For now ease Julians inbox load by dropping him here as well.

[1]: https://lists.ubuntu.com/archives/devel-permissions/2026-June/003052.html