### PR TITLE
fix: typo for listing the available schroots in Ubuntu development setup

### DIFF
--- a/docs/contributors/setup/set-up-for-ubuntu-development.md
+++ b/docs/contributors/setup/set-up-for-ubuntu-development.md
@@ -367,7 +367,7 @@ $ mk-sbuild resolute --arch=amd64
 List the available schroots:
 
 ```none
-$ sbuild -l
+$ schroot -l
 ```
 
 Update a schroot:


### PR DESCRIPTION
### Description

Fix a typo in the "How to set up for Ubuntu development" page for command to list available schroots.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [ ] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected


