### PR TITLE
Add per-label Matrix reports and approval filtering to queue report

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,45 @@
+# Weekly queue report
+
+**Files:** `.github/workflows/queue-report.yml` · `.github/scripts/queue-report.py`
+
+Runs every **Monday at 12:00 UTC** (and on demand via `workflow_dispatch`) to post a summary of the open issue and PR queues to Mattermost and Matrix.
+
+## What it reports
+
+Each row in the report table links to a pre-filtered GitHub view.
+
+| Category | GitHub filter query |
+|---|---|
+| ✅ Issues — triaged | `is:open is:issue label:triaged` |
+| ⚠️ Issues — untriaged | `is:open is:issue -label:triaged` |
+| 📝 Draft PRs | `is:open is:pr draft:true` |
+| 🕐 PRs older than 2 weeks | `is:open is:pr sort:created-asc` (oldest-first proxy) |
+| 👀 PRs awaiting review | `is:open is:pr review:required draft:false` |
+| ✅ PRs ready to merge | `is:open is:pr review:approved draft:false` |
+| 🔄 PRs with changes requested | `is:open is:pr review:changes_requested draft:false` |
+
+## Implementation
+
+The script uses only the Python standard library (no third-party packages).
+GitHub data is fetched via the GraphQL API. PRs are paginated in pages of 100.
+Three message formats are produced: Markdown (Mattermost), plain text and HTML
+(Matrix `body` / `formatted_body`). Either notification is silently skipped
+when its token or channel/room ID is absent.
+
+## Configuration
+
+### Secrets
+
+| Secret | Purpose |
+|---|---|
+| `MATTERMOST_TOKEN` | Mattermost bot-user token |
+| `MATTERMOST_CHANNEL_ID` | Mattermost channel ID |
+| `MATRIX_TOKEN` | Matrix access token |
+| `MATRIX_ROOM_ID` | Matrix room ID (e.g. `!abc123:ubuntu.com`) |
+
+### Variables (repo Settings → Variables)
+
+| Variable | Default |
+|---|---|
+| `MATTERMOST_URL` | `https://chat.canonical.com` |
+| `MATRIX_HOMESERVER` | `https://ubuntu.com` |

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -10,8 +10,8 @@ Each row in the report table links to a pre-filtered GitHub view.
 
 | Category | GitHub filter query |
 |---|---|
-| ✅ Issues — triaged | `is:open is:issue label:triaged` |
-| ⚠️ Issues — untriaged | `is:open is:issue -label:triaged` |
+| ✅ Issues — triaged | `is:open is:issue -label:untriaged` |
+| ⚠️ Issues — untriaged | `is:open is:issue label:untriaged` |
 | 📝 Draft PRs | `is:open is:pr draft:true` |
 | 🕐 PRs older than 2 weeks | `is:open is:pr sort:created-asc` (oldest-first proxy) |
 | 👀 PRs awaiting review | `is:open is:pr review:required draft:false` |

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -6,7 +6,13 @@ Runs every **Monday at 12:00 UTC** (and on demand via `workflow_dispatch`) to po
 
 ## What it reports
 
-Each row in the report table links to a pre-filtered GitHub view.
+The report comes in two kinds:
+
+1. **All-encompassing dashboard** — a counts table (triaged/untriaged issues; draft/old/unreviewed/approved/changes PRs), posted to the configured Mattermost channel and the main Matrix room (`MAIN_MATRIX_ALIAS`). Each row links to a pre-filtered GitHub view.
+
+2. **Per-label item reports** — for each label listed in `LABEL_ROUTES`, a report listing the actual issues and PRs carrying that label, posted to the label's Matrix room. Items with several routed labels appear in every matching room's report. Multiple labels may share one room (e.g. `Release team` and `AA` both post to `#release:ubuntu.com`); such a room receives a single combined report.
+
+### Dashboard categories
 
 | Category | GitHub filter query |
 |---|---|
@@ -18,13 +24,26 @@ Each row in the report table links to a pre-filtered GitHub view.
 | ✅ PRs ready to merge | `is:open is:pr review:approved draft:false` |
 | 🔄 PRs with changes requested | `is:open is:pr review:changes_requested draft:false` |
 
+### Label routing
+
+To add a new label→room pair, append one `LabelRoute(...)` line to `LABEL_ROUTES` in the script:
+
+```python
+LABEL_ROUTES: tuple[LabelRoute, ...] = (
+    LabelRoute("MIR", "#ubuntu-mir:ubuntu.com"),
+    # …add a new line here…
+)
+```
+
+Room IDs are resolved at runtime from their aliases (no per-room secrets).
+
 ## Implementation
 
 The script uses only the Python standard library (no third-party packages).
 GitHub data is fetched via the GraphQL API. PRs are paginated in pages of 100.
 Three message formats are produced: Markdown (Mattermost), plain text and HTML
-(Matrix `body` / `formatted_body`). Either notification is silently skipped
-when its token or channel/room ID is absent.
+(Matrix `body` / `formatted_body`). Notifications are silently skipped when
+their token is absent.
 
 ## Configuration
 
@@ -34,8 +53,10 @@ when its token or channel/room ID is absent.
 |---|---|
 | `MATTERMOST_TOKEN` | Mattermost bot-user token |
 | `MATTERMOST_CHANNEL_ID` | Mattermost channel ID |
-| `MATRIX_TOKEN` | Matrix access token |
-| `MATRIX_ROOM_ID` | Matrix room ID (e.g. `!abc123:ubuntu.com`) |
+| `MATRIX_TOKEN` | Matrix access token (used for all Matrix rooms) |
+
+Matrix room IDs are resolved at runtime from aliases defined in the script
+(`MAIN_MATRIX_ALIAS` / `LABEL_ROUTES`), so no per-room secrets are needed.
 
 ### Variables (repo Settings → Variables)
 

