### PR TITLE
docs: add --no-clean-source explanation and fix architecture variants section in build-packages-locally

### DIFF
--- a/docs/contributors/building/build-packages-locally.rst
+++ b/docs/contributors/building/build-packages-locally.rst
@@ -118,6 +118,20 @@ To build both **source** and **binary** packages for a specific release, use the
 Useful ``sbuild`` options
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Skipping the source clean step:
+  By default, ``sbuild`` runs ``debian/rules clean`` before building, which
+  requires some build dependencies to be installed on the host system. If you
+  maintain your source tree in git and have already cleaned it (e.g. with
+  ``git clean -ffdx``), use ``--no-clean-source`` to skip this step:
+
+  .. code-block:: none
+
+     --no-clean-source
+
+  This is particularly useful when building source packages with
+  ``dpkg-buildpackage --no-pre-clean`` (``-nc``), as it avoids requiring build
+  dependencies on the host solely for the clean step.
+
 Parallel building:
   To speed up the build, set the ``parallel`` option through the ``DEB_BUILD_OPTIONS`` environment variable. For example:
 
@@ -209,11 +223,30 @@ When building with ``sbuild``, specify the target architecture with the ``--arch
 Building for architecture variants
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some architectures have variants (e.g. ``amd64`` has ``amd64v3``). To build for an architecture variant, specify the variant as an argument to ``--host=``:
+Some architectures have variants (e.g. ``amd64`` has ``amd64v3``). Architecture
+variants are treated as separate architectures by ``dpkg`` and ``sbuild``, so
+building for a variant requires a chroot configured for that variant.
+
+.. note::
+
+   Building for an architecture variant requires the ``schroot`` backend. The
+   ``unshare`` backend does not currently support architecture variants. See
+   the `Debian sbuild wiki
+   <https://wiki.debian.org/sbuild#Use_schroot_instead_of_unshare>`_ for
+   details on switching backends.
+
+First, create a schroot for the architecture variant using ``mk-sbuild`` from
+the ``ubuntu-dev-tools`` package:
 
 .. code-block:: none
 
-    $ sbuild --host=<ARCH_VARIANT> --dist=<RELEASE>
+    $ mk-sbuild --arch=<ARCH_VARIANT> <RELEASE>
+
+Then, build with ``sbuild`` using the ``--arch=`` option:
+
+.. code-block:: none
+
+    $ sbuild --arch=<ARCH_VARIANT> --dist=<RELEASE>
 
 where ``<ARCH_VARIANT>`` is the architecture variant (e.g. ``amd64v3``).
 

--- a/docs/contributors/building/build-packages-locally.rst
+++ b/docs/contributors/building/build-packages-locally.rst
@@ -115,7 +115,7 @@ To build both **source** and **binary** packages for a specific release, use the
     Launchpad rejects uploads that contain both binaries and sources.
 
 
-Useful ``sbuild`` options
+Useful build options
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Skipping the source clean step:


### PR DESCRIPTION
### Description

- Add `--no-clean-source` explanation to the "Useful sbuild options" section, clarifying that sbuild runs `debian/rules clean` by default (requiring build dependencies on the host) and that `--no-clean-source` skips this step — particularly useful when maintaining the source tree in git
- Fix the "Building for architecture variants" section: change incorrect `--host=` to `--arch=` (the correct sbuild option for specifying the build architecture, per the sbuild manpage), add instructions for creating a schroot for the variant using `mk-sbuild`, and add a note about the `schroot` backend requirement

### Related issue

- Fixes: #536

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected