### PR TITLE
docs: clarify that sponsors upload security fixes

### DIFF
--- a/docs/contributors/uploading/find-a-sponsor.md
+++ b/docs/contributors/uploading/find-a-sponsor.md
@@ -4,7 +4,7 @@
 The ability to upload or sync directly to the Archive is carefully managed to ensure the stability and security of Ubuntu. New contributors don't have upload rights immediately -- they must request {ref}`sponsorship` from someone who *does* have upload rights to:
 
 - Make changes to existing packages or incremental updates.
-- Submit security updates or bug fixes.
+- Upload security updates or bug fixes.
 - Introduce new packages to Ubuntu.
 - Initiate syncs from Debian.
 


### PR DESCRIPTION
## Description

- Change "Submit security updates or bug fixes" to "Upload security updates or bug fixes" in the sponsor list to clarify that a sponsor is needed to upload (land) changes, not just to submit them

## Related issue

- Fixes: #278

## Checklist

- [x] Read the [contributing guidelines](https://documentation.ubuntu.com/project/contributors/documentation/)
- [x] Build succeeds (`make clean-doc && make html`)
- [x] Spellcheck passes (`make spelling`)
- [x] Inclusive language check passes (`make woke`)