--- a/.github/scripts/queue-report.py
+++ b/.github/scripts/queue-report.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Weekly issue and PR queue report for ubuntu-project-docs.
+
+Fetches open-issue and open-PR statistics via the GitHub GraphQL API,
+formats a summary message, and posts it to Mattermost and Matrix.
+
+Environment variables:
+    GITHUB_TOKEN        (required) GitHub API token — auto-set in Actions.
+    GITHUB_REPOSITORY   (required) owner/repo slug — auto-set in Actions.
+
+    MATTERMOST_TOKEN       Bot-user token [secret]; notification skipped if absent.
+    MATTERMOST_CHANNEL_ID  Channel ID [secret]; notification skipped if absent.
+    MATTERMOST_URL         Base URL [var]; default: https://chat.canonical.com.
+
+    MATRIX_TOKEN           Access token [secret]; notification skipped if absent.
+    MATRIX_ROOM_ID         Room ID [secret]; notification skipped if absent.
+    MATRIX_HOMESERVER      Homeserver URL [var]; default: https://ubuntu.com.
+"""
+
+import json
+import os
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+TWO_WEEKS = timedelta(weeks=2)
+
+
+# ── Domain models ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class IssueStats:
+    """Counts of open issues by triage status."""
+
+    triaged: int
+    untriaged: int
+
+    @property
+    def total(self) -> int:
+        """Total open issue count."""
+        return self.triaged + self.untriaged
+
+
+@dataclass
+class PRStats:
+    """Counts of open pull requests by review/draft status."""
+
+    draft: int
+    old: int
+    unreviewed: int
+    approved: int
+    changes_requested: int
+    total: int
+
+
+@dataclass
+class Config:
+    """Runtime configuration loaded from environment variables."""
+
+    github_token: str
+    repo_slug: str
+    mattermost_token: str
+    mattermost_channel_id: str
+    mattermost_url: str
+    matrix_token: str
+    matrix_room_id: str
+    matrix_homeserver: str
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        """Load configuration from environment variables.
+
+        Returns:
+            Populated Config instance.
+
+        Raises:
+            KeyError: If GITHUB_TOKEN or GITHUB_REPOSITORY is not set.
+        """
+        return cls(
+            github_token=os.environ["GITHUB_TOKEN"],
+            repo_slug=os.environ["GITHUB_REPOSITORY"],
+            mattermost_token=os.environ.get("MATTERMOST_TOKEN", ""),
+            mattermost_channel_id=os.environ.get("MATTERMOST_CHANNEL_ID", ""),
+            mattermost_url=os.environ.get("MATTERMOST_URL") or "https://chat.canonical.com",
+            matrix_token=os.environ.get("MATRIX_TOKEN", ""),
+            matrix_room_id=os.environ.get("MATRIX_ROOM_ID", ""),
+            matrix_homeserver=os.environ.get("MATRIX_HOMESERVER") or "https://ubuntu.com",
+        )
+
+    @property
+    def owner(self) -> str:
+        """Repository owner extracted from the owner/repo slug."""
+        return self.repo_slug.split("/")[0]
+
+    @property
+    def repo(self) -> str:
+        """Repository name extracted from the owner/repo slug."""
+        return self.repo_slug.split("/")[1]
+
+    @property
+    def repo_url(self) -> str:
+        """Full GitHub URL for the repository."""
+        return f"https://github.com/{self.repo_slug}"
+
+
+# ── HTTP helper ────────────────────────────────────────────────────────────
+
+
+def _http_json_request(
+    url: str,
+    token: str,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> Any:
+    """Make an authenticated JSON HTTP request.
+
+    Args:
+        url: Full request URL.
+        token: Bearer token for the Authorization header.
+        method: HTTP method (GET, POST, PUT).
+        body: Optional JSON-serializable request body.
+
+    Returns:
+        Parsed JSON response.
+    """
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+# ── GitHub API ─────────────────────────────────────────────────────────────
+
+
+def _github_graphql(
+    token: str, query: str, variables: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Execute a GitHub GraphQL query and return the data field.
+
+    Args:
+        token: GitHub API token.
+        query: GraphQL query string.
+        variables: Optional query variables.
+
+    Returns:
+        The `data` portion of the GraphQL response.
+
+    Raises:
+        RuntimeError: If the API response contains errors.
+    """
+    result: dict[str, Any] = _http_json_request(
+        GRAPHQL_URL, token, "POST", {"query": query, "variables": variables or {}}
+    )
+    errors = result.get("errors")
+    if errors:
+        raise RuntimeError(f"GraphQL errors: {errors}")
+    return result["data"]
+
+
+def fetch_issue_stats(cfg: Config) -> IssueStats:
+    """Fetch counts of triaged and untriaged open issues.
+
+    Args:
+        cfg: Runtime configuration.
+
+    Returns:
+        IssueStats with triaged and untriaged counts.
+    """
+    query = """
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        allOpen: issues(states: OPEN) { totalCount }
+        triaged: issues(states: OPEN, filterBy: { labels: ["triaged"] }) { totalCount }
+      }
+    }
+    """
+    data = _github_graphql(cfg.github_token, query, {"owner": cfg.owner, "repo": cfg.repo})
+    triaged = data["repository"]["triaged"]["totalCount"]
+    total = data["repository"]["allOpen"]["totalCount"]
+    return IssueStats(triaged=triaged, untriaged=total - triaged)
+
+
+def _classify_pr(pr: dict[str, Any], cutoff: datetime) -> dict[str, int]:
+    """Return incremental category counts for a single open PR.
+
+    reviewDecision semantics:
+        APPROVED            All required reviewers have approved.
+        CHANGES_REQUESTED   At least one reviewer requested changes.
+        REVIEW_REQUIRED     At least one required reviewer hasn't reviewed yet.
+        None                No review rules apply — nothing blocking merge.
+
+    Draft PRs are counted only in the draft bucket; their review state is ignored.
+
+    Args:
+        pr: A pullRequests.nodes entry from the GitHub GraphQL response.
+        cutoff: Datetime before which a PR is considered older than 2 weeks.
+
+    Returns:
+        Dict of category increments (all keys present, zero if not matching).
+    """
+    counts: dict[str, int] = {
+        "draft": 0,
+        "old": 0,
+        "unreviewed": 0,
+        "approved": 0,
+        "changes_requested": 0,
+    }
+    created_at = datetime.fromisoformat(pr["createdAt"].replace("Z", "+00:00"))
+    if created_at < cutoff:
+        counts["old"] = 1
+
+    if pr["isDraft"]:
+        counts["draft"] = 1
+        return counts  # skip review-state classification for drafts
+
+    decision = pr["reviewDecision"]
+    if decision == "CHANGES_REQUESTED":
+        counts["changes_requested"] = 1
+    elif decision == "REVIEW_REQUIRED":
+        counts["unreviewed"] = 1
+    else:
+        # APPROVED or None (no required reviewers) — unblocked from a review perspective
+        counts["approved"] = 1
+
+    return counts
+
+
+def fetch_pr_stats(cfg: Config) -> PRStats:
+    """Fetch open PR counts by category, paginating through all open PRs.
+
+    Args:
+        cfg: Runtime configuration.
+
+    Returns:
+        PRStats with counts per status category.
+    """
+    query = """
+    query($owner: String!, $repo: String!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(states: OPEN, first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes { isDraft createdAt reviewDecision }
+        }
+      }
+    }
+    """
+    totals: dict[str, int] = {
+        "draft": 0,
+        "old": 0,
+        "unreviewed": 0,
+        "approved": 0,
+        "changes_requested": 0,
+        "total": 0,
+    }
+    cutoff = datetime.now(timezone.utc) - TWO_WEEKS
+    cursor: str | None = None
+
+    while True:
+        data = _github_graphql(
+            cfg.github_token, query, {"owner": cfg.owner, "repo": cfg.repo, "cursor": cursor}
+        )
+        page = data["repository"]["pullRequests"]
+        for pr in page["nodes"]:
+            totals["total"] += 1
+            for key, val in _classify_pr(pr, cutoff).items():
+                totals[key] += val
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+
+    return PRStats(**totals)
+
+
+# ── URL building ───────────────────────────────────────────────────────────
+
+
+def _issue_url(repo_url: str, extra: str) -> str:
+    return f"{repo_url}/issues?q={urllib.parse.quote_plus(f'is:open is:issue{extra}')}"
+
+
+def _pr_url(repo_url: str, extra: str) -> str:
+    return f"{repo_url}/pulls?q={urllib.parse.quote_plus(f'is:open is:pr{extra}')}"
+
+
+def build_filter_urls(repo_url: str) -> dict[str, str]:
+    """Build GitHub filter URLs for each report category.
+
+    Args:
+        repo_url: Base URL of the GitHub repository.
+
+    Returns:
+        Dict mapping category names to GitHub filter URLs.
+    """
+    return {
+        "triaged": _issue_url(repo_url, " label:triaged"),
+        "untriaged": _issue_url(repo_url, " -label:triaged"),
+        "draft": _pr_url(repo_url, " draft:true"),
+        # GitHub has no native age filter; sort oldest-first as a visual proxy.
+        "old": _pr_url(repo_url, " sort:created-asc"),
+        "unreviewed": _pr_url(repo_url, " review:required draft:false"),
+        "approved": _pr_url(repo_url, " review:approved draft:false"),
+        "changes_requested": _pr_url(repo_url, " review:changes_requested draft:false"),
+    }
+
+
+# ── Message formatting ─────────────────────────────────────────────────────
+
+
+def build_markdown(
+    issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str
+) -> str:
+    """Format the Markdown report message for Mattermost.
+
+    Args:
+        issues: Issue statistics.
+        prs: PR statistics.
+        urls: GitHub filter URLs keyed by category name.
+        repo_url: Repository URL used in the header link.
+
+    Returns:
+        Formatted Markdown string.
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return (
+        f"## 📋 Ubuntu Project Docs — Issue & PR Queue ({today})\n"
+        "\n"
+        "Weekly snapshot of open issues and pull requests"
+        f" in the [ubuntu-project-docs]({repo_url}) repository.\n"
+        "\n"
+        f"### 🐛 Issues ({issues.total} open)\n"
+        "\n"
+        "| Status | Count | GitHub filter |\n"
+        "|:--|--:|:--|\n"
+        f"| ✅ Triaged | **{issues.triaged}** | [view]({urls['triaged']}) |\n"
+        f"| ⚠️ Untriaged | **{issues.untriaged}** | [view]({urls['untriaged']}) |\n"
+        "\n"
+        f"### 🔀 Pull Requests ({prs.total} open)\n"
+        "\n"
+        "| Status | Count | GitHub filter |\n"
+        "|:--|--:|:--|\n"
+        f"| 📝 Draft | **{prs.draft}** | [view]({urls['draft']}) |\n"
+        f"| 🕐 Older than 2 weeks | **{prs.old}** | [view]({urls['old']}) |\n"
+        f"| 👀 Awaiting review | **{prs.unreviewed}** | [view]({urls['unreviewed']}) |\n"
+        f"| ✅ Ready to merge | **{prs.approved}** | [view]({urls['approved']}) |\n"
+        f"| 🔄 Changes requested | **{prs.changes_requested}** |"
+        f" [view]({urls['changes_requested']}) |\n"
+    )
+
+
+def build_plain_text(issues: IssueStats, prs: PRStats) -> str:
+    """Format a plain-text summary for the Matrix message body field.
+
+    The Matrix spec requires the `body` field to be plain text.
+    This function avoids all Markdown syntax so it renders correctly in
+    every Matrix client.
+
+    Args:
+        issues: Issue statistics.
+        prs: PR statistics.
+
+    Returns:
+        Formatted plain text string (no Markdown syntax).
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return (
+        f"📋 Ubuntu Project Docs — Issue & PR Queue ({today})\n"
+        "\n"
+        "Weekly snapshot of open issues and pull requests"
+        " in the ubuntu-project-docs repository.\n"
+        "\n"
+        f"🐛 Issues ({issues.total} open)\n"
+        f"  ✅ Triaged: {issues.triaged}\n"
+        f"  ⚠️ Untriaged: {issues.untriaged}\n"
+        "\n"
+        f"🔀 Pull Requests ({prs.total} open)\n"
+        f"  📝 Draft: {prs.draft}\n"
+        f"  🕐 Older than 2 weeks: {prs.old}\n"
+        f"  👀 Awaiting review: {prs.unreviewed}\n"
+        f"  ✅ Ready to merge: {prs.approved}\n"
+        f"  🔄 Changes requested: {prs.changes_requested}\n"
+    )
+
+
+def build_html(
+    issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str
+) -> str:
+    """Format the HTML report message for Matrix formatted_body.
+
+    Args:
+        issues: Issue statistics.
+        prs: PR statistics.
+        urls: GitHub filter URLs keyed by category name.
+        repo_url: Repository URL used in the header link.
+
+    Returns:
+        HTML string suitable for Matrix formatted_body.
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    def row(label: str, count: int, url: str) -> str:
+        return (
+            f"<tr><td>{label}</td>"
+            f"<td align='right'><strong>{count}</strong></td>"
+            f"<td><a href='{url}'>view</a></td></tr>"
+        )
+
+    table_head = "<table><thead><tr><th>Status</th><th>Count</th><th>GitHub filter</th></tr></thead><tbody>"
+    table_foot = "</tbody></table>"
+
+    return (
+        f"<h2>📋 Ubuntu Project Docs — Issue &amp; PR Queue ({today})</h2>"
+        f"<p>Weekly snapshot of open issues and pull requests in the"
+        f" <a href='{repo_url}'>ubuntu-project-docs</a> repository.</p>"
+        f"<h3>🐛 Issues ({issues.total} open)</h3>"
+        f"{table_head}"
+        f"{row('✅ Triaged', issues.triaged, urls['triaged'])}"
+        f"{row('⚠️ Untriaged', issues.untriaged, urls['untriaged'])}"
+        f"{table_foot}"
+        f"<h3>🔀 Pull Requests ({prs.total} open)</h3>"
+        f"{table_head}"
+        f"{row('📝 Draft', prs.draft, urls['draft'])}"
+        f"{row('🕐 Older than 2 weeks', prs.old, urls['old'])}"
+        f"{row('👀 Awaiting review', prs.unreviewed, urls['unreviewed'])}"
+        f"{row('✅ Ready to merge', prs.approved, urls['approved'])}"
+        f"{row('🔄 Changes requested', prs.changes_requested, urls['changes_requested'])}"
+        f"{table_foot}"
+    )
+
+
+# ── Mattermost ─────────────────────────────────────────────────────────────
+
+
+def _mm_api(cfg: Config, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+    """Call the Mattermost REST API."""
+    return _http_json_request(
+        f"{cfg.mattermost_url.rstrip('/')}/api/v4{path}", cfg.mattermost_token, method, body
+    )
+
+
+def send_mattermost(cfg: Config, message: str) -> None:
+    """Post a Markdown message to the configured Mattermost channel.
+
+    Args:
+        cfg: Runtime configuration.
+        message: Markdown-formatted message text.
+    """
+    if not cfg.mattermost_token or not cfg.mattermost_channel_id:
+        print("MATTERMOST_TOKEN or MATTERMOST_CHANNEL_ID not set — skipping Mattermost.")
+        return
+    _mm_api(cfg, "POST", "/posts", {"channel_id": cfg.mattermost_channel_id, "message": message})
+    print(f"✓ Sent to Mattermost channel '{cfg.mattermost_channel_id}'")
+
+
+# ── Matrix ─────────────────────────────────────────────────────────────────
+
+
+def _matrix_api(
+    cfg: Config, method: str, path: str, body: dict[str, Any] | None = None
+) -> Any:
+    """Call the Matrix client-server API."""
+    return _http_json_request(
+        f"{cfg.matrix_homeserver.rstrip('/')}{path}", cfg.matrix_token, method, body
+    )
+
+
+def send_matrix(cfg: Config, body_plain: str, body_html: str) -> None:
+    """Post a message to the configured Matrix room.
+
+    Sends with both a plain-text body and an HTML formatted_body as required
+    by the Matrix client-server specification (MSC1767 / m.room.message).
+
+    Args:
+        cfg: Runtime configuration.
+        body_plain: Plain text version of the message (no Markdown syntax).
+        body_html: HTML version of the message for clients that support it.
+    """
+    if not cfg.matrix_token or not cfg.matrix_room_id:
+        print("MATRIX_TOKEN or MATRIX_ROOM_ID not set — skipping Matrix.")
+        return
+    txn_id = int(time.time() * 1000)
+    _matrix_api(
+        cfg,
+        "PUT",
+        f"/_matrix/client/v3/rooms/{urllib.parse.quote(cfg.matrix_room_id)}/send/m.room.message/{txn_id}",
+        {
+            "msgtype": "m.text",
+            "body": body_plain,
+            "format": "org.matrix.custom.html",
+            "formatted_body": body_html,
+        },
+    )
+    print(f"✓ Sent to Matrix room '{cfg.matrix_room_id}'")
+
+
+# ── Entry point ────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    """Fetch queue stats, build the report, and send it to Mattermost and Matrix."""
+    cfg = Config.from_env()
+
+    print("Fetching issue counts…")
+    issues = fetch_issue_stats(cfg)
+    print(f"  Triaged: {issues.triaged}, Untriaged: {issues.untriaged}")
+
+    print("Fetching PR stats…")
+    prs = fetch_pr_stats(cfg)
+    print(
+        f"  Draft: {prs.draft}, Old (>2w): {prs.old}, "
+        f"Awaiting review: {prs.unreviewed}, "
+        f"Ready: {prs.approved}, Changes requested: {prs.changes_requested}"
+    )
+
+    urls = build_filter_urls(cfg.repo_url)
+    message_md = build_markdown(issues, prs, urls, cfg.repo_url)
+    message_plain = build_plain_text(issues, prs)
+    message_html = build_html(issues, prs, urls, cfg.repo_url)
+
+    print("\n── Message preview ──────────────────────────────────────────────")
+    print(message_md)
+    print("─────────────────────────────────────────────────────────────────\n")
+
+    send_mattermost(cfg, message_md)
+    send_matrix(cfg, message_plain, message_html)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/queue-report.py
+++ b/.github/scripts/queue-report.py
@@ -139,10 +139,12 @@ class Config:
             repo_slug=os.environ["GITHUB_REPOSITORY"],
             mattermost_token=os.environ.get("MATTERMOST_TOKEN", ""),
             mattermost_channel_id=os.environ.get("MATTERMOST_CHANNEL_ID", ""),
-            mattermost_url=os.environ.get("MATTERMOST_URL") or "https://chat.canonical.com",
+            mattermost_url=os.environ.get("MATTERMOST_URL")
+            or "https://chat.canonical.com",
             matrix_token=os.environ.get("MATRIX_TOKEN", ""),
             matrix_room_id=os.environ.get("MATRIX_ROOM_ID", ""),
-            matrix_homeserver=os.environ.get("MATRIX_HOMESERVER") or "https://ubuntu.com",
+            matrix_homeserver=os.environ.get("MATRIX_HOMESERVER")
+            or "https://ubuntu.com",
         )
 
     @property
@@ -236,14 +238,16 @@ def fetch_issue_stats(cfg: Config) -> IssueStats:
     query($owner: String!, $repo: String!) {
       repository(owner: $owner, name: $repo) {
         allOpen: issues(states: OPEN) { totalCount }
-        triaged: issues(states: OPEN, filterBy: { labels: ["triaged"] }) { totalCount }
+        untriaged: issues(states: OPEN, filterBy: { labels: ["untriaged"] }) { totalCount }
       }
     }
     """
