### PR TITLE
docs: clarify commit message format in merge process

### DIFF
--- a/docs/contributors/merging/merge-process.md
+++ b/docs/contributors/merging/merge-process.md
@@ -221,6 +221,8 @@ Start a rebase at `old/debian`, and then reset to `HEAD^` to bring back the chan
 
 Next, add the commits:
 
+Each commit message follows the changelog entry format: the `*` prefix denotes a bullet point, and continuation lines are indented to align with it. The entire block constitutes the commit message (there is no separate subject/body split). See {ref}`how-to-commit-changes` for more information about commit message standards.
+
 ------------------------------------------------------------------------------
 
 Logical unit:


### PR DESCRIPTION
## Description

- Add a clarifying note explaining the changelog entry commit message format (`*` prefix, continuation indentation, entire block as commit message)
- Link to ``{ref}`how-to-commit-changes` `` for further details

## Related issue

- Fixes: #279

## Checklist

- [x] Read the [contributing guidelines](https://documentation.ubuntu.com/project/contributors/documentation/)
- [x] Build succeeds (`make clean-doc && make html`)
- [x] Spellcheck passes (`make spelling`)
- [x] Inclusive language check passes (`make woke`)