### PR TITLE
Exclude MIR team from label reports

### DIFF
--- a/.github/scripts/queue-report.py
+++ b/.github/scripts/queue-report.py
@@ -81,7 +81,7 @@ class LabelRoute:
 # "AA" both post to #release:ubuntu.com); in that case the room receives a
 # single combined report covering all its labels.
 LABEL_ROUTES: tuple[LabelRoute, ...] = (
-    LabelRoute("MIR", "#ubuntu-mir:ubuntu.com"),
+    # LabelRoute("MIR", "#ubuntu-mir:ubuntu.com"),
     LabelRoute("SRU", "#sru:ubuntu.com"),
     LabelRoute("DMB", "#dmb:ubuntu.com"),
     LabelRoute("Release team", "#release:ubuntu.com"),


### PR DESCRIPTION
Comment out the MIR team from queue report script, so MIR-labeled items are excluded from per-label reports.