### PR TITLE
Supported architectures: fix a couple typos

### DIFF
--- a/docs/how-ubuntu-is-made/concepts/supported-architectures.rst
+++ b/docs/how-ubuntu-is-made/concepts/supported-architectures.rst
@@ -49,7 +49,7 @@ binaries that cannot be rebuilt as ``amd64`` native applications
 Architecture baselines
 ----------------------
 
-For each architecture above, there is a *baseline* which is the oldest or least capable CPU that can be used to run Ubuntu of that architecture:
+For each architecture above, there is a *baseline* which is the oldest or least capable CPU that can be used to run Ubuntu on that architecture:
 
 .. list-table::
     :header-rows: 1
@@ -83,7 +83,7 @@ Architecture variants
 
 To be able to assume features of more modern CPUs without dropping support for older machines, Ubuntu 25.10 introduced the concept of :term:`Architecture variant`. This allows packages to be built for given :term:`Architecture` (in this context, architecture really means :term:`ABI`) multiple times, each build assuming different CPU features.
 
-Ubuntu supports the ``amd64v3`` variant, which assumes the ``x86-64-v3`` microarchiture level. This assumes a number of instructions that have been added in the years since the first AMD64 CPUs, including AVX2, FMA, BMI2, and others. Most AMD64-compatible processors produced since about 2013 support this.
+Ubuntu supports the ``amd64v3`` variant, which assumes the ``x86-64-v3`` microarchitecture level. This assumes a number of instructions that have been added in the years since the first AMD64 CPUs, including AVX2, FMA, BMI2, and others. Most AMD64-compatible processors produced since about 2013 support this.
 
 
 Further reading


### PR DESCRIPTION
"Ubuntu of that architecture" technically can make sense but "on" sounds more right, more consistent with other docs?