### PR TITLE
docs: add Ubuntu 26.04.1 LTS to future releases

### DIFF
--- a/docs/release-team/list-of-releases.md
+++ b/docs/release-team/list-of-releases.md
@@ -59,6 +59,7 @@ feature-based one), approximately every 6 months.
 
 | Version | Code name | Schedule | Docs | Release | End of Standard Support |
 | :---- | :---- | :---- | :---- | :---- | :---- |
+| Ubuntu 26.04.1 LTS | Resolute Raccoon | TBD | TBD | August 2026 | May 2031 |
 | Ubuntu 26.10 | Stonking Stingray | TBD | TBD | October 2026 | July 2027 |
 
 


### PR DESCRIPTION
### Description

- Add Ubuntu 26.04.1 LTS (Resolute Raccoon) to the Future releases table

### Related issue

- Fixes: #645

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected