### PR TITLE
Governance: Revise Ubuntu on Github

### DIFF
--- a/docs/how-ubuntu-is-made/processes/ubuntu-on-github.md
+++ b/docs/how-ubuntu-is-made/processes/ubuntu-on-github.md
@@ -7,9 +7,9 @@ In addition to code/projects on Launchpad and the Ubuntu archive, Ubuntu also ma
 
 Repositories under github.com/ubuntu are individually managed by their owners as admin.
 
-Ubuntu members that get {ref}`Ubuntu Core Developer <dmb-joining-core-dev>` permission are also added as [members of the organization](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization) with access to the whole scope of [github.com/ubuntu](https://github.com/ubuntu). Repository owners cannot revoke this access.
+While it isn't a requirement nor a guarantee, it might still help to be an approved [Core Developer](https://launchpad.net/) with a GitHub user is registered with the Launchpad ID (configured under 'Social accounts' on your Launchpad profile page). This will prove you are someones with wide reaching contributions and permissions to Ubuntu already when reaching out asking for membership to a particular repository.
 
-This is inclusive (Ubuntu Core Developers get access to the whole scope) and not exclusive (one does not need to be an Ubuntu Core Developer to be allowed access to an individual project).
+This access is not exclusive to Ubuntu Core Developer or other permissions (one does not need to be an Ubuntu Core Developer to be allowed access to an individual project).
 
 ## Contributions
 

--- a/docs/who-makes-ubuntu/developers/dmb-joining-core-dev.md
+++ b/docs/who-makes-ubuntu/developers/dmb-joining-core-dev.md
@@ -13,15 +13,9 @@ Core Devs also have elevated privileges for re-triggering autopkgtests and perfo
 (dmb-access-to-ubuntu-on-github)=
 ## Access to Ubuntu on Github
 
-To maintain all resources used to make Ubuntu, a Core Developer also gets access to {ref}`ubuntu-on-github`.
+Some resources used to make Ubuntu are managed in repositories under {ref}`ubuntu-on-github`.
 
-Upon achieving Ubuntu Core Developer permission - and under the condition that a GitHub user is registered with the Launchpad ID (configured under 'Social accounts' on your Launchpad profile page) - the DMB also add the applicant as a [member to the github.com/ubuntu organization](https://github.com/orgs/ubuntu/people).
-
-Ubuntu Core Developers that did not identify their associated GitHub user before can reach out to the {ref}`DMB <dmb>` to be added.
-
-Upon loss of Ubuntu Core Developer status, GitHub organization membership is revoked as well.
-
-<!-- TODO - once PR #364 is merged adn the content is in the new form at the right place we also need to update the doc in regard to the steps after approving an applicant` -->
+Contributions to those repositories are always possible, but these repositories are quite diverse in scope and purpose, being a core-developer does therefore not automatically grant access.
 
 (core-dev-training-and-preparation)=
 ## Training and preparation


### PR DESCRIPTION
### Description

We have been overeager when defining core-developers general membership to github.com/ubuntu. The repositores there are too diverse and range from not-related-to-core-dev to an independent project a core-dev would not generally get access to.

After rediscussing it was decided that this takes a step back to individual ownership and management, which is also what was already definee in the ubuntu-on-github.md page. But the implications on the DMBs pages about inherited rights on the DMB pages have been stronger than they can in reality be applied.

Fixes: 2e3706ff

### Attributing the reporter

@seb128 reached out to me after the last discussion and decision, because implementing it for some projects made him realize "wait, here this does not make sense". That had no issue tracker but was on internal agendas for a while. Now that the discussion and decision happened yesterday I've also tagged him as additional reviewer of the PR to ensure this works to over come the initial struggle applying the policy.
