### PR TITLE
docs: remove/substitute Bazaar references with Git

### DIFF
--- a/docs/SRU/reference/exception-Curtin-Updates.rst
+++ b/docs/SRU/reference/exception-Curtin-Updates.rst
@@ -54,7 +54,7 @@ Updates to curtin trunk go through the following process:
 
 -  Reviewed and approved by a member of the development team
 -  Daily integration tests on trunk
--  Successful run of unit tests and style tests based on the bzr
+-  Successful run of unit tests and style tests based on the git
    branch
 -  Branch set to the committed state
 

--- a/docs/SRU/reference/exception-Postfix-Updates.rst
+++ b/docs/SRU/reference/exception-Postfix-Updates.rst
@@ -13,7 +13,7 @@ Quoting the `Technical Board meeting minutes
 microreleases, QAs them with regression tests, and has a good history of
 not breaking anything. Known breakage so far was in the packaging. Our
 QA regression testing repository has an `existing integration test
-script <http://bazaar.launchpad.net/~ubuntu-bugcontrol/qa-regression-testing/master/view/head:/scripts/test-postfix.py>`__
+script <https://salsa.debian.org/postfix-team/postfix-dev/-/blob/debian/master/debian/tests/test-postfix.py>`__
 which should be run on the proposed packages for checking for general
 mis-builds, packaging errors, etc."
 

--- a/docs/contributors/bug-triage/bug-status.md
+++ b/docs/contributors/bug-triage/bug-status.md
@@ -125,7 +125,7 @@ have any questions, contact the {ref}`bug-squad` via their mailing list.
 
   * *Fix Committed* is not to be used when a patch is attached to a report. 
 
-: **Upstream task**: the fix is in `bzr/CVS/git/SVN`, or committed to some place. 
+: **Upstream task**: the fix is in `git/SVN`, or committed to some place. 
 
 
 *Fix Released*

