### PR TITLE
dmb: clarify actions in regard to github membership

### DIFF
--- a/docs/who-makes-ubuntu/councils/dmb-rules.md
+++ b/docs/who-makes-ubuntu/councils/dmb-rules.md
@@ -80,7 +80,9 @@ The following details [are agreed on](https://irclogs.ubuntu.com/2009/10/13/#ubu
 4. Consider more {ref}`teams to add uploaders to <dmb-teams-to-also-add-uploaders-to>`
    if granting PPU or packageset permissions.
 
-5. Announce successful applicants (this can be done in a single email or multiple
+5. If a new {ref}`Core Developer <dmb-joining-core-dev>` was approved add them to {ref}`github on Ubuntu <dmb-access-to-ubuntu-on-github>`
+
+6. Announce successful applicants (this can be done in a single email or multiple
    emails as appropriate), as the Community Council
    [would like to see these announced](https://irclogs.ubuntu.com/2016/07/21/%23ubuntu-meeting.html#t17:17)
    and [we agreed in a subsequent meeting](https://irclogs.ubuntu.com/2016/08/01/%23ubuntu-meeting.html#t16:02).

--- a/docs/who-makes-ubuntu/developers/dmb-joining-core-dev.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-core-dev.md
@@ -10,7 +10,8 @@ Core Developers (Core Devs) are members of the [`ubuntu-core-dev`](https://launc
 Core Devs collectively maintain all packages in Ubuntu, which notably includes uploading to the `main` component.
 Core Devs also have elevated privileges for re-triggering autopkgtests and performing other administrative actions in Ubuntu.
 
-## Coverage Ubuntu on Github
+(dmb-access-to-ubuntu-on-github)=
+## Access to Ubuntu on Github
 
 To maintain all resources used to make Ubuntu, a Core Developer also gets access to {ref}`ubuntu-on-github`.
 


### PR DESCRIPTION
It was raised that the title "Coverage Ubuntu on Github" is rather hard to understand and in fixing it I found that the "actions after an approval" also do not yet include it.

TBH we can#t even do that yet, it is still worked out if the DMB gets admin there of if we can automap the core-dev group. But the intention should be documented correctly which this PR tries to help with.