### PR TITLE
Explain how to disable a flaky autopkgtest when patching Rust

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -290,6 +290,7 @@ pbuilder
 reportbug
 rmadison
 rustc
+selfbuild
 smartcard
 Snapcraft
 snapcraft

--- a/docs/maintainers/niche-package-maintenance/rustc/backport-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/backport-rust.md
@@ -219,6 +219,12 @@ The `rustc` autopkgtest suite includes a test that runs the package build proces
 -Restrictions: rw-build-tree, allow-stderr
 ```
 
+If you have read the {ref}`Rust patching guide <how-to-patch-rust>` you may
+remember {ref}`instructions<disable-rust-selfbuild-autopkgtest>` to reference a
+bug when disabling the test. While you may do this if you wish, it is
+unnecessary when backporting because you are uploading a brand-new package to
+your target series—there is no regression.
+
 Even in the absence of this test, the build process already includes a self-build step as part of the [Rust compiler bootstrapping process](https://rustc-dev-guide.rust-lang.org/building/bootstrapping/what-bootstrapping-does.html): the previous Rust compiler is used to build a "stage1" new Rust compiler, which is then used to build the "stage2" compiler that is being packaged. For backports this is generally sufficient. The ability of the new packaged toolchain to build the next Rust version can be verified directly when the next Rust version is backported. If this verification is needed immediately, and the next Rust version is not yet available, it can be done with a {ref}`Launchpad self-build <launchpad-self-build-optional>`.
 
 (rust-ppa-build)=

--- a/docs/maintainers/niche-package-maintenance/rustc/patch-rust.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/patch-rust.md
@@ -143,6 +143,40 @@ You must also verify that none of your changes have interfered with {term}`autop
 
 ```
 
+(disable-rust-selfbuild-autopkgtest)=
+#### Failing selfbuild autopkgtest
+
+The selfbuild autopkgtest is often flaky because it recompiles the entire
+compiler—a task too large for typical autopkgtest infrastructure. This is a
+well-known problem; it is unlikely you have done anything wrong (especially if
+your patch is small). The bug representing this issue is {lpbug}`2144934`.
+
+For a {ref}`new toolchain upload <how-to-update-rust>`, this should be
+addressed, but you are not expected to fix this when simply patching the
+toolchain; the autopkgtest already passed once before.
+
+In this case, go to {lpbug}`2144934`, mark the bug as affecting the toolchain
+version you're working on, and then comment out the autopkgtest in
+`debian/tests/control`, referencing the bug number:
+
+```diff
+--- a/debian/tests/control
++++ b/debian/tests/control
+@@ -1,6 +1,7 @@
+-Test-Command: ./debian/rules build RUST_TEST_SELFBUILD=1
+-Depends: @, @builddeps@
+-Restrictions: rw-build-tree, allow-stderr
++# Disabled due to excessive resource usage (LP: #2144934)
++# Test-Command: ./debian/rules build RUST_TEST_SELFBUILD=1
++# Depends: @, @builddeps@
++# Restrictions: rw-build-tree, allow-stderr
+ 
+ Tests: create-and-build-crate
+ Restrictions: rw-build-tree, allow-stderr
+```
+
+Ensure you reference the bug in your commit message and changelog entry as well.
+
 ### Uploading the patched package
 
 Once you are satisfied with your changes, upload the package.


### PR DESCRIPTION
### Description

One of the most common questions I get when teaching people how to maintain the Rust toolchain is what to do when the resource-intensive selfbuild autopkgtest keeps running out of resources.

The answer (as long as you're not uploading a new upstream Rust version) is to disable it. This was already documented in the "Backporting Rust" docs, but not in the "Patching Rust" docs, which is important because you need to reference an actual bug when uploading a patch or SRU.

I have included instructions on properly disabling the autopkgtest and referencing the bug when patching Rust, and I have also explained why referencing the bug isn't necessary when disabling the autopkgtest for a backport.

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [x] I have tested my changes, and they work as expected

---