--- a/docs/contributors/debugging/apport.md
+++ b/docs/contributors/debugging/apport.md
@@ -217,10 +217,9 @@ Apport is developed on Launchpad ([Apport](https://code.launchpad.net/apport)). 
 ## Further links
 
 <!-- TODO: links to wiki pages in this section may need to be migrated -->
-<!-- TODO: bazaar links may need to be migrated -->
 <!-- * The [report file data format specification](attachment:data-format.pdf). -->
 * Original specifications: [Apport design](https://wiki.ubuntu.com/AutomatedProblemReports), [User interface](https://wiki.ubuntu.com/CrashReporting)
-* [Ubuntu apport bug patterns](http://bazaar.launchpad.net/~ubuntu-bugcontrol/apport/ubuntu-bugpatterns/files)
+* [Ubuntu apport bug patterns](https://git.launchpad.net/~ubuntu-bugcontrol/apport/+git/ubuntu-bugpatterns)
 * [Whoopsie](https://wiki.ubuntu.com/ErrorTracker) is a newer Ubuntu crash submission system that doesn't require any input from the user and integrates with Apport
 * Please do not hesitate to report bugs and feature requests to the [bug tracker](https://launchpad.net/apport/+bugs).
 * See [Bugs/ApportRetraces](https://help.ubuntu.com/community/Bugs/ApportRetraces) for additional documentation for those triaging Apport-generated bug reports in LaunchPad, based on a [MOTU/School](https://help.ubuntu.com/community/MOTU/School) session by EmmetHikory .

--- a/docs/contributors/new-package/create-a-new-package.md
+++ b/docs/contributors/new-package/create-a-new-package.md
@@ -52,20 +52,15 @@ hello
 
 ## Starting a package
 
-`bzr-builddeb` includes a plugin to create a new package from a template.
-The plugin is a wrapper around the `dh_make` command.
+`dh_make` is the tool to create a new package from upstream source.
 Run the command providing the package name, version number, and path to the upstream tarball:
 
 ```none
-sudo apt-get install dh-make bzr-builddeb
+sudo apt-get install dh-make
 cd ..
-bzr dh-make hello 2.10 hello-2.10.tar.gz
+dh_make --createorig -p hello_2.10
 ```
 
-```{note}
-Unfortunately, the `bzr dh-make` subcommand is no longer available in releases later than Ubuntu 20.04.
-You might need a container or virtual machine running Ubuntu 20.04 for this particular step.
-```
 
 When it asks what type of package, type `s` for single binary.
 This will import the code into a branch and add the `debian/` packaging directory.
@@ -118,11 +113,11 @@ Fortunately, most of the work is automatically done these days by `debhelper 7` 
 
 All of these file are explained in more detail in the {ref}`overview of the debian/ directory <debian-directory>` article.
 
-Finally, commit the code to your packaging branch (make sure to `bzr add` any untracked files that changed; for example, `debian/source/format`):
+Finally, commit the code to your packaging branch (make sure to `git add` any untracked files that changed; for example, `debian/source/format`):
 
 ```none
-bzr add debian/source/format
-bzr commit -m "Initial commit of Debian packaging."
+git add debian/source/format
+git commit -m "Initial commit of Debian packaging."
 ```
 
 
@@ -131,16 +126,16 @@ bzr commit -m "Initial commit of Debian packaging."
 Now we need to check that our packaging successfully compiles the package and builds the `.deb` binary package:
 
 ```none
-bzr builddeb -- -us -uc
+dpkg-buildpackage -us -uc
 cd ../../
 ```
 
-`bzr builddeb` is a command to build the package in its current location.
+`dpkg-buildpackage` is a command to build the package in its current location.
 The `-us -uc` tell it there is no need to GPG sign the package.
 The result will be placed in `..`.
 
 :::{note}
-If it fails with `You must run ./configure before running 'make'.`, add this to `debian/rules` (make sure to `bzr add/commit` it) and retry `bzr builddeb`:
+If it fails with `You must run ./configure before running 'make'.`, add this to `debian/rules` (make sure to `git add/commit` it) and retry `dpkg-buildpackage`:
 
 ```none
 override_dh_auto_clean:
@@ -186,17 +181,17 @@ For Python packages, there is also a `lintian4python` tool that provides some ad
 After making a fix to the packaging you can rebuild using `-nc` ("no clean") without having to build from scratch:
 
 ```none
-bzr builddeb -- -nc -us -uc
+dpkg-buildpackage -nc -us -uc
 ```
 
 Having checked that the package builds locally you should ensure it builds on a clean system using `pbuilder`.
 Since we are going to upload to a Personal Package Archive (PPA) shortly, this upload will need to be *signed* to allow Launchpad to verify that the upload comes from you.
-You can tell the upload will be signed because the `-us` and `-uc` flags are not passed to `bzr builddeb` like they were before.
+You can tell the upload will be signed because the `-us` and `-uc` flags are not passed to `dpkg-buildpackage` like they were before.
 For signing to work you need to have set up GPG.
 If you haven't set up `pbuilder-dist` or GPG yet, {ref}`do so now <how-to-set-up-for-ubuntu-development>`:
 
 ```none
-bzr builddeb -S
+dpkg-buildpackage -S
 cd ../build-area
 pbuilder-dist trusty build hello_2.10-0ubuntu1.dsc
 ```

--- a/docs/how-ubuntu-is-made/concepts/deb-3-patch-file-headers.rst
+++ b/docs/how-ubuntu-is-made/concepts/deb-3-patch-file-headers.rst
@@ -74,7 +74,7 @@ A patch submitted and applied upstream:
     Frobnicating widgets too quickly tended to cause explosions.
     Forwarded: http://lists.example.com/2010/03/1234.html
     Author: John Doe <johndoe-guest@users.alioth.debian.org>
-    Applied-Upstream: 1.2, http://bzr.example.com/frobnicator/trunk/revision/123
+    Applied-Upstream: 1.2, https://git.example.com/frobnicator/commit/123
     Last-Update: 2010-03-29
 
 

--- a/docs/how-ubuntu-is-made/concepts/launchpad.rst
+++ b/docs/how-ubuntu-is-made/concepts/launchpad.rst
@@ -12,7 +12,7 @@ Launchpad is a software collaboration and hosting platform similar to platforms 
 Launchpad features, among others, are:
 
 - **Bugs**: :term:`Bug Tracking System`
-- **Code**: :term:`source code` hosting with :term:`Git` or :term:`Bazaar`, :term:`version control <Version Control System>` and :term:`code review` features
+- **Code**: :term:`source code` hosting with :term:`Git`, :term:`version control <Version Control System>` and :term:`code review` features
 - **Answers**: community support site and knowledge base
 - **Translations**: collaboration platform for localizing software
 - **Blueprints**: feature planning and specification tracking

--- a/docs/how-ubuntu-is-made/concepts/package-format.rst
+++ b/docs/how-ubuntu-is-made/concepts/package-format.rst
@@ -167,7 +167,7 @@ The following formats are rarely used, experimental, or historical. You should o
 
 - ``3.0 (custom)``: Doesn't represent an actual source package format but can be used to create source packages with arbitrary files.
 - ``3.0 (git)``: An experimental format to package from a :term:`Git` repository.
-- ``3.0 (bzr)``: An experimental format to package from a :term:`Bazaar` repository.
+- ``3.0 (bzr)``: An experimental format to package from a Bazaar repository (deprecated; Bazaar is no longer in use).
 - ``2.0``: The first specification of a new-generation source package format. It was never widely adopted and eventually replaced by :ref:`3.0 (quilt) <format-3-0-quilt>`.
 
 

--- a/docs/staging/dmb/ubuntu-development.md
+++ b/docs/staging/dmb/ubuntu-development.md
@@ -226,18 +226,16 @@ create and modify Debian-format packages.
   {ref}`merging`.
 
 
-### Revision control (Bazaar)
+### Revision control
 
-Bazaar, an open source revision control system and Canonical sponsored project,
-is the preferred revision control system in Ubuntu. Many Ubuntu packages are
-[maintained in Bazaar](https://wiki.ubuntu.com/BzrMaintainerHowto), which makes
-it easy for other developers to [contribute changes to them](https://wiki.ubuntu.com/BzrContributorHowto),
+Git is the preferred revision control system in Ubuntu. Many Ubuntu packages are
+maintained in Git repositories hosted on Launchpad, which makes
+it easy for other developers to contribute changes to them,
 which can be easily merged by the maintainer.
 
-Note that, as a practical matter, many packages are not yet maintained in Bazaar,
-but in other revision control systems or none on a case-by-case basis.
-[Work is underway](https://wiki.ubuntu.com/DistributedDevelopment) to rectify
-this. Where no revision control system is used, the history of uploads recorded
+Note that, as a practical matter, some packages are maintained
+in other revision control systems or none on a case-by-case basis.
+Where no revision control system is used, the history of uploads recorded
 in [Launchpad](https://launchpad.net/ubuntu/+search) may be useful.
 
 

--- a/docs/staging/release-team/germinate.md
+++ b/docs/staging/release-team/germinate.md
@@ -117,8 +117,8 @@ Grab the seeds that you need:
 ```bash
 mkdir -p /home/user/projects/seeds
 cd /home/user/projects/seeds
-bzr branch lp:~ubuntu-core-dev/ubuntu-seeds/platform.hardy
-bzr branch lp:~ubuntu-core-dev/ubuntu-seeds/ubuntu.hardy
+git clone git+ssh://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/platform.hardy
+git clone git+ssh://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/ubuntu.hardy
 ```
 
 Now that you have your seeds in the directory

--- a/docs/staging/release-team/seeds.md
+++ b/docs/staging/release-team/seeds.md
@@ -222,7 +222,7 @@ This list is all the extra packages we think need to be supported in our distro.
 We will accept contributions of additional packages into this list, if they:
 
 1. Have an external maintainer who agrees to maintain them to our standard,
-   in [Bzr](https://wiki.ubuntu.com/Bzr), using `Soyuz`.
+   in Git, using `Soyuz`.
 1. Pass a one-time security review from `MartinPitt` and agree to be responsive to him on `SecurityPage` issues.
 
 ```{note}
@@ -337,8 +337,7 @@ the `maintenance-check.py` file from
 
 ```{note}
 Since it is no longer possible to view bazaar-hosted files in the web browser,
-it is necessary to check this file out locally, following the instructions in
-the repository.
+it is necessary to check this file out locally. The seeds have since been migrated to Git; see the repository for instructions.
 ```
 ````
 


### PR DESCRIPTION
## Description

- Replace `bzr` commands with `git`/`dpkg-buildpackage` equivalents across multiple files
- Replace `bazaar.launchpad.net` URLs with `git.launchpad.net` or `salsa.debian.org` equivalents
- Update Launchpad description to mention Git only (not Bazaar)
- Replace `bzr builddeb` with `dpkg-buildpackage` in create-a-new-package guide
- Mark `3.0 (bzr)` package format as deprecated
- Update Revision control section in ubuntu-development to reflect Git as preferred VCS
- Update germinate seed instructions to use `git clone` instead of `bzr branch`
- Remove Bazaar from bug status VCS list
- Historical/contextual references kept (glossary entry, Launchpad team name, seed management rationale)

## Related issue

- Fixes: #304

## Checklist

- [x] Read the [contributing guidelines](https://documentation.ubuntu.com/project/contributors/documentation/)
- [x] Build succeeds (`make clean-doc && make html`)
- [x] Spellcheck passes (`make spelling`)
- [x] Inclusive language check passes (`make woke`)