### PR TITLE
docs: update autopkgtest PPA result URL format

### DIFF
--- a/docs/contributors/advanced/resolve-a-migration-issue.md
+++ b/docs/contributors/advanced/resolve-a-migration-issue.md
@@ -177,10 +177,10 @@ release=<RELEASE>&arch=<ARCH>&package=<SRCPKG>&trigger=<SRCPKG>/<VERSION>&ppa=<L
 You must have upload rights for the package (`<SRCPKG>` above) for the test request to be successful.
 :::
 
-The test is then displayed at [`autopkgtest.ubuntu.com/running`](https://autopkgtest.ubuntu.com/running). Upon completion, the test result is available at an index page at `https://autopkgtest.ubuntu.com/results/autopkgtest-<RELEASE>-<LPUSER>-<PPA>/?format=plain`. The index contains the results for each autopkgtest run against this particular `<PPA>` for this `<RELEASE>`. To see a particular test, append the appropriate path from the index to
+The test is then displayed at [`autopkgtest.ubuntu.com/running`](https://autopkgtest.ubuntu.com/running). Upon completion, the test result is available at `https://autopkgtest.ubuntu.com/user/<LPUSER>/ppa`. The index contains the results for each autopkgtest run against this particular `<PPA>`. To see a particular test, navigate to
 
 ```none
-https://autopkgtest.ubuntu.com/results/autopkgtest-<RELEASE>-<LPUSER>-<PPA>/
+https://autopkgtest.ubuntu.com/user/<LPUSER>/ppa
 ```
 
 


### PR DESCRIPTION
## Description

- Update the autopkgtest PPA result URL from the old `results/autopkgtest-<RELEASE>-<LPUSER>-<PPA>/` format to the new `user/<LPUSER>/ppa` format

## Related issue

- Fixes: #269

## Checklist

- [x] Read the [contributing guidelines](https://documentation.ubuntu.com/project/contributors/documentation/)
- [x] Build succeeds (`make clean-doc && make html`)
- [x] Spellcheck passes (`make spelling`)
- [x] Inclusive language check passes (`make woke`)

## Additional notes

This PR only addresses the clear URL format change from the issue. It does not address:
- The mention of an unnamed Launchpad group that grants test-request power to non-uploaders (the reporter didn't know the group name)
- The unverified claim that "you can't test autopkgtests in a PPA until after that package has autopkgtests in the Ubuntu archive"

These would need input from the Ubuntu Release Management team.