### PR TITLE
Find Rust sysroot with `rustc --print`

### DIFF
--- a/docs/maintainers/niche-package-maintenance/rustc/common/orig-vendor.md
+++ b/docs/maintainers/niche-package-maintenance/rustc/common/orig-vendor.md
@@ -15,9 +15,9 @@ It is expected that you have a copy of the toolchain installed locally (e.g. usi
 
 ```none
 ~/rustc/rustc$ rustup install 1.92.0
-~/rustc/rustc$ rustup +1.92.0 which rustc
-/home/<user>/.rustup/toolchains/1.92.0-x86_64-unknown-linux-gnu/bin/rustc
-~/rustc/rustc$ export RUST_BOOTSTRAP_DIR=/home/<user>/.rustup/toolchains/1.92.0-x86_64-unknown-linux-gnu
+~/rustc/rustc$ rustup run 1.92.0 rustc --print sysroot
+/home/<user>/.rustup/toolchains/1.92.0-x86_64-unknown-linux-gnu
+~/rustc/rustc$ export RUST_BOOTSTRAP_DIR=$(rustup run 1.92.0 rustc --print sysroot)
 ```
 
 The process of filtering the vendored crates relies on a custom cargo subcommand [`cargo-vendor-filterer`](https://github.com/coreos/cargo-vendor-filterer), which we run indirectly via the `vendor-tarball` target of `debian/rules`. You first need to install the `cargo-vendor-filterer` binary:


### PR DESCRIPTION
### Description

`rustc --print sysroot` outputs the syroot directory path, so there is no need to `which rustc` and walk from the binary path up to the sysroot path.

This still works when `rustc` is `/usr/bin/rustc` and not rustup's. On my machine:

    $ which rustc
    /usr/bin/rustc
    $ rustc --print sysroot
    /usr/lib/rust-1.93
    $ rustup run 1.95.0 which rustc
    /usr/bin/rustc
    $ rustup run 1.95.0 rustc --print sysroot
    <RUSTUP_HOME>/toolchains/1.95.0-x86_64-unknown-linux-gnu

If your rustup is installed via snap, an alternative spelling is `rustup.rustc +1.95.0 --print sysroot`, but I don't use that for the docs here to avoid making assumptions about the environment.

---

### Related issue

Fixes: FR-14171

---

### Checklist

- [x] I have read and followed the [Ubuntu Project contributing guide](https://documentation.ubuntu.com/project/contributors/contribute-docs/)
- [x] My pull request is linked to an existing issue (if applicable)
- [ ] I have tested my changes, and they work as expected

---

### Additional notes (optional)

The absolutely most foolproof way to do this would be `$(rustup +1.92.0 which rustc) --print sysroot` as this only requires `rustup` to be on the PATH and bypasses PATH lookup for `rustc`. But this is overkill; the `rustup run` environment is fully guaranteed to work with every rustc version both forwards and backwards compatibly.