-    data = _github_graphql(cfg.github_token, query, {"owner": cfg.owner, "repo": cfg.repo})
-    triaged = data["repository"]["triaged"]["totalCount"]
+    data = _github_graphql(
+        cfg.github_token, query, {"owner": cfg.owner, "repo": cfg.repo}
+    )
+    untriaged = data["repository"]["untriaged"]["totalCount"]
     total = data["repository"]["allOpen"]["totalCount"]
-    return IssueStats(triaged=triaged, untriaged=total - triaged)
+    return IssueStats(triaged=total - untriaged, untriaged=untriaged)
 
 
 def _classify_pr(pr: dict[str, Any], cutoff: datetime) -> dict[str, int]:
@@ -323,7 +327,9 @@ def fetch_pr_stats(cfg: Config) -> PRStats:
 
     while True:
         data = _github_graphql(
-            cfg.github_token, query, {"owner": cfg.owner, "repo": cfg.repo, "cursor": cursor}
+            cfg.github_token,
+            query,
+            {"owner": cfg.owner, "repo": cfg.repo, "cursor": cursor},
         )
         page = data["repository"]["pullRequests"]
         for pr in page["nodes"]:
@@ -358,8 +364,8 @@ def build_filter_urls(repo_url: str) -> dict[str, str]:
         Dict mapping category names to GitHub filter URLs.
     """
     return {
-        "triaged": _issue_url(repo_url, " label:triaged"),
-        "untriaged": _issue_url(repo_url, " -label:triaged"),
+        "triaged": _issue_url(repo_url, " -label:untriaged"),
+        "untriaged": _issue_url(repo_url, " label:untriaged"),
         "draft": _pr_url(repo_url, " draft:true"),
         # GitHub has no native age filter; sort oldest-first as a visual proxy.
         "old": _pr_url(repo_url, " sort:created-asc"),
@@ -377,7 +383,9 @@ def build_filter_urls(repo_url: str) -> dict[str, str]:
 # REPORT_* / *_ROWS constants.
 
 
-def build_report(issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str) -> Report:
+def build_report(
+    issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str
+) -> Report:
     """Assemble the report model from stats, using the module-level layout.
 
     Args:
