### PR TITLE
DMB: adjust time and time handling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ community/ @aaronprisk @ilvipero
 
 # DMB team PR approvals
 # Like the AA team, these files are prefixed with "dmb-" but not kept in a specific directory
-**/dmb-*.md @cpaelzer @lvoytek @rbasak @utkarsh2102 @athos-ribeiro @bdrung
+**/dmb-*.md @cpaelzer @lvoytek @rbasak @utkarsh2102 @athos-ribeiro @bdrung @uraltun
 
 # TAs' & special teams' ack required for changes to the CODEOWNERS file
 /.github/CODEOWNERS @s-makin @rkratky @setharnold @joalif @didrocks @cpaelzer @MylesJP @pushkarnk @panlinux @paride @ginggs @schopin-pro @mwhudson @utkarsh2102 @tjaalton @seb128 @raof @aaronprisk @ilvipero @basak @teward @enr0n @julian-klode @awhitcroft @Hyask

--- a/docs/who-makes-ubuntu/councils/dmb-meetings.md
+++ b/docs/who-makes-ubuntu/councils/dmb-meetings.md
@@ -11,12 +11,14 @@ The {ref}`dmb` conducts meetings every two weeks.
 
 ## Scheduling
 
-DMB meetings are held on Mondays alternating between 13:00 UTC and 15:30 UTC.
-In case of common vacations (such as over New Year), a meeting may be skipped.
+DMB meetings are held on Mondays alternating between 13:00 UTC and 16:00 UTC.
 [Refer to the Agenda](https://discourse.ubuntu.com/t/ubuntu-developer-membership-board-agenda/66634) to check on the times, dates and topics of upcoming meetings.
 
-The meeting schedule can be changed by the DMB by majority vote, and it is expected for the schedule to be confirmed or changed as necessary at the first meeting after new DMB members are elected.
-Please also consider the needs of pending and future applicants if changing the schedule, as doing so may affect their plans.
+In case of common vacations (such as over New Year), a meeting may be skipped.
+In case of high demand stretching the agenda entries far into the future, the DMB tam may decide to add extra meetings and contact the applicants to coordinate.
+
+In general the meeting schedule can be changed by the DMB by majority vote, and it is expected for the schedule to be confirmed or changed as necessary at the first meeting after new DMB members are elected.
+The DMB will try to also consider the needs of pending and future applicants if changing the schedule, as doing so may affect their plans and ability to attend.
 
 
 ## Meeting location


### PR DESCRIPTION
The new time has been decided in the last DMB meeting. Furthermore we get a better hold of spikes of applicants and how we dynamically react to that - which is here put down into the rules and expectations.

 I've also spotted that we need to add @uraltun as a reviewer, done in an extra commit