### PR TITLE
docs: remove unsupported 32-bit PowerPC architecture references

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -1095,9 +1095,6 @@ POSIX
     interfaces, for software compatibility with variants of Unix and other
     {term}`Operating Systems <Operating System>`.
 
-PowerPC
-    *Work in Progress*
-
 ppc64el
     *Work in Progress* (PowerPC64 Little-Endian)
 
@@ -1142,7 +1139,7 @@ Reduced Instruction Set Computer
     {term}`RISC` processors typically prioritize speed over complexity.
 
     Examples of {term}`RISC` {term}`Architectures <Architecture>` are {term}`arm64`,
-    {term}`armhf`, {term}`RISC-V`, {term}`ppc64el`, and {term}`PowerPC`.
+    {term}`armhf`, {term}`RISC-V`, and {term}`ppc64el`.
 
     See also:
     * [Reduced instruction set computer (Wikipedia)](https://en.wikipedia.org/wiki/Reduced_instruction_set_computer)

--- a/docs/how-ubuntu-is-made/concepts/launchpad.rst
+++ b/docs/how-ubuntu-is-made/concepts/launchpad.rst
@@ -25,7 +25,7 @@ While platforms like GitHub put users and groups at the top level, Launchpad put
 Why not use platforms like GitHub?
 ----------------------------------
 
-Although Launchpad's :term:`UI` and :term:`UX` are a bit dated, Launchpad offers an unparalleled Ubuntu package building and hosting infrastructure that no other platform offers. Even simple requirements like building for architectures like :term:`PowerPC`, :term:`s390x`, or :term:`RISC-V` cannot be fulfilled by GitHub or similar platforms.
+Although Launchpad's :term:`UI` and :term:`UX` are a bit dated, Launchpad offers an unparalleled Ubuntu package building and hosting infrastructure that no other platform offers. Even simple requirements like building for architectures like :term:`ppc64el`, :term:`s390x`, or :term:`RISC-V` cannot be fulfilled by GitHub or similar platforms.
 
 
 Personal Package Archive (PPA)


### PR DESCRIPTION
## Description

- Remove the unsupported 32-bit `PowerPC` glossary entry
- Replace ``:term:`PowerPC` `` references with ``:term:`ppc64el` `` (the supported 64-bit little-endian variant)
- Update the RISC architecture examples list to remove `PowerPC`

## Related issue

- Fixes: #311

## Checklist

- [x] Read the [contributing guidelines](https://documentation.ubuntu.com/project/contributors/documentation/)
- [x] Build succeeds (`make clean-doc && make html`)
- [x] Spellcheck passes (`make spelling`)
- [x] Inclusive language check passes (`make woke`)