### PR TITLE
git-ubuntu-merge: add a note for defaultReviewer

### DIFF
--- a/docs/contributors/merging/git-ubuntu-merge-proposal.md
+++ b/docs/contributors/merging/git-ubuntu-merge-proposal.md
@@ -69,8 +69,8 @@ $ git config [--global] gitubuntu.submit.defaultReviewer <launchpad-reviewer>
 ```
 
 :::{note}
-Note that the previous configurations for` defaultReviewer` will only work
-starting with git ubuntu version 1.2, before this version you need to pass
+The previous configurations for `defaultReviewer` will only work
+starting with `git-ubuntu` version 1.2, before this version you need to pass
 the `--reviewer` command-line option to the command.
 :::
 

--- a/docs/contributors/merging/git-ubuntu-merge-proposal.md
+++ b/docs/contributors/merging/git-ubuntu-merge-proposal.md
@@ -68,6 +68,12 @@ The equivalent `git config` command is:
 $ git config [--global] gitubuntu.submit.defaultReviewer <launchpad-reviewer>
 ```
 
+:::{note}
+Note that the previous configurations for` defaultReviewer` will only work
+starting with git ubuntu version 1.2, before this version you need to pass
+the `--reviewer` command-line option to the command.
+:::
+
 If this fails, {ref}`do it manually <merge-submit-merge-proposal-manually>`.
 
 


### PR DESCRIPTION
The defaultReviewer option has been implemented in git-ubuntu 1.2, meaning that git-ubuntu before this version won't work. Add a note that explains that.
### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)