### PR TITLE
Add missing Rust update steps

### DIFF
--- a/docs/maintainers/niche-package-maintenance/rustc/common/obtaining-upload-info.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/common/obtaining-upload-info.md
@@ -10,7 +10,7 @@ Get the default Lintian output for the source package by [cleaning up all build 
 $ lintian > <path_to_saved_lintian_output_file>
 ```
 
-If you are updating the toolchain to a new version (necessitating a new package upload), an {term}`Archive Admin` will need to approve the new package. You can make their job easier and speed up your package upload by generating a diff of the `debian/` directory and including it as an attachment, allowing the Archive Admin to easily review the changes:
+For updating the toolchain to a new version (necessitating a new package upload), an {term}`Archive Admin` needs to approve the new package. To make their job easier and speed up the package upload by generating a diff of the `debian/` directory and including it as an attachment, allowing the Archive Admin to easily review the changes:
 
 ```none
 $ git diff merge-<X.Y_old> -- debian > my_diff.diff
@@ -29,6 +29,6 @@ Compile the following information:
 - A list of any notable packaging changes (_not_ upstream changes). These are changes _you_ made to the package, such as the removal or addition of patches. Nothing routine (such as patch refreshes or vendored dependency pruning) should be added here.
 - The output of `lintian` you just got
 - The links to the build logs of all PPA autopkgtests you just got
-- If this is a Rust update, an attachment of the diff of the `debian/` directory between the old and new Rust versions
+- For Rust updates, an attachment of the diff of the `debian/` directory between the old and new Rust versions
 
-You can see a real example of such an upload request [here](https://bugs.launchpad.net/ubuntu/+bug/2156635/comments/1).
+See a real example of such an upload request at {lpbug}`2156635`.

--- a/docs/maintainers/niche-package-maintenance/rustc/common/obtaining-upload-info.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/common/obtaining-upload-info.md
@@ -31,4 +31,4 @@ Compile the following information:
 - The links to the build logs of all PPA autopkgtests you just got
 - For Rust updates, an attachment of the diff of the `debian/` directory between the old and new Rust versions
 
-See a real example of such an upload request at {lpbug}`2156635`.
+See a real example of such an upload request at [LP: #2156635](https://bugs.launchpad.net/ubuntu/+bug/2156635/comments/1).

--- a/docs/maintainers/niche-package-maintenance/rustc/common/obtaining-upload-info.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/common/obtaining-upload-info.md
@@ -10,6 +10,12 @@ Get the default Lintian output for the source package by [cleaning up all build 
 $ lintian > <path_to_saved_lintian_output_file>
 ```
 
+If you are updating the toolchain to a new version (necessitating a new package upload), an {term}`Archive Admin` will need to approve the new package. You can make their job easier and speed up your package upload by generating a diff of the `debian/` directory and including it as an attachment, allowing the Archive Admin to easily review the changes:
+
+```none
+$ git diff merge-<X.Y_old> -- debian > my_diff.diff
+```
+
 Finally, you can push your `merge-<X.Y>` branch to the Foundations `rustc` Launchpad Git remote:
 
 ```none
@@ -23,3 +29,6 @@ Compile the following information:
 - A list of any notable packaging changes (_not_ upstream changes). These are changes _you_ made to the package, such as the removal or addition of patches. Nothing routine (such as patch refreshes or vendored dependency pruning) should be added here.
 - The output of `lintian` you just got
 - The links to the build logs of all PPA autopkgtests you just got
+- If this is a Rust update, an attachment of the diff of the `debian/` directory between the old and new Rust versions
+
+You can see a real example of such an upload request [here](https://bugs.launchpad.net/ubuntu/+bug/2156635/comments/1).

--- a/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
@@ -281,7 +281,7 @@ $ RUST_BOOTSTRAP_DIR=~/.rustup/toolchains/<X.Y.Z>-x86_64-unknown-linux-gnu \
 
 You should now see a new tarball in the parent directory: `../rustc-<X.Y>_<X.Y.Z>+dfsg.orig-vendor.tar.xz`. In later steps, we use this to replace the existing `vendor/` directory.
 
-You may also notice that `debian/rust-X.Y-src.install.in` has been updated — this is intentional. One binary package, `rust-<X.Y>-src`, installs certain vendored dependencies needed to build the Rust standard library from source. The `vendor-tarball` rule updates the dependency numbers so `rust-<X.Y>-src` ships the proper files. Commit the changes to `debian/rust-X.Y-src.install.in` before proceeding.
+Notice that `debian/rust-X.Y-src.install.in` has been updated — this is intentional. One binary package, `rust-<X.Y>-src`, installs certain vendored dependencies needed to build the Rust standard library from source. The `vendor-tarball` rule updates the dependency numbers, so `rust-<X.Y>-src` ships the proper files. Commit the changes to `debian/rust-X.Y-src.install.in` before proceeding.
 
 All other changes to the repository may be safely restored.
 

--- a/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/update-rust.md
@@ -270,7 +270,7 @@ Make sure that `~/.cargo/bin` is in your `$PATH`, otherwise you won't be able to
 
 
 (updating-rust-vendor-tarball-rule)=
-Vendor tarball rule
+#### Vendor tarball rule
 
 After that, call the `vendor-tarball` rule in `debian/rules`. This uses `cargo-vendor-filterer` to generate a vendor directory that _only_ contains the dependencies required by supported Ubuntu targets. It then repacks this directory into the `vendor` tarball component. Make sure you point it to your installed Rust toolchain via `RUST_BOOTSTRAP_DIR`:
 
@@ -280,6 +280,10 @@ $ RUST_BOOTSTRAP_DIR=~/.rustup/toolchains/<X.Y.Z>-x86_64-unknown-linux-gnu \
 ```
 
 You should now see a new tarball in the parent directory: `../rustc-<X.Y>_<X.Y.Z>+dfsg.orig-vendor.tar.xz`. In later steps, we use this to replace the existing `vendor/` directory.
+
+You may also notice that `debian/rust-X.Y-src.install.in` has been updated — this is intentional. One binary package, `rust-<X.Y>-src`, installs certain vendored dependencies needed to build the Rust standard library from source. The `vendor-tarball` rule updates the dependency numbers so `rust-<X.Y>-src` ships the proper files. Commit the changes to `debian/rust-X.Y-src.install.in` before proceeding.
+
+All other changes to the repository may be safely restored.
 
 ### Removing Vendored C Libraries
 


### PR DESCRIPTION
### Description

There are two recently-added steps missing from the Rust update docs. I have added both of them in this branch.

First, I added a mandatory step which requires you to commit a file changed by a particular script and restore all the other files. I have explicitly detailed which file can be committed and which can be restored.

Second, an Archive Admin recently suggested I add the `debian/` diff between the old and new Rust versions when requesting a new package upload, making the sponsorship process easier for everyone. I have added this step as well and linked to real comment which includes all this info for reference.

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] I have tested my changes, and they work as expected