@@ -492,10 +500,15 @@ def render_html(report: Report) -> str:
 # Mattermost
 
 
-def _mm_api(cfg: Config, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+def _mm_api(
+    cfg: Config, method: str, path: str, body: dict[str, Any] | None = None
+) -> Any:
     """Call the Mattermost REST API."""
     return _http_json_request(
-        f"{cfg.mattermost_url.rstrip('/')}/api/v4{path}", cfg.mattermost_token, method, body
+        f"{cfg.mattermost_url.rstrip('/')}/api/v4{path}",
+        cfg.mattermost_token,
+        method,
+        body,
     )
 
 
@@ -507,9 +520,16 @@ def send_mattermost(cfg: Config, message: str) -> None:
         message: Markdown-formatted message text.
     """
     if not cfg.mattermost_token or not cfg.mattermost_channel_id:
-        print("MATTERMOST_TOKEN or MATTERMOST_CHANNEL_ID not set — skipping Mattermost.")
+        print(
+            "MATTERMOST_TOKEN or MATTERMOST_CHANNEL_ID not set — skipping Mattermost."
+        )
         return
-    _mm_api(cfg, "POST", "/posts", {"channel_id": cfg.mattermost_channel_id, "message": message})
+    _mm_api(
+        cfg,
+        "POST",
+        "/posts",
+        {"channel_id": cfg.mattermost_channel_id, "message": message},
+    )
     print(f"✓ Sent to Mattermost channel '{cfg.mattermost_channel_id}'")
 
 

--- a/.github/scripts/queue-report.py
+++ b/.github/scripts/queue-report.py
@@ -12,20 +12,23 @@ Environment variables:
   MATTERMOST_CHANNEL_ID  Channel ID [secret]; notification skipped if absent.
   MATTERMOST_URL         Base URL [var]; default: https://chat.canonical.com.
 
-  MATRIX_TOKEN           Access token [secret]; notification skipped if absent.
-  MATRIX_ROOM_ID         Room ID [secret]; notification skipped if absent.
+  MATRIX_TOKEN           Access token [secret]; all Matrix notifications
+                        skipped if absent. Room IDs are resolved at runtime
+                        from aliases defined in MAIN_MATRIX_ALIAS / LABEL_ROUTES.
   MATRIX_HOMESERVER      Homeserver URL [var]; default: https://ubuntu.com.
 """
 
+import argparse
 import html
 import json
 import os
-import time
+import sys
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from uuid import uuid4
 
 GRAPHQL_URL = "https://api.github.com/graphql"
 TWO_WEEKS = timedelta(weeks=2)
@@ -53,6 +56,36 @@ PR_ROWS: tuple[tuple[str, str, str], ...] = (
     ("🔄 Changes requested", "changes_requested", "changes_requested"),
 )
 TABLE_COLUMNS = ("Status", "Count", "GitHub filter")
+
+# Matrix room alias for the all-encompassing (non-label) dashboard report.
+MAIN_MATRIX_ALIAS = "#ubuntu-devel:ubuntu.com"
+
+
+@dataclass(frozen=True)
+class LabelRoute:
+    """Maps a GitHub label to the Matrix room that should receive its report.
+
+    To add a new label→room pair, append one line to LABEL_ROUTES below.
+    """
+
+    label: str
+    matrix_alias: str
+
+
+# Label→Matrix-room routing table.
+#
+# Issues/PRs carrying a label are listed in a report sent to that label's
+# Matrix room. Items with several of these labels appear in every matching
+# room's report. Multiple labels may share one room (e.g. "Release team" and
+# "AA" both post to #release:ubuntu.com); in that case the room receives a
+# single combined report covering all its labels.
+LABEL_ROUTES: tuple[LabelRoute, ...] = (
+    LabelRoute("MIR", "#ubuntu-mir:ubuntu.com"),
+    LabelRoute("SRU", "#sru:ubuntu.com"),
+    LabelRoute("DMB", "#dmb:ubuntu.com"),
+    LabelRoute("Release team", "#release:ubuntu.com"),
+    LabelRoute("AA", "#release:ubuntu.com"),
+)
 
 
 # Domain models
@@ -93,22 +126,43 @@ class ReportRow:
 
 
 @dataclass
+class Item:
+    """A single issue or PR listed in a label report: number, title, URL."""
+
+    number: int
+    title: str
+    url: str
+
+
+@dataclass
 class ReportSection:
-    """A titled section of the report containing a table of rows."""
+    """A titled section of the report containing a table of count rows."""
 
     heading: str
     rows: list[ReportRow]
 
 
 @dataclass
+class ItemListSection:
+    """A titled section listing actual issues/PRs (for label reports)."""
+
+    heading: str
+    items: list[Item]
+
+
+@dataclass
 class Report:
-    """The full report as structured data — the single source of truth."""
+    """The full report as structured data — the single source of truth.
+
+    Sections may be count-table sections (ReportSection) or item-list
+    sections (ItemListSection); renderers branch on the type.
+    """
 
     title: str
     intro: str
     repo_url: str
     repo_name: str
-    sections: list[ReportSection] = field(default_factory=list)
+    sections: list[ReportSection | ItemListSection] = field(default_factory=list)
 
 
 @dataclass
@@ -121,19 +175,32 @@ class Config:
     mattermost_channel_id: str
     mattermost_url: str
     matrix_token: str
-    matrix_room_id: str
     matrix_homeserver: str
 
     @classmethod
     def from_env(cls) -> "Config":
         """Load configuration from environment variables.
 
+        Required variables (GITHUB_TOKEN, GITHUB_REPOSITORY) cause a clean
+        exit with a diagnostic message when absent, rather than a traceback.
+        All other variables are optional and default to empty strings.
+
         Returns:
             Populated Config instance.
-
-        Raises:
-            KeyError: If GITHUB_TOKEN or GITHUB_REPOSITORY is not set.
         """
+        missing = [
+            name
+            for name in ("GITHUB_TOKEN", "GITHUB_REPOSITORY")
+            if not os.environ.get(name)
+        ]
+        if missing:
+            print(
+                "Missing required environment variable(s): "
+                + ", ".join(missing)
+                + ". Aborting.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         return cls(
             github_token=os.environ["GITHUB_TOKEN"],
             repo_slug=os.environ["GITHUB_REPOSITORY"],
@@ -142,7 +209,6 @@ class Config:
             mattermost_url=os.environ.get("MATTERMOST_URL")
             or "https://chat.canonical.com",
             matrix_token=os.environ.get("MATRIX_TOKEN", ""),
-            matrix_room_id=os.environ.get("MATRIX_ROOM_ID", ""),
             matrix_homeserver=os.environ.get("MATRIX_HOMESERVER")
             or "https://ubuntu.com",
         )
@@ -343,6 +409,63 @@ def fetch_pr_stats(cfg: Config) -> PRStats:
     return PRStats(**totals)
 
 
+def fetch_labeled_items(cfg: Config, label: str) -> tuple[list[Item], list[Item]]:
+    """Fetch all open issues and PRs carrying ``label``.
+
+    Args:
+        cfg: Runtime configuration.
+        label: GitHub label name to filter by.
+
+    Returns:
+        (issues, prs) as lists of Item, each paginated through all results.
+    """
+    issue_query = """
+    query($owner: String!, $repo: String!, $label: String!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        issues(states: OPEN, first: 100, after: $cursor,
+               filterBy: { labels: [$label] }) {
+          pageInfo { hasNextPage endCursor }
+          nodes { number title url }
+        }
+      }
+    }
+    """
+    pr_query = """
+    query($owner: String!, $repo: String!, $label: String!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(states: OPEN, first: 100, after: $cursor,
+                     labels: [$label]) {
+          pageInfo { hasNextPage endCursor }
+          nodes { number title url }
+        }
+      }
+    }
+    """
+
+    def _collect(query: str, field: str) -> list[Item]:
+        items: list[Item] = []
+        cursor: str | None = None
+        while True:
+            data = _github_graphql(
+                cfg.github_token,
+                query,
+                {
+                    "owner": cfg.owner,
+                    "repo": cfg.repo,
+                    "label": label,
+                    "cursor": cursor,
+                },
+            )
+            page = data["repository"][field]
+            items += [Item(n["number"], n["title"], n["url"]) for n in page["nodes"]]
+            if not page["pageInfo"]["hasNextPage"]:
+                break
+            cursor = page["pageInfo"]["endCursor"]
+        return items
+
+    return _collect(issue_query, "issues"), _collect(pr_query, "pullRequests")
+
+
 # URL building
 
 
@@ -377,16 +500,16 @@ def build_filter_urls(repo_url: str) -> dict[str, str]:
 
 # Message formatting
 #
-# The report is assembled once as a Report model (build_report), then each
-# renderer below turns that same model into a specific output format. Message
-# content — titles, labels, section order — is defined once in the module-level
-# REPORT_* / *_ROWS constants.
+# The report is assembled once as a Report model (build_report /
+# build_label_report), then each renderer below turns that same model into a
+# specific output format. Message content — titles, labels, section order — is
+# defined once in the module-level REPORT_* / *_ROWS constants.
 
 
 def build_report(
     issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str
 ) -> Report:
-    """Assemble the report model from stats, using the module-level layout.
+    """Assemble the dashboard report model from stats, using the module-level layout.
 
     Args:
         issues: Issue statistics.
@@ -416,6 +539,53 @@ def build_report(
     )
 
 
+def build_label_report(
+    alias: str,
+    labels: list[str],
+    items_by_label: dict[str, tuple[list[Item], list[Item]]],
+    repo_url: str,
+) -> Report:
+    """Assemble a per-room label report listing actual issues/PRs.
+
+    For single-label rooms, section headings omit the label name (it is
+    already in the report title). For rooms fed by several labels, each
+    label gets its own sub-heading so the audience can tell them apart.
+
+    Args:
+        alias: Matrix room alias (e.g. "#release:ubuntu.com").
+        labels: Labels routed to this room, in LABEL_ROUTES order.
+        items_by_label: {label: (issues, prs)} fetched items per label.
+        repo_url: Repository URL used in the header link.
+
+    Returns:
+        A Report whose sections are ItemListSections.
+    """
+    room_name = alias.lstrip("#").split(":")[0]
+    multi = len(labels) > 1
+    title = f"🏷️ Ubuntu Project Docs — {room_name} queue"
+    label_names = " or ".join(f"`{lbl}`" for lbl in labels)
+    intro = f"Items labeled {label_names} in the {{repo_link}} repo."
+
+    sections: list[ReportSection | ItemListSection] = []
+    for label in labels:
+        issues, prs = items_by_label[label]
+        prefix = f"{label}: " if multi else ""
+        sections.append(
+            ItemListSection(heading=f"🐛 Issues — {prefix}{len(issues)}", items=issues)
+        )
+        sections.append(
+            ItemListSection(heading=f"🔀 Pull Requests — {prefix}{len(prs)}", items=prs)
+        )
+
+    return Report(
+        title=title,
+        intro=intro,
+        repo_url=repo_url,
+        repo_name=REPORT_REPO_NAME,
+        sections=sections,
+    )
+
+
 def render_markdown(report: Report) -> str:
     """Render the report as Markdown for Mattermost.
 
@@ -435,9 +605,17 @@ def render_markdown(report: Report) -> str:
     header = f"| {' | '.join(TABLE_COLUMNS)} |"
     divider = "|:--|--:|---|"
     for section in report.sections:
-        lines += ["", f"### {section.heading}", "", header, divider]
-        for r in section.rows:
-            lines.append(f"| {r.label} | **{r.count}** | [view]({r.url}) |")
+        lines += ["", f"### {section.heading}", ""]
+        if isinstance(section, ItemListSection):
+            if section.items:
+                for it in section.items:
+                    lines.append(f"- [#{it.number}]({it.url}) {it.title}")
+            else:
+                lines.append("_(none)_")
+        else:
+            lines += [header, divider]
+            for r in section.rows:
+                lines.append(f"| {r.label} | **{r.count}** | [view]({r.url}) |")
     return "\n".join(lines) + "\n"
 
 
@@ -461,8 +639,15 @@ def render_plain_text(report: Report) -> str:
     ]
     for section in report.sections:
         lines += ["", section.heading]
-        for r in section.rows:
-            lines.append(f"  {r.label}: {r.count}")
+        if isinstance(section, ItemListSection):
+            if section.items:
+                for it in section.items:
+                    lines.append(f"  #{it.number} — {it.title}")
+            else:
+                lines.append("  (none)")
+        else:
+            for r in section.rows:
+                lines.append(f"  {r.label}: {r.count}")
     return "\n".join(lines) + "\n"
 
 
@@ -486,14 +671,26 @@ def render_html(report: Report) -> str:
     table_foot = "</tbody></table>"
     for section in report.sections:
         parts.append(f"<h3>{html.escape(section.heading)}</h3>")
-        parts.append(table_head)
-        for r in section.rows:
-            parts.append(
-                f"<tr><td>{html.escape(r.label)}</td>"
-                f"<td align='right'><strong>{r.count}</strong></td>"
-                f"<td><a href='{r.url}'>view</a></td></tr>"
-            )
-        parts.append(table_foot)
+        if isinstance(section, ItemListSection):
+            if section.items:
+                parts.append("<ul>")
+                for it in section.items:
+                    parts.append(
+                        f"<li><a href='{it.url}'>#{it.number}</a> "
+                        f"{html.escape(it.title)}</li>"
+                    )
+                parts.append("</ul>")
+            else:
+                parts.append("<p><em>(none)</em></p>")
+        else:
+            parts.append(table_head)
+            for r in section.rows:
+                parts.append(
+                    f"<tr><td>{html.escape(r.label)}</td>"
+                    f"<td align='right'><strong>{r.count}</strong></td>"
+                    f"<td><a href='{r.url}'>view</a></td></tr>"
+                )
+            parts.append(table_foot)
     return "".join(parts)
 
 
@@ -545,25 +742,50 @@ def _matrix_api(
     )
 
 
-def send_matrix(cfg: Config, body_plain: str, body_html: str) -> None:
-    """Post a message to the configured Matrix room.
+def resolve_matrix_alias(cfg: Config, alias: str) -> str:
+    """Resolve a Matrix room alias to its room ID via the directory API.
+
+    Args:
+        cfg: Runtime configuration.
+        alias: Matrix room alias, e.g. "#ubuntu-devel:ubuntu.com".
+
+    Returns:
+        Room ID string, e.g. "!abc123:ubuntu.com".
+
+    Raises:
+        RuntimeError: If the response does not contain a room_id.
+    """
+    data = _matrix_api(
+        cfg,
+        "GET",
+        f"/_matrix/client/v3/directory/room/{urllib.parse.quote(alias, safe='')}",
+    )
+    room_id = data.get("room_id")
+    if not room_id:
+        raise RuntimeError(f"Could not resolve Matrix alias '{alias}'")
+    return room_id
+
+
+def send_matrix(cfg: Config, room_id: str, body_plain: str, body_html: str) -> None:
+    """Post a message to a Matrix room.
 
     Sends with both a plain-text body and an HTML formatted_body as required
     by the Matrix client-server specification (MSC1767 / m.room.message).
 
     Args:
         cfg: Runtime configuration.
+        room_id: Matrix room ID (e.g. "!abc123:ubuntu.com").
         body_plain: Plain text version of the message (no Markdown syntax).
         body_html: HTML version of the message for clients that support it.
     """
-    if not cfg.matrix_token or not cfg.matrix_room_id:
-        print("MATRIX_TOKEN or MATRIX_ROOM_ID not set — skipping Matrix.")
+    if not cfg.matrix_token:
+        print("MATRIX_TOKEN not set — skipping Matrix.")
         return
-    txn_id = int(time.time() * 1000)
+    txn_id = uuid4().hex
     _matrix_api(
         cfg,
         "PUT",
-        f"/_matrix/client/v3/rooms/{urllib.parse.quote(cfg.matrix_room_id)}/send/m.room.message/{txn_id}",
+        f"/_matrix/client/v3/rooms/{urllib.parse.quote(room_id)}/send/m.room.message/{txn_id}",
         {
             "msgtype": "m.text",
             "body": body_plain,
@@ -571,14 +793,32 @@ def send_matrix(cfg: Config, body_plain: str, body_html: str) -> None:
             "formatted_body": body_html,
         },
     )
-    print(f"✓ Sent to Matrix room '{cfg.matrix_room_id}'")
+    print(f"✓ Sent to Matrix room '{room_id}'")
 
 
 # Entry point
 
 
 def main() -> None:
-    """Fetch queue stats, build the report, and send it to Mattermost and Matrix."""
+    """Fetch queue stats, build reports, and send them to Mattermost and Matrix.
+
+    The all-encompassing dashboard is posted to the configured Mattermost
+    channel and the main Matrix room (MAIN_MATRIX_ALIAS). Then, for each
+    label→room route in LABEL_ROUTES, a per-label item list is posted to the
+    matching Matrix room (one combined report per destination room).
+
+    With ``--preview`` all reports are built and printed to stdout but no
+    messages are sent.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--preview",
+        action="store_true",
+        help="Build and print all reports without sending any messages.",
+    )
+    args = parser.parse_args()
+    preview = args.preview
+
     cfg = Config.from_env()
 
     print("Fetching issue counts…")
@@ -599,12 +839,59 @@ def main() -> None:
     message_plain = render_plain_text(report)
     message_html = render_html(report)
 
-    print("\n── Message preview ──────────────────────────────────────────────")
+    print("\n── Dashboard ───────────────────────────────────────────────────")
     print(message_md)
     print("─────────────────────────────────────────────────────────────────\n")
 
-    send_mattermost(cfg, message_md)
-    send_matrix(cfg, message_plain, message_html)
+    if not preview:
+        send_mattermost(cfg, message_md)
+
+    # Group labels by destination room (preserving LABEL_ROUTES order).
+    rooms: dict[str, list[str]] = {}
+    for route in LABEL_ROUTES:
+        rooms.setdefault(route.matrix_alias, []).append(route.label)
+
+    # Fetch + build + print every per-label report (always).
+    label_reports: list[tuple[str, str, str, str]] = []  # (alias, plain, html, md)
+    for alias, labels in rooms.items():
+        print(f"\nBuilding report for '{alias}' ({', '.join(labels)})…")
+        items_by_label: dict[str, tuple[list[Item], list[Item]]] = {}
+        for label in labels:
+            issues_l, prs_l = fetch_labeled_items(cfg, label)
+            print(f"  {label}: {len(issues_l)} issues, {len(prs_l)} PRs")
+            items_by_label[label] = (issues_l, prs_l)
+        label_report = build_label_report(alias, labels, items_by_label, cfg.repo_url)
+        lr_md = render_markdown(label_report)
+        lr_plain = render_plain_text(label_report)
+        lr_html = render_html(label_report)
+        print(f"\n── {alias} ──────────────────────────────────────────────────")
+        print(lr_md)
+        print("─────────────────────────────────────────────────────────────────\n")
+        label_reports.append((alias, lr_plain, lr_html, lr_md))
+
+    if preview:
+        print("Preview mode — no messages sent. Done.")
+        return
+
+    # Resolve every Matrix room alias once (main room + label rooms).
+    aliases = {MAIN_MATRIX_ALIAS} | set(rooms)
+    room_ids: dict[str, str] = {}
+    if cfg.matrix_token:
+        for alias in sorted(aliases):
+            try:
+                room_ids[alias] = resolve_matrix_alias(cfg, alias)
+            except (RuntimeError, OSError) as exc:
+                print(f"⚠ Could not resolve Matrix alias '{alias}': {exc}")
+
+    # All-encompassing dashboard → main Matrix room.
+    if MAIN_MATRIX_ALIAS in room_ids:
+        send_matrix(cfg, room_ids[MAIN_MATRIX_ALIAS], message_plain, message_html)
+
+    # Per-label reports → routed Matrix rooms.
+    for alias, lr_plain, lr_html, _ in label_reports:
+        if alias in room_ids:
+            send_matrix(cfg, room_ids[alias], lr_plain, lr_html)
+
     print("Done.")
 
 

--- a/.github/scripts/queue-report.py
+++ b/.github/scripts/queue-report.py
@@ -5,32 +5,57 @@ Fetches open-issue and open-PR statistics via the GitHub GraphQL API,
 formats a summary message, and posts it to Mattermost and Matrix.
 
 Environment variables:
-    GITHUB_TOKEN        (required) GitHub API token — auto-set in Actions.
-    GITHUB_REPOSITORY   (required) owner/repo slug — auto-set in Actions.
+  GITHUB_TOKEN        (required) GitHub API token — auto-set in Actions.
+  GITHUB_REPOSITORY   (required) owner/repo slug — auto-set in Actions.
 
-    MATTERMOST_TOKEN       Bot-user token [secret]; notification skipped if absent.
-    MATTERMOST_CHANNEL_ID  Channel ID [secret]; notification skipped if absent.
-    MATTERMOST_URL         Base URL [var]; default: https://chat.canonical.com.
+  MATTERMOST_TOKEN       Bot-user token [secret]; notif. skipped if absent.
+  MATTERMOST_CHANNEL_ID  Channel ID [secret]; notification skipped if absent.
+  MATTERMOST_URL         Base URL [var]; default: https://chat.canonical.com.
 
-    MATRIX_TOKEN           Access token [secret]; notification skipped if absent.
-    MATRIX_ROOM_ID         Room ID [secret]; notification skipped if absent.
-    MATRIX_HOMESERVER      Homeserver URL [var]; default: https://ubuntu.com.
+  MATRIX_TOKEN           Access token [secret]; notification skipped if absent.
+  MATRIX_ROOM_ID         Room ID [secret]; notification skipped if absent.
+  MATRIX_HOMESERVER      Homeserver URL [var]; default: https://ubuntu.com.
 """
 
+import html
 import json
 import os
 import time
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 GRAPHQL_URL = "https://api.github.com/graphql"
 TWO_WEEKS = timedelta(weeks=2)
 
+# Report structure — the single source of truth for message content.
+#
+# Each format (Markdown, plain text, HTML) is rendered from this one
+# definition, so labels, order, and columns only ever need editing here.
+# ``{count}`` and ``{url}`` are filled in per row when the report is built.
+REPORT_TITLE = "📋 Ubuntu Project Docs — Issue & PR Queue"
+REPORT_INTRO = "Weekly snapshot of issues and PRs in the {repo_link} repo."
+REPORT_REPO_NAME = "ubuntu-project-docs"
 
-# ── Domain models ──────────────────────────────────────────────────────────
+# Per-section row definitions: (label, stats-attribute, filter-URL key).
+# The stats attribute is read from the IssueStats / PRStats instance.
+ISSUE_ROWS: tuple[tuple[str, str, str], ...] = (
+    ("✅ Triaged", "triaged", "triaged"),
+    ("⚠️ Untriaged", "untriaged", "untriaged"),
+)
+PR_ROWS: tuple[tuple[str, str, str], ...] = (
+    ("📝 Draft", "draft", "draft"),
+    ("🕐 Older than 2 weeks", "old", "old"),
+    ("👀 Awaiting review", "unreviewed", "unreviewed"),
+    ("✅ Ready to merge", "approved", "approved"),
+    ("🔄 Changes requested", "changes_requested", "changes_requested"),
+)
+TABLE_COLUMNS = ("Status", "Count", "GitHub filter")
+
+
+# Domain models
 
 
 @dataclass
@@ -56,6 +81,34 @@ class PRStats:
     approved: int
     changes_requested: int
     total: int
+
+
+@dataclass
+class ReportRow:
+    """A single row of a report section: a label, a count, and a filter URL."""
+
+    label: str
+    count: int
+    url: str
+
+
+@dataclass
+class ReportSection:
+    """A titled section of the report containing a table of rows."""
+
+    heading: str
+    rows: list[ReportRow]
+
+
+@dataclass
+class Report:
+    """The full report as structured data — the single source of truth."""
+
+    title: str
+    intro: str
+    repo_url: str
+    repo_name: str
+    sections: list[ReportSection] = field(default_factory=list)
 
 
 @dataclass
@@ -108,7 +161,7 @@ class Config:
         return f"https://github.com/{self.repo_slug}"
 
 
-# ── HTTP helper ────────────────────────────────────────────────────────────
+# HTTP helper
 
 
 def _http_json_request(
@@ -142,7 +195,7 @@ def _http_json_request(
         return json.loads(resp.read())
 
 
-# ── GitHub API ─────────────────────────────────────────────────────────────
+# GitHub API
 
 
 def _github_graphql(
@@ -202,7 +255,7 @@ def _classify_pr(pr: dict[str, Any], cutoff: datetime) -> dict[str, int]:
         REVIEW_REQUIRED     At least one required reviewer hasn't reviewed yet.
         None                No review rules apply — nothing blocking merge.
 
-    Draft PRs are counted only in the draft bucket; their review state is ignored.
+    Draft PRs are counted only in the draft bucket; review state is ignored.
 
     Args:
         pr: A pullRequests.nodes entry from the GitHub GraphQL response.
@@ -232,7 +285,7 @@ def _classify_pr(pr: dict[str, Any], cutoff: datetime) -> dict[str, int]:
     elif decision == "REVIEW_REQUIRED":
         counts["unreviewed"] = 1
     else:
-        # APPROVED or None (no required reviewers) — unblocked from a review perspective
+        # APPR'D or None (no req. reviews) — unblocked from a review persp.
         counts["approved"] = 1
 
     return counts
@@ -284,7 +337,7 @@ def fetch_pr_stats(cfg: Config) -> PRStats:
     return PRStats(**totals)
 
 
-# ── URL building ───────────────────────────────────────────────────────────
+# URL building
 
 
 def _issue_url(repo_url: str, extra: str) -> str:
@@ -316,131 +369,127 @@ def build_filter_urls(repo_url: str) -> dict[str, str]:
     }
 
 
-# ── Message formatting ─────────────────────────────────────────────────────
+# Message formatting
+#
+# The report is assembled once as a Report model (build_report), then each
+# renderer below turns that same model into a specific output format. Message
+# content — titles, labels, section order — is defined once in the module-level
+# REPORT_* / *_ROWS constants.
 
 
-def build_markdown(
-    issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str
-) -> str:
-    """Format the Markdown report message for Mattermost.
+def build_report(issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str) -> Report:
+    """Assemble the report model from stats, using the module-level layout.
 
     Args:
         issues: Issue statistics.
         prs: PR statistics.
         urls: GitHub filter URLs keyed by category name.
         repo_url: Repository URL used in the header link.
+
+    Returns:
+        A fully populated Report ready to be rendered into any format.
+    """
+
+    def rows(stats: Any, spec: tuple[tuple[str, str, str], ...]) -> list[ReportRow]:
+        return [
+            ReportRow(label=label, count=getattr(stats, attr), url=urls[url_key])
+            for label, attr, url_key in spec
+        ]
+
+    return Report(
+        title=REPORT_TITLE,
+        intro=REPORT_INTRO,
+        repo_url=repo_url,
+        repo_name=REPORT_REPO_NAME,
+        sections=[
+            ReportSection(f"🐛 Issues ({issues.total} open)", rows(issues, ISSUE_ROWS)),
+            ReportSection(f"🔀 Pull Requests ({prs.total} open)", rows(prs, PR_ROWS)),
+        ],
+    )
+
+
+def render_markdown(report: Report) -> str:
+    """Render the report as Markdown for Mattermost.
+
+    Args:
+        report: The report model.
 
     Returns:
         Formatted Markdown string.
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    return (
-        f"## 📋 Ubuntu Project Docs — Issue & PR Queue ({today})\n"
-        "\n"
-        "Weekly snapshot of open issues and pull requests"
-        f" in the [ubuntu-project-docs]({repo_url}) repository.\n"
-        "\n"
-        f"### 🐛 Issues ({issues.total} open)\n"
-        "\n"
-        "| Status | Count | GitHub filter |\n"
-        "|:--|--:|:--|\n"
-        f"| ✅ Triaged | **{issues.triaged}** | [view]({urls['triaged']}) |\n"
-        f"| ⚠️ Untriaged | **{issues.untriaged}** | [view]({urls['untriaged']}) |\n"
-        "\n"
-        f"### 🔀 Pull Requests ({prs.total} open)\n"
-        "\n"
-        "| Status | Count | GitHub filter |\n"
-        "|:--|--:|:--|\n"
-        f"| 📝 Draft | **{prs.draft}** | [view]({urls['draft']}) |\n"
-        f"| 🕐 Older than 2 weeks | **{prs.old}** | [view]({urls['old']}) |\n"
-        f"| 👀 Awaiting review | **{prs.unreviewed}** | [view]({urls['unreviewed']}) |\n"
-        f"| ✅ Ready to merge | **{prs.approved}** | [view]({urls['approved']}) |\n"
-        f"| 🔄 Changes requested | **{prs.changes_requested}** |"
-        f" [view]({urls['changes_requested']}) |\n"
-    )
+    repo_link = f"[{report.repo_name}]({report.repo_url})"
+    lines = [
+        f"## {report.title} ({today})",
+        "",
+        report.intro.format(repo_link=repo_link),
+    ]
+    header = f"| {' | '.join(TABLE_COLUMNS)} |"
+    divider = "|:--|--:|---|"
+    for section in report.sections:
+        lines += ["", f"### {section.heading}", "", header, divider]
+        for r in section.rows:
+            lines.append(f"| {r.label} | **{r.count}** | [view]({r.url}) |")
+    return "\n".join(lines) + "\n"
 
 
-def build_plain_text(issues: IssueStats, prs: PRStats) -> str:
-    """Format a plain-text summary for the Matrix message body field.
+def render_plain_text(report: Report) -> str:
+    """Render the report as plain text for the Matrix message body field.
 
-    The Matrix spec requires the `body` field to be plain text.
-    This function avoids all Markdown syntax so it renders correctly in
-    every Matrix client.
+    The Matrix spec requires the `body` field to be plain text, so this
+    avoids all Markdown syntax and renders correctly in every Matrix client.
 
     Args:
-        issues: Issue statistics.
-        prs: PR statistics.
+        report: The report model.
 
     Returns:
         Formatted plain text string (no Markdown syntax).
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    return (
-        f"📋 Ubuntu Project Docs — Issue & PR Queue ({today})\n"
-        "\n"
-        "Weekly snapshot of open issues and pull requests"
-        " in the ubuntu-project-docs repository.\n"
-        "\n"
-        f"🐛 Issues ({issues.total} open)\n"
-        f"  ✅ Triaged: {issues.triaged}\n"
-        f"  ⚠️ Untriaged: {issues.untriaged}\n"
-        "\n"
-        f"🔀 Pull Requests ({prs.total} open)\n"
-        f"  📝 Draft: {prs.draft}\n"
-        f"  🕐 Older than 2 weeks: {prs.old}\n"
-        f"  👀 Awaiting review: {prs.unreviewed}\n"
-        f"  ✅ Ready to merge: {prs.approved}\n"
-        f"  🔄 Changes requested: {prs.changes_requested}\n"
-    )
+    lines = [
+        f"{report.title} ({today})",
+        "",
+        report.intro.format(repo_link=report.repo_name),
+    ]
+    for section in report.sections:
+        lines += ["", section.heading]
+        for r in section.rows:
+            lines.append(f"  {r.label}: {r.count}")
+    return "\n".join(lines) + "\n"
 
 
-def build_html(
-    issues: IssueStats, prs: PRStats, urls: dict[str, str], repo_url: str
-) -> str:
-    """Format the HTML report message for Matrix formatted_body.
+def render_html(report: Report) -> str:
+    """Render the report as HTML for the Matrix formatted_body field.
 
     Args:
-        issues: Issue statistics.
-        prs: PR statistics.
-        urls: GitHub filter URLs keyed by category name.
-        repo_url: Repository URL used in the header link.
+        report: The report model.
 
     Returns:
         HTML string suitable for Matrix formatted_body.
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-
-    def row(label: str, count: int, url: str) -> str:
-        return (
-            f"<tr><td>{label}</td>"
-            f"<td align='right'><strong>{count}</strong></td>"
-            f"<td><a href='{url}'>view</a></td></tr>"
-        )
-
-    table_head = "<table><thead><tr><th>Status</th><th>Count</th><th>GitHub filter</th></tr></thead><tbody>"
+    repo_link = f"<a href='{report.repo_url}'>{html.escape(report.repo_name)}</a>"
+    parts = [
+        f"<h2>{html.escape(f'{report.title} ({today})')}</h2>",
+        f"<p>{html.escape(report.intro).format(repo_link=repo_link)}</p>",
+    ]
+    header_cells = "".join(f"<th>{html.escape(c)}</th>" for c in TABLE_COLUMNS)
+    table_head = f"<table><thead><tr>{header_cells}</tr></thead><tbody>"
     table_foot = "</tbody></table>"
-
-    return (
-        f"<h2>📋 Ubuntu Project Docs — Issue &amp; PR Queue ({today})</h2>"
-        f"<p>Weekly snapshot of open issues and pull requests in the"
-        f" <a href='{repo_url}'>ubuntu-project-docs</a> repository.</p>"
-        f"<h3>🐛 Issues ({issues.total} open)</h3>"
-        f"{table_head}"
-        f"{row('✅ Triaged', issues.triaged, urls['triaged'])}"
-        f"{row('⚠️ Untriaged', issues.untriaged, urls['untriaged'])}"
-        f"{table_foot}"
-        f"<h3>🔀 Pull Requests ({prs.total} open)</h3>"
-        f"{table_head}"
-        f"{row('📝 Draft', prs.draft, urls['draft'])}"
-        f"{row('🕐 Older than 2 weeks', prs.old, urls['old'])}"
-        f"{row('👀 Awaiting review', prs.unreviewed, urls['unreviewed'])}"
-        f"{row('✅ Ready to merge', prs.approved, urls['approved'])}"
-        f"{row('🔄 Changes requested', prs.changes_requested, urls['changes_requested'])}"
-        f"{table_foot}"
-    )
+    for section in report.sections:
+        parts.append(f"<h3>{html.escape(section.heading)}</h3>")
+        parts.append(table_head)
+        for r in section.rows:
+            parts.append(
+                f"<tr><td>{html.escape(r.label)}</td>"
+                f"<td align='right'><strong>{r.count}</strong></td>"
+                f"<td><a href='{r.url}'>view</a></td></tr>"
+            )
+        parts.append(table_foot)
+    return "".join(parts)
 
 
-# ── Mattermost ─────────────────────────────────────────────────────────────
+# Mattermost
 
 
 def _mm_api(cfg: Config, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
@@ -464,7 +513,7 @@ def send_mattermost(cfg: Config, message: str) -> None:
     print(f"✓ Sent to Mattermost channel '{cfg.mattermost_channel_id}'")
 
 
-# ── Matrix ─────────────────────────────────────────────────────────────────
+# Matrix
 
 
 def _matrix_api(
@@ -505,7 +554,7 @@ def send_matrix(cfg: Config, body_plain: str, body_html: str) -> None:
     print(f"✓ Sent to Matrix room '{cfg.matrix_room_id}'")
 
 
-# ── Entry point ────────────────────────────────────────────────────────────
+# Entry point
 
 
 def main() -> None:
@@ -525,9 +574,10 @@ def main() -> None:
     )
 
     urls = build_filter_urls(cfg.repo_url)
-    message_md = build_markdown(issues, prs, urls, cfg.repo_url)
-    message_plain = build_plain_text(issues, prs)
-    message_html = build_html(issues, prs, urls, cfg.repo_url)
+    report = build_report(issues, prs, urls, cfg.repo_url)
+    message_md = render_markdown(report)
+    message_plain = render_plain_text(report)
+    message_html = render_html(report)
 
     print("\n── Message preview ──────────────────────────────────────────────")
     print(message_md)

--- a/.github/workflows/queue-report.yml
+++ b/.github/workflows/queue-report.yml
@@ -1,0 +1,40 @@
+name: Weekly Issue & PR Queue Report
+
+# Runs every Monday at 12:00 UTC and can also be triggered manually.
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  queue-report:
+    name: Generate and send queue report
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run queue report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Mattermost — set both as repo secrets.
+          # MATTERMOST_URL can be overridden as a repo variable if needed.
+          MATTERMOST_TOKEN: ${{ secrets.MATTERMOST_TOKEN }}
+          MATTERMOST_CHANNEL_ID: ${{ secrets.MATTERMOST_CHANNEL_ID }}
+          MATTERMOST_URL: ${{ vars.MATTERMOST_URL }}
+          # Matrix — set both as repo secrets.
+          # MATRIX_HOMESERVER can be overridden as a repo variable if needed.
+          MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
+          MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
+          MATRIX_HOMESERVER: ${{ vars.MATRIX_HOMESERVER }}
+        run: python .github/scripts/queue-report.py

--- a/.github/workflows/queue-report.yml
+++ b/.github/workflows/queue-report.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   queue-report:
     name: Generate and send queue report
+    environment: 'IM notifications'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/queue-report.yml
+++ b/.github/workflows/queue-report.yml
@@ -33,9 +33,10 @@ jobs:
           MATTERMOST_TOKEN: ${{ secrets.MATTERMOST_TOKEN }}
           MATTERMOST_CHANNEL_ID: ${{ secrets.MATTERMOST_CHANNEL_ID }}
           MATTERMOST_URL: ${{ vars.MATTERMOST_URL }}
-          # Matrix — set both as repo secrets.
-          # MATRIX_HOMESERVER can be overridden as a repo variable if needed.
+          # Matrix — set the token as a repo secret.
+          # Room IDs are resolved at runtime from aliases defined in the script
+          # (MAIN_MATRIX_ALIAS / LABEL_ROUTES). MATRIX_HOMESERVER can be
+          # overridden as a repo variable if needed.
           MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
-          MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
           MATRIX_HOMESERVER: ${{ vars.MATRIX_HOMESERVER }}
         run: python .github/scripts/queue-report.py


### PR DESCRIPTION
Follow-up to #497 (merged). Extends the queue-report script with:

- Per-label Matrix reports: items carrying a routed label are listed in a report sent to that label's Matrix room (MIR, SRU, DMB, Release team, AA)
- `LABEL_ROUTES` routing table — adding a label→room pair is one line
- Matrix room IDs resolved at runtime from aliases (no per-room secrets)
- `--preview` flag for local testing without sending messages
- Approval filtering: PRs already approved by a team member (parsed from `.github/CODEOWNERS`) are omitted from that team's report