### PR TITLE
fix: minor typo in work-with-debian-patches

### DIFF
--- a/docs/contributors/updating/work-with-debian-patches.md
+++ b/docs/contributors/updating/work-with-debian-patches.md
@@ -119,7 +119,7 @@ changelog entry.
 
 ### Automatic header generation
 
-You can use `quilt`` to automatically add a DEP-3 header:
+You can use `quilt` to automatically add a DEP-3 header:
 
 ```none
 $ quilt header -e --dep3 my-changes.patch
@@ -170,7 +170,7 @@ associated bugs.
 
 ## Verify the patchfile
 
-Use `quilt`` to apply the patches in order:
+Use `quilt` to apply the patches in order:
 
 ```none
 $ quilt push -a


### PR DESCRIPTION
### Description

There is a minor type where after the string "quilt", there are two backticks which throw off the formatting.
---

### Related issue

N/A

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---

### Additional notes (optional)

None
---

### Testing
**Before**
<img width="1118" height="220" alt="image" src="https://github.com/user-attachments/assets/adb92ab4-41af-4eab-9485-93a3db90469e" />
**After**
<img width="1118" height="220" alt="image" src="https://github.com/user-attachments/assets/52ab0590-e8b2-489d-b66e-3cfb953ebd44" />