### PR TITLE
sponsor-an-upload.md: add section to verify the upload contents

### DIFF
--- a/docs/contributors/advanced/sponsor-an-upload.md
+++ b/docs/contributors/advanced/sponsor-an-upload.md
@@ -109,6 +109,36 @@ These instructions assume the request for sponsorship is in the form of a {term}
 
    See {ref}`how-to-review-a-merge-proposal` for general review details.
 
+1. Verify the upload contents:
+
+   It is important to verify that the upload contents are good and do not contain undesired changes, especially
+   the Debian tarball that has been generated: `<package>_<version>.debian.tar.xz`, since there is no control
+   of its contents on the server side.
+
+   Assume that you would like to upload version `12.0.0-1ubuntu5.4` of the package `libvirt` to Ubuntu Resolute 26.04,
+   and the latest version in the archive is `12.0.0-1ubuntu5.3`. Here are the instructions to generate the debdiff of the upload:
+
+   Pull the latest package from Resolute:
+
+    ```none
+    $ pull-lp-source libvirt resolute
+    ```
+
+   Run `debdiff` between the two `.dsc` files:
+
+    ```none
+    $ debdiff libvirt_12.0.0-1ubuntu5.3.dsc libvirt_12.0.0-1ubuntu5.4.dsc
+    ```
+
+   This shows the changes between `12.0.0-1ubuntu5.3` and `12.0.0-1ubuntu5.4`. It is important to make sure that
+   the changes look good and there are no unexpected changes.
+
+   To summarize the diff, you can use `diffstat`:
+
+    ```none
+    $ debdiff libvirt_12.0.0-1ubuntu5.3.dsc libvirt_12.0.0-1ubuntu5.4.dsc 2>/dev/null | diffstat
+    ```
+
 1. Sign the {file}`.changes` file:
 
     ```none

--- a/docs/contributors/advanced/sponsor-an-upload.md
+++ b/docs/contributors/advanced/sponsor-an-upload.md
@@ -115,6 +115,11 @@ These instructions assume the request for sponsorship is in the form of a {term}
    the Debian tarball that has been generated: `<package>_<version>.debian.tar.xz`, since there is no control
    of its contents on the server side.
 
+Examples of issues you might catch may include, but are not limited to:
+- Generated files that you did not intend to be in the upload, like a `debian/cscope.out` file or a `debian/control.swp` from an editor => you see them in the diff, but did not expect them
+- The archive changed, your upload is not based on the most recent version => you see in diff conflicting or dropped changes
+- Files from development, unused but left behind, like a `debian/patch/foo.patch` that is not in `debian/series` and therefore silently stays behind doing nothing => you see its content in the diff, but did not expect them to be part of the upload
+
    Assume that you would like to upload version `12.0.0-1ubuntu5.4` of the package `libvirt` to Ubuntu Resolute 26.04,
    and the latest version in the archive is `12.0.0-1ubuntu5.3`. Here are the instructions to generate the debdiff of the upload, which allows a quick cross check against what you expect from your work on git or the files directly:
 

--- a/docs/contributors/advanced/sponsor-an-upload.md
+++ b/docs/contributors/advanced/sponsor-an-upload.md
@@ -116,7 +116,7 @@ These instructions assume the request for sponsorship is in the form of a {term}
    of its contents on the server side.
 
    Assume that you would like to upload version `12.0.0-1ubuntu5.4` of the package `libvirt` to Ubuntu Resolute 26.04,
-   and the latest version in the archive is `12.0.0-1ubuntu5.3`. Here are the instructions to generate the debdiff of the upload:
+   and the latest version in the archive is `12.0.0-1ubuntu5.3`. Here are the instructions to generate the debdiff of the upload, which allows a quick cross check against what you expect from your work on git or the files directly:
 
    Pull the latest package from Resolute:
 


### PR DESCRIPTION
Add a section to verify the contents of an upload

I think it is important for uploaders to verify the final contents of the upload before issuing the dput command.

