### PR TITLE
Auto-add untriaged label to new issues

### DIFF
--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -13,6 +13,7 @@ jobs:
     
     steps:
       - name: Validate new issue
+        id: validate
         uses: actions/github-script@v7
         with:
           script: |
@@ -228,6 +229,25 @@ jobs:
             } else {
               console.log('Issue is valid. No action needed.');
             }
+            
+            // Expose whether the issue was auto-closed so later steps can
+            // skip issues that don't need a human to triage them.
+            core.setOutput('shouldClose', shouldClose ? 'true' : 'false');
+
+      - name: Add untriaged label
+        if: github.event.action == 'opened' && steps.validate.outputs.shouldClose != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Every new issue starts as "untriaged" unless it was auto-closed
+            // as invalid. A maintainer removes this label manually to confirm
+            // they have looked at the issue.
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['untriaged']
+            });
   
   apply-team-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Modifies the pre-triage validation workflow to auto-add the "untriaged" label to new issues. This steps runs after the step where the issue contents are validated, so that invalid issues are not labelled, and therefore won't appear in the triage queue.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

Add any extra information or context that reviewers may need to know. This could include testing instructions, screenshots, or links to related discussions.

---

Thank you for contributing to the Ubuntu Project documentation!

